### PR TITLE
feat(pcb): translate pcb_copper_pour records to KiCad (zone …) blocks

### DIFF
--- a/lib/pcb/CircuitJsonToKicadPcbConverter.ts
+++ b/lib/pcb/CircuitJsonToKicadPcbConverter.ts
@@ -8,6 +8,7 @@ import { AddNetsStage } from "./stages/AddNetsStage"
 import { AddFootprintsStage } from "./stages/AddFootprintsStage"
 import { AddTracesStage } from "./stages/AddTracesStage"
 import { AddViasStage } from "./stages/AddViasStage"
+import { AddCopperPoursStage } from "./stages/AddCopperPoursStage"
 import { AddStandalonePcbElements } from "./stages/AddStandalonePcbElements"
 import { AddGraphicsStage } from "./stages/AddGraphicsStage"
 
@@ -70,6 +71,7 @@ export class CircuitJsonToKicadPcbConverter {
       }),
       new AddTracesStage(circuitJson, this.ctx),
       new AddViasStage(circuitJson, this.ctx),
+      new AddCopperPoursStage(circuitJson, this.ctx),
       new AddStandalonePcbElements(circuitJson, this.ctx),
       new AddGraphicsStage(circuitJson, this.ctx),
     ]

--- a/lib/pcb/stages/AddCopperPoursStage.ts
+++ b/lib/pcb/stages/AddCopperPoursStage.ts
@@ -1,0 +1,145 @@
+import type { CircuitJson } from "circuit-json"
+import { type KicadPcb, parseKicadSexpr, Zone } from "kicadts"
+import {
+  ConverterStage,
+  type ConverterContext,
+  type PcbNetInfo,
+} from "../../types"
+import { applyToPoint } from "transformation-matrix"
+import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
+import { getKicadLayer } from "../utils/layerMapping"
+
+interface PourLike {
+  pcb_copper_pour_id?: string
+  layer?: string
+  source_net_id?: string
+  shape?: string
+  brep_shape?: {
+    outer_ring?: { vertices: { x: number; y: number }[] }
+    inner_rings?: { vertices: { x: number; y: number }[] }[]
+  }
+  // Some pours may also carry the outline directly (older shape variant).
+  outline?: { x: number; y: number }[]
+}
+
+const escapeNetName = (name: string): string =>
+  name.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+
+const formatXy = (x: number, y: number): string =>
+  `(xy ${x.toFixed(6)} ${y.toFixed(6)})`
+
+/**
+ * Adds copper pour zones to the PCB from circuit JSON `pcb_copper_pour`
+ * records. Each pour is translated to a KiCad `(zone …)` block with the
+ * outer-ring polygon as the zone outline; inner rings (cutouts) are
+ * preserved as additional `(polygon …)` children so KiCad can subtract
+ * them when refilling.
+ *
+ * KiCad's pcbnew will compute the actual filled copper at refill time
+ * from the outline + connect_pads/min_thickness/clearance settings.
+ */
+export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
+  private poursProcessed = 0
+  private pours: PourLike[] = []
+
+  constructor(input: CircuitJson, ctx: ConverterContext) {
+    super(input, ctx)
+    this.pours = (this.ctx.db.pcb_copper_pour?.list() ?? []) as PourLike[]
+  }
+
+  override _step(): void {
+    const { kicadPcb, c2kMatPcb, pcbNetMap } = this.ctx
+
+    if (!kicadPcb) {
+      throw new Error("KicadPcb instance not initialized in context")
+    }
+    if (!c2kMatPcb) {
+      throw new Error("PCB transformation matrix not initialized in context")
+    }
+
+    if (this.poursProcessed >= this.pours.length) {
+      this.finished = true
+      return
+    }
+
+    const pour = this.pours[this.poursProcessed]
+    if (!pour) {
+      this.finished = true
+      return
+    }
+
+    const outerVertices =
+      pour.brep_shape?.outer_ring?.vertices ?? pour.outline ?? []
+    if (outerVertices.length < 3) {
+      // Not a renderable polygon — skip.
+      this.poursProcessed++
+      return
+    }
+
+    const innerRings = pour.brep_shape?.inner_rings ?? []
+
+    // Resolve the KiCad net via the source_net's connectivity key.
+    let netInfo: PcbNetInfo | undefined
+    if (pcbNetMap && pour.source_net_id) {
+      const sourceNet = this.ctx.db.source_net?.get(pour.source_net_id)
+      const connectivityKey =
+        sourceNet?.subcircuit_connectivity_map_key ?? pour.source_net_id
+      if (connectivityKey) {
+        netInfo = pcbNetMap.get(connectivityKey)
+      }
+    }
+
+    const netId = netInfo?.id ?? 0
+    const netName = netInfo?.name ?? ""
+    const kicadLayer = getKicadLayer(pour.layer)
+
+    const transformVertices = (
+      vertices: { x: number; y: number }[],
+    ): string => {
+      const xys = vertices
+        .map((v) => {
+          const p = applyToPoint(c2kMatPcb, { x: v.x, y: v.y })
+          return formatXy(p.x, p.y)
+        })
+        .join(" ")
+      return `(pts ${xys})`
+    }
+
+    const polygonChildren = [
+      `(polygon ${transformVertices(outerVertices)})`,
+      ...innerRings
+        .filter((r) => r?.vertices?.length >= 3)
+        .map((r) => `(polygon ${transformVertices(r.vertices)})`),
+    ].join("\n  ")
+
+    const uuidSeed = `copper_pour:${pour.pcb_copper_pour_id ?? this.poursProcessed}:${kicadLayer}:${netId}`
+    const uuid = generateDeterministicUuid(uuidSeed)
+
+    const zoneSexpr = `(zone
+  (net ${netId})
+  (net_name "${escapeNetName(netName)}")
+  (layer "${kicadLayer}")
+  (uuid "${uuid}")
+  (hatch edge 0.5)
+  (connect_pads (clearance 0.2))
+  (min_thickness 0.25)
+  (filled_areas_thickness no)
+  (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
+  ${polygonChildren}
+)`
+
+    const parsed = parseKicadSexpr(zoneSexpr)
+    const zone = parsed[0]
+    if (zone instanceof Zone) {
+      const zones = kicadPcb.zones
+      zones.push(zone)
+      kicadPcb.zones = zones
+    }
+
+    this.poursProcessed++
+  }
+
+  override getOutput(): KicadPcb {
+    return this.ctx.kicadPcb!
+  }
+}

--- a/tests/pcb/copperpour-zone-export.test.ts
+++ b/tests/pcb/copperpour-zone-export.test.ts
@@ -1,0 +1,162 @@
+import { test, expect } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+// Regression: pcb_copper_pour records in circuit.json must translate to
+// KiCad (zone …) blocks in the .kicad_pcb output. Previously the
+// converter emitted 0 (zone) blocks regardless of how many pours
+// existed in the input, leaving KiCad's pcbnew unable to display
+// ground planes / pour fills designed in tscircuit.
+
+test("pcb_copper_pour translates to a KiCad (zone …) block", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "GND",
+      member_source_group_ids: [],
+      subcircuit_connectivity_map_key: "gnd",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: [],
+      connected_source_net_ids: ["source_net_0"],
+      subcircuit_connectivity_map_key: "gnd",
+    },
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pcb_copper_pour_0",
+      shape: "brep",
+      layer: "bottom",
+      source_net_id: "source_net_0",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: -8, y: -8 },
+            { x: 8, y: -8 },
+            { x: 8, y: 8 },
+            { x: -8, y: 8 },
+          ],
+        },
+        inner_rings: [],
+      },
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  // A zone block was emitted.
+  const numZones = (output.match(/\(zone\b/g) || []).length
+  expect(numZones).toBe(1)
+
+  // Net resolution worked: the zone is on net 1 named "GND".
+  expect(output).toMatch(/\(zone\b[\s\S]*?\(net 1\)[\s\S]*?\(net_name GND\)/)
+
+  // Layer is correctly mapped: bottom → B.Cu
+  expect(output).toMatch(/\(zone\b[\s\S]*?\(layer B\.Cu\)/)
+
+  // Polygon outline is emitted with the four vertices we provided
+  // (transformed through the c2kMatPcb origin shift + Y-flip).
+  expect(output).toMatch(/\(polygon\s+\(pts\b/)
+  // Four (xy ...) points.
+  const xyPoints = output.match(/\(xy [^)]+\)/g) || []
+  expect(xyPoints.length).toBeGreaterThanOrEqual(4)
+})
+
+test("pcb_copper_pour without resolvable source_net falls back to net 0", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pcb_copper_pour_0",
+      shape: "brep",
+      layer: "bottom",
+      // no source_net_id at all
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: -5, y: -5 },
+            { x: 5, y: -5 },
+            { x: 5, y: 5 },
+            { x: -5, y: 5 },
+          ],
+        },
+        inner_rings: [],
+      },
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  expect((output.match(/\(zone\b/g) || []).length).toBe(1)
+  expect(output).toMatch(/\(zone\b[\s\S]*?\(net 0\)/)
+})
+
+test("pcb_copper_pour with inner_rings emits cutout polygons", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pcb_copper_pour_0",
+      shape: "brep",
+      layer: "bottom",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: -8, y: -8 },
+            { x: 8, y: -8 },
+            { x: 8, y: 8 },
+            { x: -8, y: 8 },
+          ],
+        },
+        inner_rings: [
+          {
+            vertices: [
+              { x: -1, y: -1 },
+              { x: 1, y: -1 },
+              { x: 1, y: 1 },
+              { x: -1, y: 1 },
+            ],
+          },
+        ],
+      },
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  // Outline + cutout = 2 polygons.
+  const polygons = output.match(/\(polygon\s+\(pts\b/g) || []
+  expect(polygons.length).toBeGreaterThanOrEqual(2)
+})


### PR DESCRIPTION
## Summary

Closes #284.

The PCB exporter previously emitted **no `(zone)` blocks** regardless of how many `pcb_copper_pour` records were in the input circuit JSON. Pours rendered correctly in gerber export (G36/G37 region commands in `B_Cu.gbr`/`F_Cu.gbr`) but were silently dropped on the KiCad path — so opening the resulting `.kicad_pcb` in pcbnew showed pads + traces + silkscreen but no ground plane.

## Fix

New `AddCopperPoursStage` slotted into the PCB pipeline after `AddViasStage`. For each `pcb_copper_pour` record:

- Resolve the KiCad net via `source_net_id` → source_net's `subcircuit_connectivity_map_key` → `pcbNetMap` (same lookup pattern as `AddViasStage`).
- Map `layer` to the KiCad layer name via the existing `getKicadLayer` helper (`bottom` → `B.Cu`, `inner1` → `In1.Cu`, etc.).
- Transform `brep_shape.outer_ring.vertices` through the existing `c2kMatPcb` matrix (origin shift + Y-flip) to emit `(polygon (pts (xy …)))`.
- Preserve `brep_shape.inner_rings` as additional `(polygon …)` children so KiCad subtracts them when refilling.
- Assign a deterministic UUID via the same helper used by `AddViasStage`.

Build the Zone via `parseKicadSexpr` round-trip on a sexpr-string template, since `kicadts` exposes Zone primarily through that path (the class itself is sparse — `rawChildren` only).

## Test plan

- [x] 3 new tests in `tests/pcb/copperpour-zone-export.test.ts`:
   - basic pour with resolvable net → 1 zone, correct `(net 1) (net_name GND) (layer B.Cu)`
   - pour without `source_net_id` → falls back to `(net 0)`
   - pour with inner_rings → emits both outline and cutout polygons
- [x] All previously-passing tests still pass: **89/97**
   - The 8 failing tests fail on `main` too (pre-existing unrelated issues with the KiCad-CLI snapshot fixtures — verified via `git stash && bun test <failing> && git stash pop` round-trip)
- [x] `bun run typecheck`: clean
- [x] `biome format`: clean

## Smoke test against a real board

Tested against an InsightSiP ISP3080-UX daughter board (`circuit.json` with 4 `pcb_copper_pour` fragments, all on `net.GND`, bottom layer). Output `.kicad_pcb` contains 4 `(zone)` blocks each with `(net 1) (net_name GND) (layer B.Cu)` and correctly transformed polygon vertices:

```
(zone
    (net 1)
    (net_name GND)
    (layer B.Cu)
    (uuid 56720008-153e-7238-7f11-1b881360a948)
    (hatch edge 0.5)
    (connect_pads (clearance 0.2))
    (min_thickness 0.25)
    (filled_areas_thickness no)
    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
    (polygon (pts (xy 88.3 89.3) (xy 111.7 89.3) ...))
)
```

## What's not in this PR

- KiCad will recompute the actual filled copper at refill time from outline + clearance / min_thickness. We don't pre-fill the polygon — that would require running the same constraint-solver KiCad does internally, and KiCad's refill is reliable.
- Inner rings are emitted as separate `(polygon)` children rather than as parts of a `(filled_polygon)`. This works for the "outline as input to refill" model but the visual representation in pcbnew before refill may show outline-only. After Edit → Fill All Zones (`B`), the actual fill matches the source pour intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
