### PR TITLE
Use manufacturer_part_number for simple_chip PCB value text

### DIFF
--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -55,7 +55,7 @@ export function getkicadComponentProperty(
   if (sourceComp.ftype === "simple_chip") {
     return {
       reference,
-      kicadComponentValue: name,
+      kicadComponentValue: sourceComp.manufacturer_part_number || name,
     }
   }
 

--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -55,7 +55,7 @@ export function getkicadComponentProperty(
   if (sourceComp.ftype === "simple_chip") {
     return {
       reference,
-      kicadComponentValue: sourceComp.manufacturer_part_number || name,
+      kicadComponentValue: sourceComp.manufacturer_part_number,
     }
   }
 

--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -9,7 +9,7 @@ import { getReferenceDesignator } from "../../../utils/getKicadCompatibleCompone
 
 export interface kicadComponentProperty {
   reference: string
-  kicadComponentValue: string
+  kicadComponentValue?: string
 }
 
 /**
@@ -55,7 +55,7 @@ export function getkicadComponentProperty(
   if (sourceComp.ftype === "simple_chip") {
     return {
       reference,
-      kicadComponentValue: sourceComp.manufacturer_part_number,
+      kicadComponentValue: sourceComp?.manufacturer_part_number,
     }
   }
 

--- a/tests/pcb/basics/basics16-component-text.test.tsx
+++ b/tests/pcb/basics/basics16-component-text.test.tsx
@@ -16,3 +16,18 @@ test("pcb writes resistor and capacitor footprint text fields", () => {
   expect(output).toContain('(property "Reference" "C1"')
   expect(output).toContain('(property "Value" "1000pF"')
 })
+
+test("pcb writes manufacturer part numbers for simple_chip footprint text fields", () => {
+  const circuitJson = JSON.parse(
+    readFileSync("tests/assets/555-timer-circuit.json", "utf8"),
+  )
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  expect(output).toContain('(property "Reference" "P1"')
+  expect(output).toContain('(property "Value" "KF301_5_0_2P"')
+  expect(output).toContain('(property "Reference" "U1"')
+  expect(output).toContain('(property "Value" "NE555P"')
+})


### PR DESCRIPTION
- update `getKicadComponentProperty` so `simple_chip` footprints use `manufacturer_part_number` for the KiCad `Value` field when available
- keep the existing `name` fallback for `simple_chip` components without a part number
- add converter-level test coverage in `tests/pcb/basics/basics16-component-text.test.tsx`
- verify the new behavior with the `555-timer-circuit` fixture for parts like `P1` and `U1`

