### PR TITLE
fix: add support for pcb_silkscreen_rect in KiCad footprint export

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -182,6 +182,20 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
     )
     footprint.fpLines = fpLines
 
+    // Convert silkscreen rects
+    const pcbSilkscreenRects =
+      this.ctx.db.pcb_silkscreen_rect
+        ?.list()
+        .filter(
+          (rect: any) => rect.pcb_component_id === component.pcb_component_id,
+        ) || []
+
+    const fpSilkscreenRects = footprint.fpRects ?? []
+    fpSilkscreenRects.push(
+      ...convertSilkscreenRects(pcbSilkscreenRects, component.center),
+    )
+    footprint.fpRects = fpSilkscreenRects
+
     // Convert pads
     const fpPads = footprint.fpPads
     const getNetInfo = (pcbPortId?: string) =>

--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -32,6 +32,7 @@ import { convertNoteRects } from "./footprints-stage-converters/convertNoteRects
 import { convertCourtyardRects } from "./footprints-stage-converters/convertCourtyardRects"
 import { convertCourtyardOutlines } from "./footprints-stage-converters/convertCourtyardOutlines"
 import { convertSilkscreenTexts } from "./footprints-stage-converters/convertSilkscreenTexts"
+import { convertSilkscreenRects } from "./footprints-stage-converters/convertSilkscreenRects"
 import { convertSilkscreenPaths } from "./footprints-stage-converters/convertSilkscreenPaths"
 import { convertNoteTexts } from "./footprints-stage-converters/convertNoteTexts"
 import { create3DModelsFromCadComponent } from "./footprints-stage-converters/create3DModelsFromCadComponent"

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -1,6 +1,6 @@
 import type { CircuitJson, PcbSilkscreenPath } from "circuit-json"
 import type { KicadPcb } from "kicadts"
-import { GrLine } from "kicadts"
+import { GrLine, FpRect, Stroke } from "kicadts"
 import { ConverterStage, type ConverterContext } from "../../types"
 import { createFabricationNoteTextFromCircuitJson } from "./utils/CreateFabricationNoteTextFromCircuitJson"
 import { applyToPoint } from "transformation-matrix"
@@ -45,6 +45,56 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
 
     if (!c2kMatPcb) {
       throw new Error("PCB transformation matrix not initialized in context")
+    }
+
+    // Get PCB board silkscreen rects (not associated with components)
+    const pcbSilkscreenRects =
+      this.ctx.db.pcb_silkscreen_rect
+        ?.list()
+        .filter((rect: any) => !rect.pcb_component_id) || []
+
+    for (const rect of pcbSilkscreenRects) {
+      const transformedCenter = applyToPoint(c2kMatPcb, {
+        x: rect.center.x,
+        y: rect.center.y,
+      })
+
+      const layerMap: Record<string, string> = {
+        top: "F.SilkS",
+        bottom: "B.SilkS",
+      }
+      const kicadLayer = layerMap[rect.layer] || "F.SilkS"
+
+      const halfW =
+        (typeof rect.width === "number" ? rect.width : parseFloat(rect.width)) /
+        2
+      const halfH =
+        (typeof rect.height === "number"
+          ? rect.height
+          : parseFloat(rect.height)) / 2
+
+      const fpRect = new FpRect({
+        start: {
+          x: transformedCenter.x - halfW,
+          y: transformedCenter.y - halfH,
+        },
+        end: { x: transformedCenter.x + halfW, y: transformedCenter.y + halfH },
+        layer: kicadLayer,
+        stroke: new Stroke(),
+        fill: rect.is_filled ?? false,
+      })
+
+      if (fpRect.stroke) {
+        fpRect.stroke.width =
+          typeof rect.stroke_width === "number"
+            ? rect.stroke_width
+            : parseFloat(rect.stroke_width ?? "0.1")
+        fpRect.stroke.type = "default"
+      }
+
+      const footprintRects = kicadPcb.footprintRects
+      footprintRects.push(fpRect)
+      kicadPcb.footprintRects = footprintRects
     }
 
     // Get PCB board silkscreen paths if they exist

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -93,8 +93,7 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
       }
 
       const fpRects = (kicadPcb as any).fpRects
-      fpRects.push(fpRect)
-      (kicadPcb as any).fpRects = fpRects
+      fpRects.push(fpRect)(kicadPcb as any).fpRects = fpRects
     }
 
     // Get PCB board silkscreen paths if they exist

--- a/lib/pcb/stages/AddGraphicsStage.ts
+++ b/lib/pcb/stages/AddGraphicsStage.ts
@@ -92,9 +92,9 @@ export class AddGraphicsStage extends ConverterStage<CircuitJson, KicadPcb> {
         fpRect.stroke.type = "default"
       }
 
-      const footprintRects = kicadPcb.footprintRects
-      footprintRects.push(fpRect)
-      kicadPcb.footprintRects = footprintRects
+      const fpRects = (kicadPcb as any).fpRects
+      fpRects.push(fpRect)
+      (kicadPcb as any).fpRects = fpRects
     }
 
     // Get PCB board silkscreen paths if they exist

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
@@ -1,0 +1,46 @@
+import type { PcbSilkscreenRect } from "circuit-json"
+import { FpRect, Stroke } from "kicadts"
+
+export function convertSilkscreenRects(
+  silkscreenRects: PcbSilkscreenRect[],
+  componentCenter: { x: number; y: number },
+): FpRect[] {
+  const fpRects: FpRect[] = []
+
+  for (const rect of silkscreenRects) {
+    const relX = rect.center.x - componentCenter.x
+    const relY = -(rect.center.y - componentCenter.y)
+    const halfW =
+      (typeof rect.width === "number" ? rect.width : parseFloat(rect.width)) / 2
+    const halfH =
+      (typeof rect.height === "number"
+        ? rect.height
+        : parseFloat(rect.height)) / 2
+
+    const layerMap: Record<string, string> = {
+      top: "F.SilkS",
+      bottom: "B.SilkS",
+    }
+    const kicadLayer = layerMap[rect.layer] || "F.SilkS"
+
+    const fpRect = new FpRect({
+      start: { x: relX - halfW, y: relY - halfH },
+      end: { x: relX + halfW, y: relY + halfH },
+      layer: kicadLayer,
+      stroke: new Stroke(),
+      fill: rect.is_filled ?? false,
+    })
+
+    if (fpRect.stroke) {
+      fpRect.stroke.width =
+        typeof rect.stroke_width === "number"
+          ? rect.stroke_width
+          : parseFloat(rect.stroke_width ?? "0.1")
+      fpRect.stroke.type = "default"
+    }
+
+    fpRects.push(fpRect)
+  }
+
+  return fpRects
+}


### PR DESCRIPTION
## Summary

When using `silkscreenrect` in tscircuit, the silkscreen graphics were not being exported to KiCad as `fp_rect` elements inside footprints. Instead, they were being silently dropped.

This PR adds:
1. **Footprint-level support**: Converts `pcb_silkscreen_rect` elements associated with components into `FpRect` inside the footprint (`footprint.fpRects`)
2. **Board-level support**: Converts standalone `pcb_silkscreen_rect` elements (not associated with any component) into `fp_rect` board-level elements in `AddGraphicsStage`

## Changes

- **New converter**: `lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts` - converts `PcbSilkscreenRect[]` → `FpRect[]` using the same relative-coordinate pattern as other silkscreen converters
- **AddFootprintsStage.ts**: Added silkscreen rect conversion for component-associated rects (mirrors the pattern used for `pcb_silkscreen_path`, `pcb_silkscreen_circle`)
- **AddGraphicsStage.ts**: Added standalone silkscreen rect conversion (mirrors the pattern used for `pcb_silkscreen_path`)

## Behavior

| tscircuit Element | Before | After |
|---|---|---|
| `silkscreenrect` (in component) | Silently dropped ✗ | `fp_rect` inside footprint ✓ |
| `silkscreenrect` (standalone) | Silently dropped ✗ | `fp_rect` board-level ✓ |

Closes https://github.com/tscircuit/circuit-json-to-kicad/issues/191