### PR TITLE
Fix via size conversion

### DIFF
--- a/lib/pcb/stages/AddViasStage.ts
+++ b/lib/pcb/stages/AddViasStage.ts
@@ -187,9 +187,9 @@ export class AddViasStage extends ConverterStage<CircuitJson, KicadPcb> {
     // For through-hole vias, span all copper layers
     const viaLayers = this.getKicadViaLayers(via)
 
-    // KiCad minimum via sizes
-    const viaSize = Math.max(via.outer_diameter || 0.8, 0.5)
-    const viaDrill = Math.max(via.hole_diameter || 0.4, 0.3)
+    // Preserve explicit Circuit JSON via dimensions; only fall back when absent.
+    const viaSize = via.outer_diameter ?? 0.8
+    const viaDrill = via.hole_diameter ?? 0.4
 
     // Create a via with deterministic UUID
     const viaData = `via:${transformedPos.x},${transformedPos.y}:${viaSize}:${viaDrill}:${netInfo?.id ?? 0}`

--- a/tests/pcb/repros/repro09-via-size-kicad-rules.test.tsx
+++ b/tests/pcb/repros/repro09-via-size-kicad-rules.test.tsx
@@ -1,10 +1,9 @@
 /**
- * Bug 2 (Moderate): Via sizes don't match KiCad design rules
+ * Bug 2 (Moderate): Explicit via sizes are clamped instead of preserved
  *
- * The capacity-autorouter can output vias with outer_diameter=0.3mm /
- * hole_diameter=0.2mm. KiCad's minimum via size is 0.5mm outer / 0.3mm drill.
- * AddViasStage passes values straight through without clamping to minimums,
- * causing DRC via-size violations in KiCad.
+ * Circuit JSON vias can legitimately carry explicit outer and drill diameters.
+ * The KiCad exporter should copy those values through verbatim rather than
+ * force them up to a hard-coded default.
  *
  * To run: bun test tests/pcb/repros/repro09-via-size-kicad-rules.test.tsx
  */
@@ -12,7 +11,7 @@ import { test, expect } from "bun:test"
 import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
 import circuitJson from "tests/assets/repro09-555-timer-circuit-small-vias.json"
 
-test("repro09: via sizes below KiCad minimums (0.3mm/0.2mm) pass through unchanged", () => {
+test("repro09: standalone vias preserve explicit 0.3mm/0.2mm dimensions", () => {
   const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
   converter.runUntilFinished()
   const output = converter.getOutputString()
@@ -24,9 +23,10 @@ test("repro09: via sizes below KiCad minimums (0.3mm/0.2mm) pass through unchang
       /\(via\b[\s\S]*?\(size ([\d.]+)\)[\s\S]*?\(drill ([\d.]+)\)/g,
     ),
   ]
-  const subMinVias = viaSizeMatches.filter(
-    (m) => Number(m[1]) < 0.5 || Number(m[2]) < 0.3,
-  )
+  const uniquePairs = [
+    ...new Set(viaSizeMatches.map((m) => `${m[1]}/${m[2]}`)),
+  ].sort()
 
-  expect(subMinVias.length).toBe(0)
+  expect(viaSizeMatches).toHaveLength(10)
+  expect(uniquePairs).toEqual(["0.3/0.2"])
 })

--- a/tests/pcb/repros/repro12-standalone-via-size-copy.test.tsx
+++ b/tests/pcb/repros/repro12-standalone-via-size-copy.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Bug 5 (Moderate): Standalone via diameters are rounded up to 0.5mm/0.3mm
+ *
+ * The exporter should preserve explicit standalone via sizes instead of
+ * clamping them to a hard-coded minimum.
+ *
+ * To run: bun test tests/pcb/repros/repro12-standalone-via-size-copy.test.tsx
+ */
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("repro12: standalone 0.4mm via stays 0.4mm in KiCad output", () => {
+  const circuitJson = [
+    {
+      type: "pcb_via",
+      x: 1,
+      y: 2,
+      outer_diameter: 0.4,
+      hole_diameter: 0.2,
+      from_layer: "top",
+      to_layer: "bottom",
+    },
+  ] as any
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  const viaMatch = output.match(
+    /\(via\b[\s\S]*?\(size ([\d.]+)\)[\s\S]*?\(drill ([\d.]+)\)/,
+  )
+
+  expect(viaMatch).not.toBeNull()
+  expect(Number(viaMatch![1])).toBe(0.4)
+  expect(Number(viaMatch![2])).toBe(0.2)
+})


### PR DESCRIPTION
## Summary
- Preserve explicit Circuit JSON via outer and drill diameters in KiCad export instead of clamping to hard-coded minimums.
- Update the existing via-size repro to assert exact copy-through.
- Add a standalone via regression test for `0.4mm / 0.2mm`.

## Testing
- `bun test tests/pcb/repros/repro09-via-size-kicad-rules.test.tsx`
- `bun test tests/pcb/repros/repro11-route-via-size-copy.test.tsx`
- `bun test tests/pcb/repros/repro12-standalone-via-size-copy.test.tsx`