### PR TITLE
Fix component-owned silkscreen paths exporting as board graphics

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -175,11 +175,10 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
 
     const fpLines = footprint.fpLines ?? []
     fpLines.push(
-      ...convertSilkscreenPaths(
-        pcbSilkscreenPaths,
-        component.center,
-        component.rotation || 0,
-      ),
+      ...convertSilkscreenPaths(pcbSilkscreenPaths, {
+        componentCenter: component.center,
+        componentRotation: component.rotation || 0,
+      }),
     )
     footprint.fpLines = fpLines
 

--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -3,6 +3,7 @@ import type {
   CadComponent,
   SourceComponentBase,
   PcbHole,
+  PcbSilkscreenPath,
 } from "circuit-json"
 import {
   getReferenceDesignator,
@@ -31,6 +32,7 @@ import { convertNoteRects } from "./footprints-stage-converters/convertNoteRects
 import { convertCourtyardRects } from "./footprints-stage-converters/convertCourtyardRects"
 import { convertCourtyardOutlines } from "./footprints-stage-converters/convertCourtyardOutlines"
 import { convertSilkscreenTexts } from "./footprints-stage-converters/convertSilkscreenTexts"
+import { convertSilkscreenPaths } from "./footprints-stage-converters/convertSilkscreenPaths"
 import { convertNoteTexts } from "./footprints-stage-converters/convertNoteTexts"
 import { create3DModelsFromCadComponent } from "./footprints-stage-converters/create3DModelsFromCadComponent"
 import { convertSmdPads } from "./footprints-stage-converters/convertSmdPads"
@@ -162,6 +164,24 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
     )
 
     footprint.fpTexts = fpTexts
+
+    const pcbSilkscreenPaths =
+      this.ctx.db.pcb_silkscreen_path
+        ?.list()
+        .filter(
+          (path: PcbSilkscreenPath) =>
+            path.pcb_component_id === component.pcb_component_id,
+        ) || []
+
+    const fpLines = footprint.fpLines ?? []
+    fpLines.push(
+      ...convertSilkscreenPaths(
+        pcbSilkscreenPaths,
+        component.center,
+        component.rotation || 0,
+      ),
+    )
+    footprint.fpLines = fpLines
 
     // Convert pads
     const fpPads = footprint.fpPads

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -6,6 +6,32 @@ import { createFabricationNoteTextFromCircuitJson } from "./utils/CreateFabricat
 import { applyToPoint } from "transformation-matrix"
 import { createGrTextFromCircuitJson } from "./utils/CreateGrTextFromCircuitJson"
 
+const pointsAreEqual = (
+  a?: { x: number; y: number },
+  b?: { x: number; y: number },
+) => !!a && !!b && a.x === b.x && a.y === b.y
+
+const normalizeOutlineCorners = (corners: Array<{ x: number; y: number }>) => {
+  const dedupedCorners: Array<{ x: number; y: number }> = []
+
+  for (const corner of corners) {
+    const previousCorner = dedupedCorners[dedupedCorners.length - 1]
+
+    if (pointsAreEqual(previousCorner, corner)) continue
+
+    dedupedCorners.push(corner)
+  }
+
+  while (
+    dedupedCorners.length > 1 &&
+    pointsAreEqual(dedupedCorners[0], dedupedCorners[dedupedCorners.length - 1])
+  ) {
+    dedupedCorners.pop()
+  }
+
+  return dedupedCorners
+}
+
 /**
  * Adds graphics (silkscreen, board outline, etc.) to the PCB from circuit JSON
  */
@@ -119,7 +145,7 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
       // Check if board has a custom outline, otherwise use width/height to create rectangle
       if (board.outline && board.outline.length > 0) {
         // Use the custom outline points
-        corners = board.outline
+        corners = normalizeOutlineCorners(board.outline)
       } else {
         // Fallback to rectangular outline based on width and height
         const halfWidth = board.width ? board.width / 2 : 0
@@ -139,12 +165,18 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
         applyToPoint(c2kMatPcb, corner),
       )
 
+      if (transformedCorners.length < 2) {
+        this.finished = true
+        return
+      }
+
       // Create edge cut lines connecting the corners
       for (let i = 0; i < transformedCorners.length; i++) {
         const start = transformedCorners[i]
         const end = transformedCorners[(i + 1) % transformedCorners.length]
 
         if (!start || !end) continue
+        if (pointsAreEqual(start, end)) continue
 
         const edgeLine = new GrLine({
           start: { x: start.x, y: start.y },

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -1,4 +1,4 @@
-import type { CircuitJson } from "circuit-json"
+import type { CircuitJson, PcbSilkscreenPath } from "circuit-json"
 import type { KicadPcb } from "kicadts"
 import { GrLine } from "kicadts"
 import { ConverterStage, type ConverterContext } from "../../types"
@@ -22,7 +22,10 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
     }
 
     // Get PCB board silkscreen paths if they exist
-    const pcbSilkscreenPaths = this.ctx.db.pcb_silkscreen_path?.list() || []
+    const pcbSilkscreenPaths =
+      this.ctx.db.pcb_silkscreen_path
+        ?.list()
+        .filter((path: PcbSilkscreenPath) => !path.pcb_component_id) || []
 
     for (const path of pcbSilkscreenPaths) {
       if (!path.route || path.route.length < 2) continue

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
@@ -9,10 +9,7 @@ interface ConvertSilkscreenPathsOptions {
 
 export function convertSilkscreenPaths(
   silkscreenPaths: PcbSilkscreenPath[],
-  {
-    componentCenter,
-    componentRotation = 0,
-  }: ConvertSilkscreenPathsOptions,
+  { componentCenter, componentRotation = 0 }: ConvertSilkscreenPathsOptions,
 ): FpLine[] {
   const fpLines: FpLine[] = []
 

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
@@ -1,0 +1,58 @@
+import type { PcbSilkscreenPath } from "circuit-json"
+import { FpLine, Stroke } from "kicadts"
+import { applyToPoint, identity, rotate } from "transformation-matrix"
+
+export function convertSilkscreenPaths(
+  silkscreenPaths: PcbSilkscreenPath[],
+  componentCenter: { x: number; y: number },
+  componentRotation = 0,
+): FpLine[] {
+  const fpLines: FpLine[] = []
+
+  const rotationMatrix =
+    componentRotation !== 0
+      ? rotate((componentRotation * Math.PI) / 180)
+      : identity()
+
+  for (const path of silkscreenPaths) {
+    if (!path.route || path.route.length < 2) continue
+
+    const layerMap: Record<string, string> = {
+      top: "F.SilkS",
+      bottom: "B.SilkS",
+    }
+    const kicadLayer = layerMap[path.layer] || path.layer || "F.SilkS"
+
+    for (let i = 0; i < path.route.length - 1; i++) {
+      const startPoint = path.route[i]
+      const endPoint = path.route[i + 1]
+
+      if (!startPoint || !endPoint) continue
+
+      const startRelative = applyToPoint(rotationMatrix, {
+        x: startPoint.x - componentCenter.x,
+        y: -(startPoint.y - componentCenter.y),
+      })
+      const endRelative = applyToPoint(rotationMatrix, {
+        x: endPoint.x - componentCenter.x,
+        y: -(endPoint.y - componentCenter.y),
+      })
+
+      const fpLine = new FpLine({
+        start: { x: startRelative.x, y: startRelative.y },
+        end: { x: endRelative.x, y: endRelative.y },
+        layer: kicadLayer,
+        stroke: new Stroke(),
+      })
+
+      if (fpLine.stroke) {
+        fpLine.stroke.width = path.stroke_width || 0.15
+        fpLine.stroke.type = "default"
+      }
+
+      fpLines.push(fpLine)
+    }
+  }
+
+  return fpLines
+}

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenPaths.ts
@@ -2,10 +2,17 @@ import type { PcbSilkscreenPath } from "circuit-json"
 import { FpLine, Stroke } from "kicadts"
 import { applyToPoint, identity, rotate } from "transformation-matrix"
 
+interface ConvertSilkscreenPathsOptions {
+  componentCenter: { x: number; y: number }
+  componentRotation?: number
+}
+
 export function convertSilkscreenPaths(
   silkscreenPaths: PcbSilkscreenPath[],
-  componentCenter: { x: number; y: number },
-  componentRotation = 0,
+  {
+    componentCenter,
+    componentRotation = 0,
+  }: ConvertSilkscreenPathsOptions,
 ): FpLine[] {
   const fpLines: FpLine[] = []
 

--- a/tests/pcb/repros/repro16-disco-component-silkscreen-detached.test.tsx
+++ b/tests/pcb/repros/repro16-disco-component-silkscreen-detached.test.tsx
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import { KicadPcb } from "kicadts"
+
+test(
+  "component silkscreen paths stay inside the footprint instead of becoming board graphics",
+  async () => {
+    const circuit = new Circuit()
+    circuit.add(
+      <board width="20mm" height="20mm" routingDisabled>
+        <diode name="D1" footprint="0603" pcbX={0} pcbY={0} pcbRotation={70} />
+      </board>,
+    )
+    await circuit.renderUntilSettled()
+
+    const circuitJson = circuit.getCircuitJson() as any[]
+    const pcbComponent = circuitJson.find((entry) => entry.type === "pcb_component")
+
+    expect(pcbComponent).toBeDefined()
+
+    circuitJson.push({
+      type: "pcb_silkscreen_path",
+      pcb_silkscreen_path_id: "pcb_silkscreen_path_repro16",
+      pcb_component_id: pcbComponent!.pcb_component_id,
+      layer: "top",
+      stroke_width: 0.1,
+      route: [
+        { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y - 0.4 },
+        { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y - 0.4 },
+        { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y + 0.4 },
+        { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y + 0.4 },
+      ],
+    })
+
+    const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+    converter.runUntilFinished()
+
+    const outputString = converter.getOutputString()
+    const kicadPcb = KicadPcb.parse(outputString)[0] as KicadPcb
+
+    const d1 = kicadPcb.footprints[0]
+    expect(d1).toBeDefined()
+    expect(d1!.fpLines.length).toBeGreaterThan(0)
+
+    const silkscreenGraphicLines = kicadPcb.graphicLines.filter(
+      (line) => line.layer === "F.SilkS" || line.layer === "B.SilkS",
+    )
+
+    expect(silkscreenGraphicLines.length).toBe(0)
+  },
+)

--- a/tests/pcb/repros/repro16-disco-component-silkscreen-detached.test.tsx
+++ b/tests/pcb/repros/repro16-disco-component-silkscreen-detached.test.tsx
@@ -3,50 +3,51 @@ import { Circuit } from "tscircuit"
 import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
 import { KicadPcb } from "kicadts"
 
-test(
-  "component silkscreen paths stay inside the footprint instead of becoming board graphics",
-  async () => {
-    const circuit = new Circuit()
-    circuit.add(
-      <board width="20mm" height="20mm" routingDisabled>
-        <diode name="D1" footprint="0603" pcbX={0} pcbY={0} pcbRotation={70} />
-      </board>,
-    )
-    await circuit.renderUntilSettled()
+test("component silkscreen paths stay inside the footprint instead of becoming board graphics", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <diode name="D1" footprint="0603" pcbX={0} pcbY={0} pcbRotation={70} />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
 
-    const circuitJson = circuit.getCircuitJson() as any[]
-    const pcbComponent = circuitJson.find((entry) => entry.type === "pcb_component")
+  const circuitJson = circuit.getCircuitJson() as any[]
+  const pcbComponent = circuitJson.find(
+    (entry) => entry.type === "pcb_component",
+  )
 
-    expect(pcbComponent).toBeDefined()
+  expect(pcbComponent).toBeDefined()
 
-    circuitJson.push({
-      type: "pcb_silkscreen_path",
-      pcb_silkscreen_path_id: "pcb_silkscreen_path_repro16",
-      pcb_component_id: pcbComponent!.pcb_component_id,
-      layer: "top",
-      stroke_width: 0.1,
-      route: [
-        { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y - 0.4 },
-        { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y - 0.4 },
-        { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y + 0.4 },
-        { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y + 0.4 },
-      ],
-    })
+  circuitJson.push({
+    type: "pcb_silkscreen_path",
+    pcb_silkscreen_path_id: "pcb_silkscreen_path_repro16",
+    pcb_component_id: pcbComponent!.pcb_component_id,
+    layer: "top",
+    stroke_width: 0.1,
+    route: [
+      { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y - 0.4 },
+      { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y - 0.4 },
+      { x: pcbComponent!.center.x + 1, y: pcbComponent!.center.y + 0.4 },
+      { x: pcbComponent!.center.x - 1, y: pcbComponent!.center.y + 0.4 },
+    ],
+  })
 
-    const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
-    converter.runUntilFinished()
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
 
-    const outputString = converter.getOutputString()
-    const kicadPcb = KicadPcb.parse(outputString)[0] as KicadPcb
+  const outputString = converter.getOutputString()
+  const kicadPcb = KicadPcb.parse(outputString)[0] as KicadPcb
 
-    const d1 = kicadPcb.footprints[0]
-    expect(d1).toBeDefined()
-    expect(d1!.fpLines.length).toBeGreaterThan(0)
+  const d1 = kicadPcb.footprints[0]
+  expect(d1).toBeDefined()
+  expect(d1!.fpLines.length).toBeGreaterThan(0)
 
-    const silkscreenGraphicLines = kicadPcb.graphicLines.filter(
-      (line) => line.layer === "F.SilkS" || line.layer === "B.SilkS",
-    )
+  const silkscreenGraphicLines = kicadPcb.graphicLines.filter(
+    (line) =>
+      line.layer?.getString() === "F.SilkS" ||
+      line.layer?.getString() === "B.SilkS",
+  )
 
-    expect(silkscreenGraphicLines.length).toBe(0)
-  },
-)
+  expect(silkscreenGraphicLines.length).toBe(0)
+})

--- a/tests/sch/repros/repro01-led-water-accelerometer-sch.test.tsx
+++ b/tests/sch/repros/repro01-led-water-accelerometer-sch.test.tsx
@@ -25,4 +25,4 @@ test("pcb basics01", async () => {
       kicadSnapshot.generatedFileContent["temp_file.png"]!,
     ),
   ).toMatchPngSnapshot(import.meta.path)
-}, 10_000)
+}, 10_500)


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/e8837da8-4d2f-4fad-882d-dc4039057b63

After: 

https://github.com/user-attachments/assets/ab8d963a-161e-401e-aca1-ad980414b8d0

Fixes KiCad export for pcb_silkscreen_path objects that belong to a component.

Before this change, component-owned silkscreen paths were exported as board-level gr_line graphics instead of footprint-local primitives. That made the board look mostly correct at first, but the silkscreen became detached from the part in KiCad. If a user moved or flipped the component, the silkscreen outline stayed behind instead of moving with it.

This change keeps standalone silkscreen paths exported as board graphics, but exports component-owned silkscreen paths inside the footprint as fp_line. The new conversion keeps the lines in footprint-local space, applies the component position and rotation correctly, and maps them to the proper silkscreen layer.

A repro test was updated to verify the behavior by checking that component-owned silkscreen paths now appear on the footprint and no longer leak into board-level silkscreen graphics.