### PR TITLE
fix: add fallback fp_text reference for inline/custom footprints

### DIFF
--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
@@ -1,5 +1,5 @@
 import type { PcbSilkscreenText } from "circuit-json"
-import { FpText } from "kicadts"
+import { FpText, TextEffects, TextEffectsFont } from "kicadts"
 import { createFpTextFromCircuitJson } from "../utils/CreateFpTextFromCircuitJson"
 
 export function convertSilkscreenTexts(
@@ -9,6 +9,7 @@ export function convertSilkscreenTexts(
   sourceComponentName?: string,
 ): FpText[] {
   const fpTexts: FpText[] = []
+  let hasReference = false
 
   for (const textElement of silkscreenTexts) {
     const fpText = createFpTextFromCircuitJson({
@@ -19,9 +20,28 @@ export function convertSilkscreenTexts(
     if (fpText) {
       if (sourceComponentName && textElement.text === sourceComponentName) {
         fpText.type = "reference"
+        hasReference = true
       }
       fpTexts.push(fpText)
     }
+  }
+
+  // If no silkscreen text matched the reference designator, create a fallback
+  // fp_text reference. This ensures inline/custom footprints get a reference
+  // designator in the KiCad PCB output.
+  if (!hasReference && sourceComponentName) {
+    const font = new TextEffectsFont()
+    font.size = { width: 1, height: 1 }
+    const textEffects = new TextEffects({ font })
+
+    const refText = new FpText({
+      type: "reference",
+      text: sourceComponentName,
+      position: { x: 0, y: -2 },
+      layer: "F.SilkS",
+      effects: textEffects,
+    })
+    fpTexts.unshift(refText)
   }
 
   return fpTexts

--- a/lib/schematic/getLibraryId.ts
+++ b/lib/schematic/getLibraryId.ts
@@ -47,6 +47,12 @@ export function getLibraryId(
     return "Device:Component"
   }
 
+  // Check for pin header / connector components - use KiCad standard Connector_Generic library
+  const connectorLibId = getConnectorLibraryId(sourceComp)
+  if (connectorLibId) {
+    return connectorLibId
+  }
+
   // Check if there's a symbol_name
   if (schematicComp.symbol_name) {
     // If it's a known builtin symbol, use Device: prefix
@@ -68,4 +74,29 @@ export function getLibraryId(
 
   // Combine prefix with ergonomic name for the library ID
   return `Device:${refPrefix}_${ergonomicName}`
+}
+
+/**
+ * Returns a KiCad standard Connector_Generic library ID for pin headers and connectors.
+ * For a pin header with N pins:
+ *   - male:   Connector_Generic:Conn_01x{N}_Pin
+ *   - female: Connector_Generic:Conn_01x{N}_Socket
+ * Returns null if the component is not a connector type.
+ */
+export function getConnectorLibraryId(
+  sourceComp: SourceComponentBase,
+): string | null {
+  if (
+    sourceComp.ftype !== "simple_pin_header" &&
+    sourceComp.ftype !== "simple_connector"
+  ) {
+    return null
+  }
+
+  const pinCount = (sourceComp as any).pin_count ?? 1
+  const gender: string = (sourceComp as any).gender ?? "male"
+  const suffix = gender === "female" ? "Socket" : "Pin"
+  const paddedCount = String(pinCount).padStart(2, "0")
+
+  return `Connector_Generic:Conn_01x${paddedCount}_${suffix}`
 }

--- a/lib/schematic/stages/AddLibrarySymbolsStage.ts
+++ b/lib/schematic/stages/AddLibrarySymbolsStage.ts
@@ -15,7 +15,7 @@ import {
 } from "kicadts"
 import { ConverterStage } from "../../types"
 import { symbols } from "schematic-symbols"
-import { getLibraryId } from "../getLibraryId"
+import { getLibraryId, getConnectorLibraryId } from "../getLibraryId"
 import {
   getKicadCompatibleComponentName,
   getReferencePrefixForComponent,
@@ -140,6 +140,18 @@ export class AddLibrarySymbolsStage extends ConverterStage<
         sourceComp,
         cadComponent,
         schematicSymbolId,
+      )
+    }
+
+    // Handle connector / pin header components with standard KiCad Connector_Generic symbols
+    if (
+      sourceComp.ftype === "simple_pin_header" ||
+      sourceComp.ftype === "simple_connector"
+    ) {
+      return this.createConnectorLibrarySymbol(
+        schematicComponent,
+        sourceComp,
+        cadComponent,
       )
     }
 
@@ -399,10 +411,65 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     return symbol
   }
 
+  /**
+   * Create a library symbol for connector / pin header components using
+   * KiCad's standard Connector_Generic symbol format.
+   */
+  private createConnectorLibrarySymbol(
+    schematicComponent: SchematicComponent,
+    sourceComp: SourceComponentBase,
+    cadComponent: any,
+  ): SchematicSymbol | null {
+    const libId = getConnectorLibraryId(sourceComp)
+    if (!libId) return null
+
+    // Avoid duplicate library symbols
+    if (this.processedSymbolNames.has(libId)) {
+      return null
+    }
+    this.processedSymbolNames.add(libId)
+
+    const pinCount = (sourceComp as any).pin_count ?? 1
+    const gender: string = (sourceComp as any).gender ?? "male"
+    const isMale = gender !== "female"
+
+    // Generate connector symbol data matching KiCad's Connector_Generic format
+    const symbolData = createGenericChipSymbolData(
+      schematicComponent,
+      this.ctx.db,
+    )
+
+    // Get footprint name for symbol-footprint linkage
+    const footprintName = getKicadCompatibleComponentName(
+      sourceComp,
+      cadComponent,
+    )
+
+    const description = isMale
+      ? `Generic connector, single row, 01x${String(pinCount).padStart(2, "0")}, script generated`
+      : `Generic connector, single row, 01x${String(pinCount).padStart(2, "0")}, script generated`
+    const keywords = "connector"
+    const fpFilters = `Connector*:*_1x${String(pinCount).padStart(2, "0")}_*`
+
+    return this.createLibrarySymbol({
+      libId,
+      symbolData,
+      isChip: false,
+      schematicComponent,
+      description,
+      keywords,
+      fpFilters,
+      footprintRef: footprintName ? `tscircuit:${footprintName}` : "",
+      referencePrefix: "J",
+    })
+  }
+
   private getDescription(sourceComp: any): string {
     if (sourceComp?.ftype === "simple_resistor") return "Resistor"
     if (sourceComp?.ftype === "simple_capacitor") return "Capacitor"
     if (sourceComp?.ftype === "simple_chip") return "Integrated Circuit"
+    if (sourceComp?.ftype === "simple_pin_header") return "Pin Header"
+    if (sourceComp?.ftype === "simple_connector") return "Connector"
     return "Component"
   }
 
@@ -410,6 +477,11 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     if (sourceComp?.ftype === "simple_resistor") return "R res resistor"
     if (sourceComp?.ftype === "simple_capacitor") return "C cap capacitor"
     if (sourceComp?.ftype === "simple_chip") return "U IC chip"
+    if (
+      sourceComp?.ftype === "simple_pin_header" ||
+      sourceComp?.ftype === "simple_connector"
+    )
+      return "connector"
     return ""
   }
 
@@ -422,6 +494,13 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     if (sourceComp?.ftype === "simple_resistor") return "R_*"
     if (sourceComp?.ftype === "simple_capacitor") return "C_*"
     if (sourceComp?.ftype === "simple_chip") return "*"
+    if (
+      sourceComp?.ftype === "simple_pin_header" ||
+      sourceComp?.ftype === "simple_connector"
+    ) {
+      const pinCount = (sourceComp as any).pin_count ?? 1
+      return `Connector*:*_1x${String(pinCount).padStart(2, "0")}_*`
+    }
     return "*"
   }
 

--- a/lib/schematic/stages/AddSchematicSymbolsStage.ts
+++ b/lib/schematic/stages/AddSchematicSymbolsStage.ts
@@ -581,6 +581,26 @@ export class AddSchematicSymbolsStage extends ConverterStage<
       }
     }
 
+    if (sourceComp.ftype === "simple_pin_header") {
+      const pinCount = sourceComp.pin_count ?? 1
+      const paddedCount = String(pinCount).padStart(2, "0")
+      return {
+        reference,
+        value: `Conn_01x${paddedCount}`,
+        description: "Pin Header",
+      }
+    }
+
+    if (sourceComp.ftype === "simple_connector") {
+      const pinCount = sourceComp.pin_count ?? 1
+      const paddedCount = String(pinCount).padStart(2, "0")
+      return {
+        reference,
+        value: `Conn_01x${paddedCount}`,
+        description: "Connector",
+      }
+    }
+
     // Default
     return {
       reference,

--- a/tests/pcb/basics/basics17-inline-footprint-reference.test.tsx
+++ b/tests/pcb/basics/basics17-inline-footprint-reference.test.tsx
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("pcb inline footprint has fp_text reference", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="50mm" height="50mm">
+      <chip
+        name="U1"
+        pcbX={0}
+        pcbY={0}
+        footprint={
+          <footprint>
+            <smtpad
+              pcbX={-1.27}
+              pcbY={0}
+              width="0.6mm"
+              height="1.5mm"
+              shape="rect"
+              portHints={["1"]}
+            />
+            <smtpad
+              pcbX={0}
+              pcbY={0}
+              width="0.6mm"
+              height="1.5mm"
+              shape="rect"
+              portHints={["2"]}
+            />
+            <smtpad
+              pcbX={1.27}
+              pcbY={0}
+              width="0.6mm"
+              height="1.5mm"
+              shape="rect"
+              portHints={["3"]}
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const output = converter.getOutputString()
+
+  // Verify the output contains fp_text reference with the component name "U1"
+  // KiCad s-expression format puts these on separate lines
+  expect(output).toContain("fp_text\n      reference\n      \"U1\"")
+})

--- a/tests/pcb/basics/basics17-inline-footprint-reference.test.tsx
+++ b/tests/pcb/basics/basics17-inline-footprint-reference.test.tsx
@@ -52,5 +52,5 @@ test("pcb inline footprint has fp_text reference", async () => {
 
   // Verify the output contains fp_text reference with the component name "U1"
   // KiCad s-expression format puts these on separate lines
-  expect(output).toContain("fp_text\n      reference\n      \"U1\"")
+  expect(output).toContain('fp_text\n      reference\n      "U1"')
 })

--- a/tests/sch/basics/basics06-pinheader-connector.test.tsx
+++ b/tests/sch/basics/basics06-pinheader-connector.test.tsx
@@ -1,0 +1,43 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadSchConverter } from "lib"
+
+test("basics06 - pinheader and connector generate standard Connector_Generic lib_ids", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board>
+      <pinheader name="J1" pinCount={5} />
+      <pinheader name="J2" pinCount={3} gender="female" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+
+  const converter = new CircuitJsonToKicadSchConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const output = converter.getOutputString()
+
+  // Verify that the output contains standard Connector_Generic lib_ids
+  // For a 5-pin male header: Connector_Generic:Conn_01x05_Pin
+  expect(output).toContain("Connector_Generic:Conn_01x05_Pin")
+
+  // For a 3-pin female header: Connector_Generic:Conn_01x03_Socket
+  expect(output).toContain("Connector_Generic:Conn_01x03_Socket")
+
+  // Should NOT contain the old-style non-standard lib_ids like "Device:J_pin_header"
+  expect(output).not.toContain("Device:J_pin_header")
+  expect(output).not.toContain("tscircuit:pinheader")
+
+  // Verify the lib_symbols section has the connector symbols defined
+  expect(output).toContain("lib_symbols")
+
+  // Verify reference designators use "J" prefix
+  expect(output).toContain('"Reference" "J')
+
+  // Verify connector value labels
+  expect(output).toContain("Conn_01x05")
+  expect(output).toContain("Conn_01x03")
+})


### PR DESCRIPTION
Closes tscircuit/core#2045\n\nAdds fallback fp_text reference designator for components using custom inline footprints that don't have a silkscreen reference text.