### PR TITLE
Add KiCad project converter and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # circuit-json-to-kicad
 
-Convert [Circuit JSON](https://github.com/tscircuit/circuit-json) files to KiCad schematic (`.kicad_sch`) and PCB (`.kicad_pcb`) files.
+Convert [Circuit JSON](https://github.com/tscircuit/circuit-json) files to KiCad schematic (`.kicad_sch`), PCB (`.kicad_pcb`), and project (`.kicad_pro`) files.
 
 Circuit JSON is an open-source file format for describing electronic circuits. This library enables you to generate KiCad-compatible files from Circuit JSON, allowing you to use KiCad's powerful PCB design tools with circuits defined in code.
 
@@ -47,6 +47,26 @@ const kicadPcbContent = converter.getOutputString()
 
 // Write to file
 Bun.write("output.kicad_pcb", kicadPcbContent)
+```
+
+### Generating a KiCad Project
+
+```typescript
+import { CircuitJsonToKicadProConverter } from "circuit-json-to-kicad"
+
+const circuitJson = /* your circuit JSON */
+
+const converter = new CircuitJsonToKicadProConverter(circuitJson, {
+  projectName: "my_project",
+  schematicFilename: "my_project.kicad_sch",
+  pcbFilename: "my_project.kicad_pcb",
+})
+
+converter.runUntilFinished()
+
+const kicadProjectContent = converter.getOutputString()
+
+Bun.write("my_project.kicad_pro", kicadProjectContent)
 ```
 
 ### Complete Example with tscircuit
@@ -102,6 +122,7 @@ Bun.write("output.kicad_pcb", pcbConverter.getOutputString())
   - Vias
   - Board outlines and graphics
   - Net assignments
+- **Project Generation**: Produce KiCad project files (`.kicad_pro`) that reference the generated schematic and PCB outputs
 
 ## Development
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./schematic/CircuitJsonToKicadSchConverter"
 export * from "./pcb/CircuitJsonToKicadPcbConverter"
+export * from "./project/CircuitJsonToKicadProConverter"

--- a/lib/project/CircuitJsonToKicadProConverter.ts
+++ b/lib/project/CircuitJsonToKicadProConverter.ts
@@ -1,0 +1,163 @@
+import type { CircuitJson } from "circuit-json"
+import { cju } from "@tscircuit/circuit-json-util"
+import { randomUUID } from "crypto"
+
+interface CircuitJsonToKicadProOptions {
+  projectName?: string
+  schematicFilename?: string
+  pcbFilename?: string
+}
+
+interface KicadProProject {
+  version: number
+  head: {
+    generator: string
+    generator_version: string
+    project_name: string
+    created: string
+    modified: string
+  }
+  meta: {
+    version: number
+  }
+  text_variables: Record<string, string>
+  libraries: {
+    pinned_symbol_libs: string[]
+    pinned_footprint_libs: string[]
+  }
+  boards: string[]
+  cvpcb: {
+    meta: {
+      version: number
+    }
+  }
+  erc: {
+    meta: {
+      version: number
+    }
+    erc_exclusions: unknown[]
+  }
+  net_settings: {
+    meta: {
+      version: number
+    }
+    last_net_id: number
+    classes: unknown[]
+  }
+  pcbnew: {
+    page_layout_descr_file: string
+    last_paths: Record<string, string>
+  }
+  schematic: {
+    meta: {
+      version: number
+    }
+    page_layout_descr_file: string
+    last_opened_files: string[]
+  }
+  board: {
+    meta: {
+      version: number
+    }
+    last_opened_board: string
+  }
+  sheets: [string, string][]
+}
+
+export class CircuitJsonToKicadProConverter {
+  ctx: {
+    db: ReturnType<typeof cju>
+    circuitJson: CircuitJson
+  }
+
+  private project: KicadProProject
+
+  constructor(
+    circuitJson: CircuitJson,
+    options: CircuitJsonToKicadProOptions = {},
+  ) {
+    const projectName =
+      options.projectName ??
+      // @ts-expect-error project metadata is optional in circuit json
+      circuitJson?.project?.name ??
+      "circuit-json-project"
+
+    const schematicFilename =
+      options.schematicFilename ?? `${projectName}.kicad_sch`
+    const pcbFilename = options.pcbFilename ?? `${projectName}.kicad_pcb`
+    const timestamp = new Date().toISOString()
+
+    this.ctx = {
+      db: cju(circuitJson),
+      circuitJson,
+    }
+
+    this.project = {
+      version: 1,
+      head: {
+        generator: "circuit-json-to-kicad",
+        generator_version: "0.0.1",
+        project_name: projectName,
+        created: timestamp,
+        modified: timestamp,
+      },
+      meta: {
+        version: 1,
+      },
+      text_variables: {},
+      libraries: {
+        pinned_symbol_libs: [],
+        pinned_footprint_libs: [],
+      },
+      boards: [],
+      cvpcb: {
+        meta: {
+          version: 0,
+        },
+      },
+      erc: {
+        meta: {
+          version: 0,
+        },
+        erc_exclusions: [],
+      },
+      net_settings: {
+        meta: {
+          version: 1,
+        },
+        last_net_id: 0,
+        classes: [],
+      },
+      pcbnew: {
+        page_layout_descr_file: "",
+        last_paths: {},
+      },
+      schematic: {
+        meta: {
+          version: 1,
+        },
+        page_layout_descr_file: "",
+        last_opened_files: [schematicFilename],
+      },
+      board: {
+        meta: {
+          version: 1,
+        },
+        last_opened_board: pcbFilename,
+      },
+      sheets: [[randomUUID(), "Root"]],
+    }
+  }
+
+  runUntilFinished() {
+    // Nothing to do for project conversion, the project is generated eagerly
+  }
+
+  getOutput(): KicadProProject {
+    return this.project
+  }
+
+  getOutputString(): string {
+    return `${JSON.stringify(this.project, null, 2)}\n`
+  }
+}

--- a/tests/project/kicad-pro-basic.test.tsx
+++ b/tests/project/kicad-pro-basic.test.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadProConverter } from "lib"
+
+const PROJECT_NAME = "test_project"
+
+const SCHEMATIC_FILENAME = `${PROJECT_NAME}.kicad_sch`
+const PCB_FILENAME = `${PROJECT_NAME}.kicad_pcb`
+
+test("generates a minimal KiCad project file", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+
+  const converter = new CircuitJsonToKicadProConverter(circuitJson, {
+    projectName: PROJECT_NAME,
+    schematicFilename: SCHEMATIC_FILENAME,
+    pcbFilename: PCB_FILENAME,
+  })
+
+  converter.runUntilFinished()
+
+  const output = converter.getOutputString()
+  const project = JSON.parse(output)
+
+  expect(project.version).toBe(1)
+  expect(project.head.project_name).toBe(PROJECT_NAME)
+  expect(project.schematic.last_opened_files).toContain(SCHEMATIC_FILENAME)
+  expect(project.board.last_opened_board).toBe(PCB_FILENAME)
+  expect(Array.isArray(project.sheets)).toBe(true)
+  expect(project.sheets[0][1]).toBe("Root")
+})


### PR DESCRIPTION
## Summary
- add a converter that generates a minimal .kicad_pro project payload referencing the schematic and PCB outputs
- document the project generation workflow in the README
- cover the new converter with a Bun test that validates the produced project structure

## Testing
- bun run typecheck
- bun test tests/project/kicad-pro-basic.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68e26d7fb0008327b1d5a73adf55ac54