### PR TITLE
Fix zero length copper segments

### DIFF
--- a/lib/pcb/stages/AddTracesStage.ts
+++ b/lib/pcb/stages/AddTracesStage.ts
@@ -10,6 +10,11 @@ import { applyToPoint } from "transformation-matrix"
 import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
 import { getKicadLayer } from "../utils/layerMapping"
 
+const pointsAreEqual = (
+  a?: { x: number; y: number },
+  b?: { x: number; y: number },
+) => !!a && !!b && a.x === b.x && a.y === b.y
+
 /**
  * Adds traces (segments/tracks) to the PCB from circuit JSON
  */
@@ -62,6 +67,16 @@ export class AddTracesStage extends ConverterStage<CircuitJson, KicadPcb> {
         x: endPoint.x,
         y: endPoint.y,
       })
+
+      if (pointsAreEqual(transformedStart, transformedEnd)) {
+        if (startPoint.layer) {
+          lastKnownLayer = startPoint.layer
+        }
+        if (endPoint.layer) {
+          lastKnownLayer = endPoint.layer
+        }
+        continue
+      }
 
       let netInfo: PcbNetInfo | undefined
       if (pcbNetMap) {

--- a/tests/pcb/repros/repro17-zero-length-trace-segment.test.ts
+++ b/tests/pcb/repros/repro17-zero-length-trace-segment.test.ts
@@ -37,8 +37,7 @@ test("duplicate adjacent trace points should not create a zero-length segment", 
   converter.runUntilFinished()
 
   const output = converter.getOutputString()
-  const segments =
-    output.match(/\(segment[\s\S]*?\(uuid [^)]+\)\n  \)/g) || []
+  const segments = output.match(/\(segment[\s\S]*?\(uuid [^)]+\)\n  \)/g) || []
 
   expect(segments.length).toBe(1)
   expect(output).not.toContain("(start 100 100)\n    (end 100 100)")

--- a/tests/pcb/repros/repro17-zero-length-trace-segment.test.ts
+++ b/tests/pcb/repros/repro17-zero-length-trace-segment.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("duplicate adjacent trace points should not create a zero-length segment", () => {
+  const circuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      source_board_id: "source_board_0",
+      center: { x: 0, y: 0 },
+      thickness: 1.6,
+      num_layers: 2,
+      width: 20,
+      height: 10,
+      material: "fr4",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "GND",
+      subcircuit_connectivity_map_key: "net.GND",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_1",
+      connection_name: "source_net_1",
+      subcircuit_connectivity_map_key: "net.GND",
+      route: [
+        { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 2, y: 0, width: 0.15, layer: "top" },
+      ],
+    },
+  ] as any
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const output = converter.getOutputString()
+  const segments =
+    output.match(/\(segment[\s\S]*?\(uuid [^)]+\)\n  \)/g) || []
+
+  expect(segments.length).toBe(1)
+  expect(output).not.toContain("(start 100 100)\n    (end 100 100)")
+  expect(output).toContain("(start 100 100)\n    (end 102 100)")
+})


### PR DESCRIPTION

<img width="1004" height="334" alt="image" src="https://github.com/user-attachments/assets/3e9b92f1-1390-4673-8b0a-3e5905603d0b" />


This fixes a KiCad export bug where duplicate adjacent PCB route points were being exported as real copper segments with zero length.

That produced invalid trace segments like 0.0000 mm in KiCad DRC. Once those ghost segments existed, KiCad could report extra downstream errors such as track crossing and clearance problems, even though the real routing was not the main problem.

This change skips zero-length trace segments during export, so duplicate route points no longer become invalid copper in KiCad.

A focused repro test was also added to confirm that duplicate adjacent points no longer generate zero-length exported trace segments.