### PR TITLE
feat: include supplier part number in KiCad footprint properties

### DIFF
--- a/lib/pcb/stages/utils/applyMetadataToFootprint.ts
+++ b/lib/pcb/stages/utils/applyMetadataToFootprint.ts
@@ -136,22 +136,21 @@ export function applyMetadataToFootprint({
       hidden: descMeta?.hide ?? true,
     }),
   )
+  // Supplier Part Number property
 
-  if (componentProperty.supplierPartNumber) {
-    newProperties.push(
-      new Property({
-        key: "Supplier Part Number",
-        value: componentProperty.supplierPartNumber,
-        position: [0, 0, 0],
-        layer: "F.Fab",
-        uuid: generateDeterministicUuid(
-          `${componentProperty.reference}-property-SupplierPartNumber`,
-        ),
-        effects: createTextEffects(),
-        hidden: true,
-      }),
-    )
-  }
+  newProperties.push(
+    new Property({
+      key: "Supplier Part Number",
+      value: componentProperty.supplierPartNumber,
+      position: [0, 0, 0],
+      layer: "F.Fab",
+      uuid: generateDeterministicUuid(
+        `${componentProperty.reference}-property-SupplierPartNumber`,
+      ),
+      effects: createTextEffects(),
+      hidden: true,
+    }),
+  )
 
   footprint.properties = newProperties
   // Apply attributes if provided

--- a/lib/pcb/stages/utils/applyMetadataToFootprint.ts
+++ b/lib/pcb/stages/utils/applyMetadataToFootprint.ts
@@ -137,6 +137,22 @@ export function applyMetadataToFootprint({
     }),
   )
 
+  if (componentProperty.supplierPartNumber) {
+    newProperties.push(
+      new Property({
+        key: "Supplier Part Number",
+        value: componentProperty.supplierPartNumber,
+        position: [0, 0, 0],
+        layer: "F.Fab",
+        uuid: generateDeterministicUuid(
+          `${componentProperty.reference}-property-SupplierPartNumber`,
+        ),
+        effects: createTextEffects(),
+        hidden: true,
+      }),
+    )
+  }
+
   footprint.properties = newProperties
   // Apply attributes if provided
 

--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -13,6 +13,16 @@ export interface kicadComponentProperty {
   supplierPartNumber?: string
 }
 
+function getJlcpcbSupplierPartNumber(
+  sourceComp: SourceComponentBase,
+): string | undefined {
+  const jlcpcbPartNumbers = sourceComp.supplier_part_numbers?.jlcpcb
+
+  return jlcpcbPartNumbers && jlcpcbPartNumbers.length > 0
+    ? jlcpcbPartNumbers.join(", ")
+    : undefined
+}
+
 /**
  * Get default footprint text fields from a source component.
  */
@@ -21,16 +31,7 @@ export function getkicadComponentProperty(
 ): kicadComponentProperty {
   const name = sourceComp.name || "?"
   const reference = getReferenceDesignator(sourceComp)
-  const supplierPartNumberCandidate = (
-    sourceComp as {
-      supplier_part_numbers?: Record<string, string | string[] | undefined>
-    }
-  ).supplier_part_numbers
-  const supplierPartNumberRaw =
-    supplierPartNumberCandidate?.lcsc || supplierPartNumberCandidate?.jlcpcb
-  const supplierPartNumber = Array.isArray(supplierPartNumberRaw)
-    ? supplierPartNumberRaw.join(", ")
-    : supplierPartNumberRaw
+  const supplierPartNumber = getJlcpcbSupplierPartNumber(sourceComp)
 
   if (sourceComp.ftype === "simple_resistor") {
     const resistor = sourceComp as SourceSimpleResistor

--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -10,6 +10,7 @@ import { getReferenceDesignator } from "../../../utils/getKicadCompatibleCompone
 export interface kicadComponentProperty {
   reference: string
   kicadComponentValue?: string
+  supplierPartNumber?: string
 }
 
 /**
@@ -20,12 +21,25 @@ export function getkicadComponentProperty(
 ): kicadComponentProperty {
   const name = sourceComp.name || "?"
   const reference = getReferenceDesignator(sourceComp)
+  const supplierPartNumberCandidate = (
+    sourceComp as {
+      supplier_part_numbers?: Record<string, string | string[] | undefined>
+    }
+  ).supplier_part_numbers
+  const supplierPartNumberRaw =
+    supplierPartNumberCandidate?.lcsc || supplierPartNumberCandidate?.jlcpcb
+  const supplierPartNumber = Array.isArray(supplierPartNumberRaw)
+    ? supplierPartNumberRaw.join(", ")
+    : supplierPartNumberRaw
+
+  console.log("supplierPartNumber", supplierPartNumber)
 
   if (sourceComp.ftype === "simple_resistor") {
     const resistor = sourceComp as SourceSimpleResistor
     return {
       reference,
       kicadComponentValue: resistor.display_resistance || "R",
+      supplierPartNumber,
     }
   }
 
@@ -34,6 +48,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: capacitor.display_capacitance || "C",
+      supplierPartNumber,
     }
   }
 
@@ -42,6 +57,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: inductor.display_inductance || "L",
+      supplierPartNumber,
     }
   }
 
@@ -49,6 +65,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: "D",
+      supplierPartNumber,
     }
   }
 
@@ -56,6 +73,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: sourceComp?.manufacturer_part_number,
+      supplierPartNumber,
     }
   }
 
@@ -63,6 +81,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: sourceComp.manufacturer_part_number || "LED",
+      supplierPartNumber,
     }
   }
 
@@ -70,6 +89,7 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: sourceComp.manufacturer_part_number || "SW",
+      supplierPartNumber,
     }
   }
 
@@ -78,11 +98,13 @@ export function getkicadComponentProperty(
     return {
       reference,
       kicadComponentValue: potentiometer.display_max_resistance || "POT",
+      supplierPartNumber,
     }
   }
 
   return {
     reference,
     kicadComponentValue: name,
+    supplierPartNumber,
   }
 }

--- a/lib/pcb/stages/utils/getKicadComponentProperty.ts
+++ b/lib/pcb/stages/utils/getKicadComponentProperty.ts
@@ -32,8 +32,6 @@ export function getkicadComponentProperty(
     ? supplierPartNumberRaw.join(", ")
     : supplierPartNumberRaw
 
-  console.log("supplierPartNumber", supplierPartNumber)
-
   if (sourceComp.ftype === "simple_resistor") {
     const resistor = sourceComp as SourceSimpleResistor
     return {

--- a/tests/pcb/supplier-part-number.test.ts
+++ b/tests/pcb/supplier-part-number.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("pcb writes supplier part number to footprint text fields", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "c1",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      supplier_part_numbers: { jlcpcb: ["C1525", "C307331"] },
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_c1",
+      source_component_id: "c1",
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 1,
+      rotation: 0,
+      layer: "top",
+      obstructs_within_bounds: true,
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  expect(output).toContain('(property "Supplier Part Number" "C1525, C307331"')
+})


### PR DESCRIPTION
This PR enables the inclusion of supplier part numbers (specifically from `jlcpcb`) as properties in the generated KiCad PCB footprints.
### Key Changes
- **Metadata Extraction**: Updated `getKicadComponentProperty` to extract supplier part numbers from the `supplier_part_numbers` record in `source_component`.
- **Footprint Property Injection**: Modified `applyMetadataToFootprint` to inject the extracted supplier part number as a [(property "Supplier Part Number" "...")] field in the KiCad footprint definition


<img width="1461" height="818" alt="Screenshot from 2026-04-22 09-01-21" src="https://github.com/user-attachments/assets/e877bbf2-2b06-4fa2-a1f2-e66425cc4380" />
