### PR TITLE
fix: support component names like U_TEST in reference designator (issue #227)

### DIFF
--- a/lib/utils/getKicadCompatibleComponentName.ts
+++ b/lib/utils/getKicadCompatibleComponentName.ts
@@ -97,7 +97,7 @@ const referencePrefixByFtype: Record<string, string> = {
   simple_battery: "BT",
 }
 
-const referenceDesignatorPattern = /^[A-Za-z]+\d+$/
+const referenceDesignatorPattern = /^[A-Za-z]+[A-Za-z0-9_-]*[A-Za-z0-9]$|^[A-Za-z]+\d+$/
 
 export function isReferenceDesignator(value?: string | null): boolean {
   if (!value) return false

--- a/lib/utils/getKicadCompatibleComponentName.ts
+++ b/lib/utils/getKicadCompatibleComponentName.ts
@@ -97,7 +97,8 @@ const referencePrefixByFtype: Record<string, string> = {
   simple_battery: "BT",
 }
 
-const referenceDesignatorPattern = /^[A-Za-z]+[A-Za-z0-9_-]*[A-Za-z0-9]$|^[A-Za-z]+\d+$/
+const referenceDesignatorPattern =
+  /^[A-Za-z]+[A-Za-z0-9_-]*[A-Za-z0-9]$|^[A-Za-z]+\d+$/
 
 export function isReferenceDesignator(value?: string | null): boolean {
   if (!value) return false

--- a/tests/pcb/repros/repro-227-ref-desig.test.tsx
+++ b/tests/pcb/repros/repro-227-ref-desig.test.tsx
@@ -48,7 +48,7 @@ test("custom inline footprint should have correct Reference (issue #227)", async
   const outputString = converter.getOutputString()
   const kicadPcb = KicadPcb.parse(outputString)[0] as KicadPcb
 
-  const u1 = kicadPcb.footprints[0]
+  const u1 = kicadPcb.footprints[0]!
   expect(u1).toBeDefined()
 
   // Find Reference property

--- a/tests/pcb/repros/repro-227-ref-desig.test.tsx
+++ b/tests/pcb/repros/repro-227-ref-desig.test.tsx
@@ -36,9 +36,12 @@ test("custom inline footprint should have correct Reference (issue #227)", async
   )
   await circuit.renderUntilSettled()
   const circuitJson = circuit.getCircuitJson()
-  
-  console.log("Circuit JSON sample:", JSON.stringify(circuitJson.slice(0,3), null, 2))
-  
+
+  console.log(
+    "Circuit JSON sample:",
+    JSON.stringify(circuitJson.slice(0, 3), null, 2),
+  )
+
   const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
   converter.runUntilFinished()
 
@@ -47,10 +50,10 @@ test("custom inline footprint should have correct Reference (issue #227)", async
 
   const u1 = kicadPcb.footprints[0]
   expect(u1).toBeDefined()
-  
+
   // Find Reference property
-  const refProp = u1.properties?.find(p => p.key === "Reference")
+  const refProp = u1.properties?.find((p) => p.key === "Reference")
   console.log("Reference property:", refProp?.value)
-  
+
   expect(outputString).toContain('(property "Reference" "U_TEST"')
 })

--- a/tests/pcb/repros/repro-227-ref-desig.test.tsx
+++ b/tests/pcb/repros/repro-227-ref-desig.test.tsx
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import { KicadPcb } from "kicadts"
+
+test("custom inline footprint should have correct Reference (issue #227)", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="10mm" routingDisabled>
+      <chip
+        name="U_TEST"
+        pcbX={0}
+        pcbY={0}
+        footprint={
+          <footprint>
+            <smtpad
+              portHints={["1"]}
+              pcbX="-1mm"
+              pcbY="0mm"
+              width="0.8mm"
+              height="1.5mm"
+              shape="rect"
+            />
+            <smtpad
+              portHints={["2"]}
+              pcbX="1mm"
+              pcbY="0mm"
+              width="0.8mm"
+              height="1.5mm"
+              shape="rect"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+  
+  console.log("Circuit JSON sample:", JSON.stringify(circuitJson.slice(0,3), null, 2))
+  
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+  const kicadPcb = KicadPcb.parse(outputString)[0] as KicadPcb
+
+  const u1 = kicadPcb.footprints[0]
+  expect(u1).toBeDefined()
+  
+  // Find Reference property
+  const refProp = u1.properties?.find(p => p.key === "Reference")
+  console.log("Reference property:", refProp?.value)
+  
+  expect(outputString).toContain('(property "Reference" "U_TEST"')
+})


### PR DESCRIPTION
## Summary

Issue #227: Reference designators empty on custom inline footprints

Root cause: The `referenceDesignatorPattern` was `/^[A-Za-z]+\d+$/` which only matched names like `R1`, `U1`, `C1` but not `U_TEST`, `VCC`, `R_1`, etc.

Fix: Extended pattern to `/^[A-Za-z]+[A-Za-z0-9_-]*[A-Za-z0-9]$|^[A-Za-z]+\d+$/`

Closes #227