### PR TITLE
fix: export silkscreen paths and rects as footprint primitives instead of board-level graphics

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -27,6 +27,8 @@ import { convertFabricationNoteRects } from "./footprints-stage-converters/conve
 import { convertNoteRects } from "./footprints-stage-converters/convertNoteRects"
 import { convertCourtyardRects } from "./footprints-stage-converters/convertCourtyardRects"
 import { convertCourtyardOutlines } from "./footprints-stage-converters/convertCourtyardOutlines"
+import { convertSilkscreenPaths } from "./footprints-stage-converters/convertSilkscreenPaths"
+import { convertSilkscreenRects } from "./footprints-stage-converters/convertSilkscreenRects"
 import { convertSilkscreenTexts } from "./footprints-stage-converters/convertSilkscreenTexts"
 import { convertNoteTexts } from "./footprints-stage-converters/convertNoteTexts"
 import { create3DModelsFromCadComponent } from "./footprints-stage-converters/create3DModelsFromCadComponent"
@@ -270,7 +272,32 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         ) || []
 
     fpRects.push(...convertCourtyardRects(pcbCourtyardRects, component.center))
+
+    const pcbSilkscreenRects =
+      this.ctx.db.pcb_silkscreen_rect
+        ?.list()
+        .filter(
+          (rect: any) => rect.pcb_component_id === component.pcb_component_id,
+        ) || []
+
+    fpRects.push(
+      ...convertSilkscreenRects(pcbSilkscreenRects, component.center),
+    )
     footprint.fpRects = fpRects
+
+    // Convert silkscreen paths to fp_line
+    const pcbSilkscreenPaths =
+      this.ctx.db.pcb_silkscreen_path
+        ?.list()
+        .filter(
+          (path: any) => path.pcb_component_id === component.pcb_component_id,
+        ) || []
+
+    const fpLines = footprint.fpLines ?? []
+    fpLines.push(
+      ...convertSilkscreenPaths(pcbSilkscreenPaths, component.center),
+    )
+    footprint.fpLines = fpLines
 
     // Convert polygons
     const pcbCourtyardOutlines =

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -21,8 +21,10 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
       throw new Error("PCB transformation matrix not initialized in context")
     }
 
-    // Get PCB board silkscreen paths if they exist
-    const pcbSilkscreenPaths = this.ctx.db.pcb_silkscreen_path?.list() || []
+    // Get PCB board silkscreen paths if they exist (exclude component-owned paths)
+    const pcbSilkscreenPaths = (
+      this.ctx.db.pcb_silkscreen_path?.list() || []
+    ).filter((path: any) => !path.pcb_component_id)
 
     for (const path of pcbSilkscreenPaths) {
       if (!path.route || path.route.length < 2) continue

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
@@ -1,0 +1,47 @@
+import type { PcbSilkscreenPath } from "circuit-json"
+import { FpLine, Stroke } from "kicadts"
+
+export function convertSilkscreenPaths(
+  silkscreenPaths: PcbSilkscreenPath[],
+  componentCenter: { x: number; y: number },
+): FpLine[] {
+  const fpLines: FpLine[] = []
+
+  for (const path of silkscreenPaths) {
+    if (!path.route || path.route.length < 2) continue
+
+    const layerMap: Record<string, string> = {
+      top: "F.SilkS",
+      bottom: "B.SilkS",
+    }
+    const kicadLayer = layerMap[path.layer] || path.layer || "F.SilkS"
+
+    for (let i = 0; i < path.route.length - 1; i++) {
+      const startPoint = path.route[i]
+      const endPoint = path.route[i + 1]
+
+      if (!startPoint || !endPoint) continue
+
+      const startRelX = startPoint.x - componentCenter.x
+      const startRelY = -(startPoint.y - componentCenter.y)
+      const endRelX = endPoint.x - componentCenter.x
+      const endRelY = -(endPoint.y - componentCenter.y)
+
+      const fpLine = new FpLine({
+        start: { x: startRelX, y: startRelY },
+        end: { x: endRelX, y: endRelY },
+        layer: kicadLayer,
+        stroke: new Stroke(),
+      })
+
+      if (fpLine.stroke) {
+        fpLine.stroke.width = path.stroke_width || 0.15
+        fpLine.stroke.type = "default"
+      }
+
+      fpLines.push(fpLine)
+    }
+  }
+
+  return fpLines
+}

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
@@ -1,0 +1,39 @@
+import type { PcbSilkscreenRect } from "circuit-json"
+import { FpRect, Stroke } from "kicadts"
+
+export function convertSilkscreenRects(
+  silkscreenRects: PcbSilkscreenRect[],
+  componentCenter: { x: number; y: number },
+): FpRect[] {
+  const fpRects: FpRect[] = []
+
+  for (const rect of silkscreenRects) {
+    const relX = rect.center.x - componentCenter.x
+    const relY = -(rect.center.y - componentCenter.y)
+    const halfW = rect.width / 2
+    const halfH = rect.height / 2
+
+    const layerMap: Record<string, string> = {
+      top: "F.SilkS",
+      bottom: "B.SilkS",
+    }
+    const kicadLayer = layerMap[rect.layer] || rect.layer || "F.SilkS"
+
+    const fpRect = new FpRect({
+      start: { x: relX - halfW, y: relY - halfH },
+      end: { x: relX + halfW, y: relY + halfH },
+      layer: kicadLayer,
+      stroke: new Stroke(),
+      fill: false,
+    })
+
+    if (fpRect.stroke) {
+      fpRect.stroke.width = rect.stroke_width || 0.1
+      fpRect.stroke.type = "default"
+    }
+
+    fpRects.push(fpRect)
+  }
+
+  return fpRects
+}

--- a/tests/pcb/basics/basics16-silkscreen-path-rect.test.tsx
+++ b/tests/pcb/basics/basics16-silkscreen-path-rect.test.tsx
@@ -1,0 +1,95 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import { takeKicadSnapshot } from "../../fixtures/take-kicad-snapshot"
+import { takeCircuitJsonSnapshot } from "../../fixtures/take-circuit-json-snapshot"
+import { stackCircuitJsonKicadPngs } from "../../fixtures/stackCircuitJsonKicadPngs"
+
+test("pcb_silkscreen_path and pcb_silkscreen_rect are exported as footprint primitives, not board-level graphics", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <platedhole
+              portHints={["1"]}
+              pcbX={0}
+              pcbY={0}
+              outerDiameter="3mm"
+              holeDiameter="1.5mm"
+              shape="circle"
+            />
+            <silkscreenpath
+              route={[
+                { x: -2, y: -2 },
+                { x: 2, y: -2 },
+                { x: 2, y: 2 },
+                { x: -2, y: 2 },
+                { x: -2, y: -2 },
+              ]}
+              layer="top"
+            />
+            <silkscreenrect
+              pcbX={0}
+              pcbY={0}
+              width={6}
+              height={4}
+              layer="top"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson() as any[]
+
+  // Verify circuit-json has the silkscreen elements with pcb_component_id
+  const silkscreenPaths = circuitJson.filter(
+    (e) => e.type === "pcb_silkscreen_path",
+  )
+  const silkscreenRects = circuitJson.filter(
+    (e) => e.type === "pcb_silkscreen_rect",
+  )
+  expect(silkscreenPaths.length).toBeGreaterThan(0)
+  expect(silkscreenRects.length).toBeGreaterThan(0)
+  expect(silkscreenPaths[0].pcb_component_id).toBeTruthy()
+  expect(silkscreenRects[0].pcb_component_id).toBeTruthy()
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+
+  // Silkscreen path should be fp_line inside the footprint, not gr_line at board level
+  expect(outputString).toContain("fp_line")
+  expect(outputString).toContain("F.SilkS")
+
+  // Silkscreen rect should be fp_rect inside the footprint
+  expect(outputString).toContain("fp_rect")
+
+  // Component-owned silkscreen paths should NOT appear as board-level gr_line on SilkS
+  // (gr_line on Edge.Cuts is expected for the board outline)
+  const grLines = outputString
+    .split("\n")
+    .filter((line) => line.includes("gr_line") && line.includes("SilkS"))
+  expect(grLines.length).toBe(0)
+
+  const kicadSnapshot = await takeKicadSnapshot({
+    kicadFileContent: outputString,
+    kicadFileType: "pcb",
+  })
+
+  expect(kicadSnapshot.exitCode).toBe(0)
+
+  expect(
+    stackCircuitJsonKicadPngs(
+      await takeCircuitJsonSnapshot({ circuitJson, outputType: "pcb" }),
+      kicadSnapshot.generatedFileContent["temp_file.png"]!,
+    ),
+  ).toMatchPngSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Problem

Fixes #191

When using `silkscreenpath` or `silkscreenrect` to draw silkscreen for a component, the graphics do not follow the component when moved in KiCad. This is because:

1. `pcb_silkscreen_path` was exported as board-level `gr_line` elements in `AddGraphicsStage` instead of `fp_line` inside the footprint
2. `pcb_silkscreen_rect` was not exported at all — no handler existed

Meanwhile, `pcb_silkscreen_circle` and `pcb_silkscreen_text` were already correctly handled as footprint primitives (`fp_circle`, `fp_text`).

| tscircuit Element | Before | After |
|---|---|---|
| `pcb_silkscreen_circle` | ✅ `fp_circle` (footprint) | ✅ No change |
| `pcb_silkscreen_text` | ✅ `fp_text` (footprint) | ✅ No change |
| `pcb_silkscreen_path` | ❌ `gr_line` (board-level) | ✅ `fp_line` (footprint) |
| `pcb_silkscreen_rect` | ❌ Not exported | ✅ `fp_rect` (footprint) |

## Changes

### New files
- **`convertSilkscreenPaths.ts`** — Converts `PcbSilkscreenPath[]` to `FpLine[]` with relative positioning, Y-axis inversion, and `F.SilkS`/`B.SilkS` layer mapping. Each path segment becomes one `fp_line`.
- **`convertSilkscreenRects.ts`** — Converts `PcbSilkscreenRect[]` to `FpRect[]`, following the same pattern as `convertFabricationNoteRects.ts`.

### Modified files
- **`AddFootprintsStage.ts`** — Imports both new converters. Filters `pcb_silkscreen_path` and `pcb_silkscreen_rect` by `pcb_component_id`, converts them, and adds to `footprint.fpLines` and `footprint.fpRects`.
- **`AddGraphicsStage.ts`** — Filters out component-owned silkscreen paths (those with `pcb_component_id`) from board-level export, preventing duplication.

### Test
- **`basics16-silkscreen-path-rect.test.tsx`** — Verifies component-owned silkscreen paths and rects appear as `fp_line`/`fp_rect` inside the footprint, and that no board-level `gr_line` exists on the silkscreen layer.

## Verification

- TypeScript: `bunx tsc --noEmit` passes with no errors
- Format: `bunx biome format` clean
- Tests: All 33 passing tests continue to pass. The new test passes all assertion checks (8 expect() calls). KiCad snapshot comparison requires `kicad-cli` which will be validated in CI.