### PR TITLE
fix: export pcb_silkscreen_rect as fp_rect inside footprint

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -4,6 +4,7 @@ import type {
   SourceComponentBase,
   PcbHole,
   PcbSilkscreenPath,
+  PcbSilkscreenRect,
 } from "circuit-json"
 import {
   getReferenceDesignator,
@@ -30,6 +31,7 @@ import { convertCourtyardCircles } from "./footprints-stage-converters/convertCo
 import { convertFabricationNoteRects } from "./footprints-stage-converters/convertFabricationNoteRects"
 import { convertNoteRects } from "./footprints-stage-converters/convertNoteRects"
 import { convertCourtyardRects } from "./footprints-stage-converters/convertCourtyardRects"
+import { convertSilkscreenRects } from "./footprints-stage-converters/convertSilkscreenRects"
 import { convertCourtyardOutlines } from "./footprints-stage-converters/convertCourtyardOutlines"
 import { convertSilkscreenTexts } from "./footprints-stage-converters/convertSilkscreenTexts"
 import { convertSilkscreenPaths } from "./footprints-stage-converters/convertSilkscreenPaths"
@@ -298,6 +300,22 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         ) || []
 
     fpRects.push(...convertCourtyardRects(pcbCourtyardRects, component.center))
+
+    const pcbSilkscreenRects =
+      this.ctx.db.pcb_silkscreen_rect
+        ?.list()
+        .filter(
+          (rect: PcbSilkscreenRect) =>
+            rect.pcb_component_id === component.pcb_component_id,
+        ) || []
+
+    fpRects.push(
+      ...convertSilkscreenRects(pcbSilkscreenRects, {
+        componentCenter: component.center,
+        componentRotation: component.rotation || 0,
+      }),
+    )
+
     footprint.fpRects = fpRects
 
     // Convert polygons

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenRects.ts
@@ -1,0 +1,53 @@
+import type { PcbSilkscreenRect } from "circuit-json"
+import { FpRect, Stroke } from "kicadts"
+import { applyToPoint, identity, rotate } from "transformation-matrix"
+
+interface ConvertSilkscreenRectsOptions {
+  componentCenter: { x: number; y: number }
+  componentRotation?: number
+}
+
+export function convertSilkscreenRects(
+  silkscreenRects: PcbSilkscreenRect[],
+  { componentCenter, componentRotation = 0 }: ConvertSilkscreenRectsOptions,
+): FpRect[] {
+  const fpRects: FpRect[] = []
+
+  const rotationMatrix =
+    componentRotation !== 0
+      ? rotate((componentRotation * Math.PI) / 180)
+      : identity()
+
+  for (const rect of silkscreenRects) {
+    const relX = rect.center.x - componentCenter.x
+    const relY = -(rect.center.y - componentCenter.y)
+    const halfW = rect.width / 2
+    const halfH = rect.height / 2
+
+    // Apply rotation to the rect center relative to footprint origin
+    const rotatedCenter = applyToPoint(rotationMatrix, { x: relX, y: relY })
+
+    const layerMap: Record<string, string> = {
+      top: "F.SilkS",
+      bottom: "B.SilkS",
+    }
+    const kicadLayer = layerMap[rect.layer] || "F.SilkS"
+
+    const fpRect = new FpRect({
+      start: { x: rotatedCenter.x - halfW, y: rotatedCenter.y - halfH },
+      end: { x: rotatedCenter.x + halfW, y: rotatedCenter.y + halfH },
+      layer: kicadLayer,
+      stroke: new Stroke(),
+      fill: rect.is_filled ?? false,
+    })
+
+    if (fpRect.stroke) {
+      fpRect.stroke.width = rect.stroke_width ?? 0.12
+      fpRect.stroke.type = "default"
+    }
+
+    fpRects.push(fpRect)
+  }
+
+  return fpRects
+}

--- a/tests/pcb/basics/basics17-silkscreen-rect.test.tsx
+++ b/tests/pcb/basics/basics17-silkscreen-rect.test.tsx
@@ -55,5 +55,4 @@ test("pcb_silkscreen_rect is converted to KiCad fp_rect inside footprint (not gr
   // Confirm it's NOT at board level (gr_rect should not contain F.SilkS)
   const grRectMatches = outputString.match(/gr_rect[\s\S]*?F\.SilkS/g)
   expect(grRectMatches).toBeNull()
-
 })

--- a/tests/pcb/basics/basics17-silkscreen-rect.test.tsx
+++ b/tests/pcb/basics/basics17-silkscreen-rect.test.tsx
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("pcb_silkscreen_rect is converted to KiCad fp_rect inside footprint (not gr_rect)", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              portHints={["1"]}
+              pcbX={0}
+              pcbY={0}
+              width="2mm"
+              height="1mm"
+              shape="rect"
+              layer="top"
+            />
+            <silkscreenrect
+              pcbX={0}
+              pcbY={0}
+              width="3mm"
+              height="2mm"
+              layer="top"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson() as any[]
+
+  // Verify pcb_silkscreen_rect is in circuit JSON
+  const silkscreenRects = circuitJson.filter(
+    (el: any) => el.type === "pcb_silkscreen_rect",
+  )
+  expect(silkscreenRects.length).toBeGreaterThan(0)
+  expect(silkscreenRects[0].pcb_component_id).toBeDefined()
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+
+  // The silkscreen rect should appear as fp_rect (inside footprint), NOT gr_rect (board-level)
+  expect(outputString).toContain("fp_rect")
+  expect(outputString).toContain("F.SilkS")
+
+  // Confirm it's NOT at board level (gr_rect should not contain F.SilkS)
+  const grRectMatches = outputString.match(/gr_rect[\s\S]*?F\.SilkS/g)
+  expect(grRectMatches).toBeNull()
+
+})


### PR DESCRIPTION
Closes #186\n\nMaps pcb_silkscreen_rect elements to KiCad fp_rect primitives inside footprint definitions.