### PR TITLE
Fix NaN KiCad segments from through_obstacle trace route points

### DIFF
--- a/lib/pcb/stages/AddTracesStage.ts
+++ b/lib/pcb/stages/AddTracesStage.ts
@@ -22,6 +22,24 @@ export class AddTracesStage extends ConverterStage<CircuitJson, KicadPcb> {
     this.pcbTraces = this.ctx.db.pcb_trace.list()
   }
 
+  private getRoutePointPosition(point: any, edge: "start" | "end") {
+    const position =
+      typeof point.x === "number" && typeof point.y === "number"
+        ? { x: point.x, y: point.y }
+        : point[edge]
+
+    if (
+      typeof position?.x !== "number" ||
+      typeof position?.y !== "number" ||
+      !Number.isFinite(position.x) ||
+      !Number.isFinite(position.y)
+    ) {
+      return null
+    }
+
+    return position
+  }
+
   override _step(): void {
     const { kicadPcb, c2kMatPcb, pcbNetMap } = this.ctx
 
@@ -52,16 +70,27 @@ export class AddTracesStage extends ConverterStage<CircuitJson, KicadPcb> {
     for (let i = 0; i < trace.route.length - 1; i++) {
       const startPoint = trace.route[i]
       const endPoint = trace.route[i + 1]
+      const startPosition = this.getRoutePointPosition(startPoint, "end")
+      const endPosition = this.getRoutePointPosition(endPoint, "start")
+
+      if (!startPosition || !endPosition) continue
 
       // Transform points to KiCad coordinates
       const transformedStart = applyToPoint(c2kMatPcb, {
-        x: startPoint.x,
-        y: startPoint.y,
+        x: startPosition.x,
+        y: startPosition.y,
       })
       const transformedEnd = applyToPoint(c2kMatPcb, {
-        x: endPoint.x,
-        y: endPoint.y,
+        x: endPosition.x,
+        y: endPosition.y,
       })
+
+      if (
+        transformedStart.x === transformedEnd.x &&
+        transformedStart.y === transformedEnd.y
+      ) {
+        continue
+      }
 
       let netInfo: PcbNetInfo | undefined
       if (pcbNetMap) {

--- a/tests/assets/diy-power-delivery-trigger.circuit.json
+++ b/tests/assets/diy-power-delivery-trigger.circuit.json
@@ -35,11 +35,7 @@
     "source_port_id": "source_port_0",
     "name": "SHIELD_A",
     "pin_number": 1,
-    "port_hints": [
-      "SHIELD_A",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["SHIELD_A", "pin1", "1"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -50,11 +46,7 @@
     "source_port_id": "source_port_1",
     "name": "SHIELD_B",
     "pin_number": 2,
-    "port_hints": [
-      "SHIELD_B",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["SHIELD_B", "pin2", "2"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -65,11 +57,7 @@
     "source_port_id": "source_port_2",
     "name": "SHIELD_C",
     "pin_number": 3,
-    "port_hints": [
-      "SHIELD_C",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["SHIELD_C", "pin3", "3"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -80,11 +68,7 @@
     "source_port_id": "source_port_3",
     "name": "SHIELD_D",
     "pin_number": 4,
-    "port_hints": [
-      "SHIELD_D",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["SHIELD_D", "pin4", "4"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -95,11 +79,7 @@
     "source_port_id": "source_port_4",
     "name": "SBU2",
     "pin_number": 5,
-    "port_hints": [
-      "SBU2",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["SBU2", "pin5", "5"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -108,11 +88,7 @@
     "source_port_id": "source_port_5",
     "name": "CC1",
     "pin_number": 6,
-    "port_hints": [
-      "CC1",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["CC1", "pin6", "6"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -123,11 +99,7 @@
     "source_port_id": "source_port_6",
     "name": "D_N2",
     "pin_number": 7,
-    "port_hints": [
-      "D_N2",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["D_N2", "pin7", "7"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -136,11 +108,7 @@
     "source_port_id": "source_port_7",
     "name": "D_P1",
     "pin_number": 8,
-    "port_hints": [
-      "D_P1",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["D_P1", "pin8", "8"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -149,11 +117,7 @@
     "source_port_id": "source_port_8",
     "name": "D_N1",
     "pin_number": 9,
-    "port_hints": [
-      "D_N1",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["D_N1", "pin9", "9"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -162,11 +126,7 @@
     "source_port_id": "source_port_9",
     "name": "D_P2",
     "pin_number": 10,
-    "port_hints": [
-      "D_P2",
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["D_P2", "pin10", "10"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -175,11 +135,7 @@
     "source_port_id": "source_port_10",
     "name": "SBU1",
     "pin_number": 11,
-    "port_hints": [
-      "SBU1",
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["SBU1", "pin11", "11"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -188,11 +144,7 @@
     "source_port_id": "source_port_11",
     "name": "CC2",
     "pin_number": 12,
-    "port_hints": [
-      "CC2",
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["CC2", "pin12", "12"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -203,11 +155,7 @@
     "source_port_id": "source_port_12",
     "name": "GND_A",
     "pin_number": 13,
-    "port_hints": [
-      "GND_A",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["GND_A", "pin13", "13"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -219,11 +167,7 @@
     "source_port_id": "source_port_13",
     "name": "GND_B",
     "pin_number": 14,
-    "port_hints": [
-      "GND_B",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["GND_B", "pin14", "14"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -235,11 +179,7 @@
     "source_port_id": "source_port_14",
     "name": "VBUS_A",
     "pin_number": 15,
-    "port_hints": [
-      "VBUS_A",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["VBUS_A", "pin15", "15"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -250,11 +190,7 @@
     "source_port_id": "source_port_15",
     "name": "VBUS_B",
     "pin_number": 16,
-    "port_hints": [
-      "VBUS_B",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["VBUS_B", "pin16", "16"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -267,9 +203,7 @@
     "name": "USB2",
     "manufacturer_part_number": "TYPE_C_31_M_12",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C165948"
-      ]
+      "jlcpcb": ["C165948"]
     },
     "source_group_id": "source_group_0"
   },
@@ -278,13 +212,7 @@
     "source_port_id": "source_port_16",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net2"
@@ -294,13 +222,7 @@
     "source_port_id": "source_port_17",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
@@ -311,11 +233,7 @@
     "ftype": "simple_resistor",
     "name": "R1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25076",
-        "C106232",
-        "C2906860"
-      ]
+      "jlcpcb": ["C25076", "C106232", "C2906860"]
     },
     "resistance": 100,
     "display_resistance": "100Ω",
@@ -327,13 +245,7 @@
     "source_port_id": "source_port_18",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net3"
@@ -343,13 +255,7 @@
     "source_port_id": "source_port_19",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
@@ -360,11 +266,7 @@
     "ftype": "simple_resistor",
     "name": "R2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25076",
-        "C106232",
-        "C2906860"
-      ]
+      "jlcpcb": ["C25076", "C106232", "C2906860"]
     },
     "resistance": 100,
     "display_resistance": "100Ω",
@@ -376,10 +278,7 @@
     "source_port_id": "source_port_20",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -390,10 +289,7 @@
     "source_port_id": "source_port_21",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -407,9 +303,7 @@
     "name": "D1",
     "manufacturer_part_number": "PESD5V0S1BA",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C5261083"
-      ]
+      "jlcpcb": ["C5261083"]
     },
     "source_group_id": "source_group_0"
   },
@@ -418,10 +312,7 @@
     "source_port_id": "source_port_22",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -432,10 +323,7 @@
     "source_port_id": "source_port_23",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -449,9 +337,7 @@
     "name": "D2",
     "manufacturer_part_number": "PESD5V0S1BA",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C5261083"
-      ]
+      "jlcpcb": ["C5261083"]
     },
     "source_group_id": "source_group_0"
   },
@@ -460,13 +346,7 @@
     "source_port_id": "source_port_24",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
@@ -476,13 +356,7 @@
     "source_port_id": "source_port_25",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -493,11 +367,7 @@
     "ftype": "simple_capacitor",
     "name": "C9",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1530",
-        "C71693",
-        "C107001"
-      ]
+      "jlcpcb": ["C1530", "C71693", "C107001"]
     },
     "capacitance": 2.2e-10,
     "display_capacitance": "220pF",
@@ -509,13 +379,7 @@
     "source_port_id": "source_port_26",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
@@ -525,13 +389,7 @@
     "source_port_id": "source_port_27",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -542,11 +400,7 @@
     "ftype": "simple_capacitor",
     "name": "C10",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1530",
-        "C71693",
-        "C107001"
-      ]
+      "jlcpcb": ["C1530", "C71693", "C107001"]
     },
     "capacitance": 2.2e-10,
     "display_capacitance": "220pF",
@@ -558,11 +412,7 @@
     "source_port_id": "source_port_28",
     "name": "CC2_B",
     "pin_number": 1,
-    "port_hints": [
-      "CC2_B",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["CC2_B", "pin1", "1"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
@@ -572,11 +422,7 @@
     "source_port_id": "source_port_29",
     "name": "VBUS",
     "pin_number": 2,
-    "port_hints": [
-      "VBUS",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["VBUS", "pin2", "2"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -587,11 +433,7 @@
     "source_port_id": "source_port_30",
     "name": "VDD_A",
     "pin_number": 3,
-    "port_hints": [
-      "VDD_A",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["VDD_A", "pin3", "3"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -602,11 +444,7 @@
     "source_port_id": "source_port_31",
     "name": "VDD_B",
     "pin_number": 4,
-    "port_hints": [
-      "VDD_B",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["VDD_B", "pin4", "4"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -617,11 +455,7 @@
     "source_port_id": "source_port_32",
     "name": "INT_N",
     "pin_number": 5,
-    "port_hints": [
-      "INT_N",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["INT_N", "pin5", "5"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -631,11 +465,7 @@
     "source_port_id": "source_port_33",
     "name": "SCL",
     "pin_number": 6,
-    "port_hints": [
-      "SCL",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["SCL", "pin6", "6"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -645,11 +475,7 @@
     "source_port_id": "source_port_34",
     "name": "SDA",
     "pin_number": 7,
-    "port_hints": [
-      "SDA",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["SDA", "pin7", "7"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -659,11 +485,7 @@
     "source_port_id": "source_port_35",
     "name": "GND_A",
     "pin_number": 8,
-    "port_hints": [
-      "GND_A",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["GND_A", "pin8", "8"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -675,11 +497,7 @@
     "source_port_id": "source_port_36",
     "name": "GND_B",
     "pin_number": 9,
-    "port_hints": [
-      "GND_B",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["GND_B", "pin9", "9"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -691,11 +509,7 @@
     "source_port_id": "source_port_37",
     "name": "CC1_B",
     "pin_number": 10,
-    "port_hints": [
-      "CC1_B",
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["CC1_B", "pin10", "10"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
@@ -705,11 +519,7 @@
     "source_port_id": "source_port_38",
     "name": "CC1_A",
     "pin_number": 11,
-    "port_hints": [
-      "CC1_A",
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["CC1_A", "pin11", "11"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
@@ -719,11 +529,7 @@
     "source_port_id": "source_port_39",
     "name": "VCONN_B",
     "pin_number": 12,
-    "port_hints": [
-      "VCONN_B",
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["VCONN_B", "pin12", "12"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -732,11 +538,7 @@
     "source_port_id": "source_port_40",
     "name": "VCONN_A",
     "pin_number": 13,
-    "port_hints": [
-      "VCONN_A",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["VCONN_A", "pin13", "13"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -745,11 +547,7 @@
     "source_port_id": "source_port_41",
     "name": "CC2_A",
     "pin_number": 14,
-    "port_hints": [
-      "CC2_A",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["CC2_A", "pin14", "14"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
@@ -759,11 +557,7 @@
     "source_port_id": "source_port_42",
     "name": "EP",
     "pin_number": 15,
-    "port_hints": [
-      "EP",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["EP", "pin15", "15"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -777,9 +571,7 @@
     "name": "U1",
     "manufacturer_part_number": "FUSB302BMPX",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C132291"
-      ]
+      "jlcpcb": ["C132291"]
     },
     "source_group_id": "source_group_0"
   },
@@ -788,13 +580,7 @@
     "source_port_id": "source_port_43",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_8",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -804,13 +590,7 @@
     "source_port_id": "source_port_44",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_8",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -821,11 +601,7 @@
     "ftype": "simple_capacitor",
     "name": "C7",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1525",
-        "C307331",
-        "C60474"
-      ]
+      "jlcpcb": ["C1525", "C307331", "C60474"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100nF",
@@ -837,13 +613,7 @@
     "source_port_id": "source_port_45",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_9",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -853,13 +623,7 @@
     "source_port_id": "source_port_46",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_9",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -870,11 +634,7 @@
     "ftype": "simple_capacitor",
     "name": "C8",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C15849",
-        "C6119852",
-        "C29936"
-      ]
+      "jlcpcb": ["C15849", "C6119852", "C29936"]
     },
     "capacitance": 0.000001,
     "display_capacitance": "1uF",
@@ -886,13 +646,7 @@
     "source_port_id": "source_port_47",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_10",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
@@ -902,13 +656,7 @@
     "source_port_id": "source_port_48",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_10",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -919,11 +667,7 @@
     "ftype": "simple_capacitor",
     "name": "C2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C14663",
-        "C1591",
-        "C282519"
-      ]
+      "jlcpcb": ["C14663", "C1591", "C282519"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100nF",
@@ -935,13 +679,7 @@
     "source_port_id": "source_port_49",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_11",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
@@ -951,13 +689,7 @@
     "source_port_id": "source_port_50",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_11",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -968,11 +700,7 @@
     "ftype": "simple_capacitor",
     "name": "C4",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C13585",
-        "C7432781",
-        "C89632"
-      ]
+      "jlcpcb": ["C13585", "C7432781", "C89632"]
     },
     "capacitance": 0.00001,
     "display_capacitance": "10uF",
@@ -984,11 +712,7 @@
     "source_port_id": "source_port_51",
     "name": "FB",
     "pin_number": 1,
-    "port_hints": [
-      "FB",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["FB", "pin1", "1"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -999,11 +723,7 @@
     "source_port_id": "source_port_52",
     "name": "EN",
     "pin_number": 2,
-    "port_hints": [
-      "EN",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["EN", "pin2", "2"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1014,11 +734,7 @@
     "source_port_id": "source_port_53",
     "name": "VIN",
     "pin_number": 3,
-    "port_hints": [
-      "VIN",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["VIN", "pin3", "3"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1029,11 +745,7 @@
     "source_port_id": "source_port_54",
     "name": "GND",
     "pin_number": 4,
-    "port_hints": [
-      "GND",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["GND", "pin4", "4"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1045,11 +757,7 @@
     "source_port_id": "source_port_55",
     "name": "SW",
     "pin_number": 5,
-    "port_hints": [
-      "SW",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["SW", "pin5", "5"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1060,11 +768,7 @@
     "source_port_id": "source_port_56",
     "name": "BST",
     "pin_number": 6,
-    "port_hints": [
-      "BST",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["BST", "pin6", "6"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1077,9 +781,7 @@
     "name": "U3",
     "manufacturer_part_number": "AP63203WU_7",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C780769"
-      ]
+      "jlcpcb": ["C780769"]
     },
     "source_group_id": "source_group_1"
   },
@@ -1088,13 +790,7 @@
     "source_port_id": "source_port_57",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_13",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net11"
@@ -1104,13 +800,7 @@
     "source_port_id": "source_port_58",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_13",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
@@ -1121,11 +811,7 @@
     "ftype": "simple_capacitor",
     "name": "C11",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1525",
-        "C307331",
-        "C60474"
-      ]
+      "jlcpcb": ["C1525", "C307331", "C60474"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100nF",
@@ -1137,10 +823,7 @@
     "source_port_id": "source_port_59",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_14",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1151,10 +834,7 @@
     "source_port_id": "source_port_60",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_14",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1167,9 +847,7 @@
     "name": "L1",
     "manufacturer_part_number": "NLV32T_6R8J_PF",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C89023"
-      ]
+      "jlcpcb": ["C89023"]
     },
     "source_group_id": "source_group_1"
   },
@@ -1178,13 +856,7 @@
     "source_port_id": "source_port_61",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_15",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1194,13 +866,7 @@
     "source_port_id": "source_port_62",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_15",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -1211,11 +877,7 @@
     "ftype": "simple_capacitor",
     "name": "C5",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C12891",
-        "C90146",
-        "C5177178"
-      ]
+      "jlcpcb": ["C12891", "C90146", "C5177178"]
     },
     "capacitance": 0.000022,
     "display_capacitance": "22uF",
@@ -1227,13 +889,7 @@
     "source_port_id": "source_port_63",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_16",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1243,13 +899,7 @@
     "source_port_id": "source_port_64",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_16",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -1260,11 +910,7 @@
     "ftype": "simple_capacitor",
     "name": "C3",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C12891",
-        "C90146",
-        "C5177178"
-      ]
+      "jlcpcb": ["C12891", "C90146", "C5177178"]
     },
     "capacitance": 0.000022,
     "display_capacitance": "22uF",
@@ -1276,11 +922,7 @@
     "source_port_id": "source_port_65",
     "name": "BOOT0",
     "pin_number": 1,
-    "port_hints": [
-      "BOOT0",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["BOOT0", "pin1", "1"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1291,11 +933,7 @@
     "source_port_id": "source_port_66",
     "name": "PF0_OSC_IN",
     "pin_number": 2,
-    "port_hints": [
-      "PF0_OSC_IN",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["PF0_OSC_IN", "pin2", "2"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1304,11 +942,7 @@
     "source_port_id": "source_port_67",
     "name": "PF1_OSC_OUT",
     "pin_number": 3,
-    "port_hints": [
-      "PF1_OSC_OUT",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["PF1_OSC_OUT", "pin3", "3"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -1318,11 +952,7 @@
     "source_port_id": "source_port_68",
     "name": "NRST",
     "pin_number": 4,
-    "port_hints": [
-      "NRST",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["NRST", "pin4", "4"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1333,11 +963,7 @@
     "source_port_id": "source_port_69",
     "name": "VDDA",
     "pin_number": 5,
-    "port_hints": [
-      "VDDA",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["VDDA", "pin5", "5"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1348,11 +974,7 @@
     "source_port_id": "source_port_70",
     "name": "PA0",
     "pin_number": 6,
-    "port_hints": [
-      "PA0",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["PA0", "pin6", "6"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1361,11 +983,7 @@
     "source_port_id": "source_port_71",
     "name": "PA1",
     "pin_number": 7,
-    "port_hints": [
-      "PA1",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["PA1", "pin7", "7"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1374,11 +992,7 @@
     "source_port_id": "source_port_72",
     "name": "PA2_TX",
     "pin_number": 8,
-    "port_hints": [
-      "PA2_TX",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["PA2_TX", "pin8", "8"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1387,11 +1001,7 @@
     "source_port_id": "source_port_73",
     "name": "PA3_RX",
     "pin_number": 9,
-    "port_hints": [
-      "PA3_RX",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["PA3_RX", "pin9", "9"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1400,11 +1010,7 @@
     "source_port_id": "source_port_74",
     "name": "PA4",
     "pin_number": 10,
-    "port_hints": [
-      "PA4",
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["PA4", "pin10", "10"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -1413,11 +1019,7 @@
     "source_port_id": "source_port_75",
     "name": "PA5_LED_R",
     "pin_number": 11,
-    "port_hints": [
-      "PA5_LED_R",
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["PA5_LED_R", "pin11", "11"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net18"
@@ -1427,11 +1029,7 @@
     "source_port_id": "source_port_76",
     "name": "PA6_LED_G",
     "pin_number": 12,
-    "port_hints": [
-      "PA6_LED_G",
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["PA6_LED_G", "pin12", "12"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net16"
@@ -1441,11 +1039,7 @@
     "source_port_id": "source_port_77",
     "name": "PA7_LED_B",
     "pin_number": 13,
-    "port_hints": [
-      "PA7_LED_B",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["PA7_LED_B", "pin13", "13"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net14"
@@ -1455,11 +1049,7 @@
     "source_port_id": "source_port_78",
     "name": "PB1_INT",
     "pin_number": 14,
-    "port_hints": [
-      "PB1_INT",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["PB1_INT", "pin14", "14"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -1469,11 +1059,7 @@
     "source_port_id": "source_port_79",
     "name": "VSS",
     "pin_number": 15,
-    "port_hints": [
-      "VSS",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["VSS", "pin15", "15"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1485,11 +1071,7 @@
     "source_port_id": "source_port_80",
     "name": "VDD",
     "pin_number": 16,
-    "port_hints": [
-      "VDD",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["VDD", "pin16", "16"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1500,11 +1082,7 @@
     "source_port_id": "source_port_81",
     "name": "PA9_SCL",
     "pin_number": 17,
-    "port_hints": [
-      "PA9_SCL",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["PA9_SCL", "pin17", "17"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -1514,11 +1092,7 @@
     "source_port_id": "source_port_82",
     "name": "PA10_SDA",
     "pin_number": 18,
-    "port_hints": [
-      "PA10_SDA",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["PA10_SDA", "pin18", "18"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -1528,11 +1102,7 @@
     "source_port_id": "source_port_83",
     "name": "PA13_SWDIO",
     "pin_number": 19,
-    "port_hints": [
-      "PA13_SWDIO",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["PA13_SWDIO", "pin19", "19"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net20"
@@ -1542,11 +1112,7 @@
     "source_port_id": "source_port_84",
     "name": "PA14_SWCLK",
     "pin_number": 20,
-    "port_hints": [
-      "PA14_SWCLK",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["PA14_SWCLK", "pin20", "20"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net21"
@@ -1558,9 +1124,7 @@
     "name": "U2",
     "manufacturer_part_number": "STM32F030F4P6TR",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C89040"
-      ]
+      "jlcpcb": ["C89040"]
     },
     "source_group_id": "source_group_2"
   },
@@ -1569,13 +1133,7 @@
     "source_port_id": "source_port_85",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_18",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1585,13 +1143,7 @@
     "source_port_id": "source_port_86",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_18",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -1602,11 +1154,7 @@
     "ftype": "simple_resistor",
     "name": "R3",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25879",
-        "C114762",
-        "C2906920"
-      ]
+      "jlcpcb": ["C25879", "C114762", "C2906920"]
     },
     "resistance": 2200,
     "display_resistance": "2.2kΩ",
@@ -1618,13 +1166,7 @@
     "source_port_id": "source_port_87",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_19",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1634,13 +1176,7 @@
     "source_port_id": "source_port_88",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_19",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -1651,11 +1187,7 @@
     "ftype": "simple_resistor",
     "name": "R4",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25879",
-        "C114762",
-        "C2906920"
-      ]
+      "jlcpcb": ["C25879", "C114762", "C2906920"]
     },
     "resistance": 2200,
     "display_resistance": "2.2kΩ",
@@ -1667,13 +1199,7 @@
     "source_port_id": "source_port_89",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_20",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1683,13 +1209,7 @@
     "source_port_id": "source_port_90",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_20",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -1700,11 +1220,7 @@
     "ftype": "simple_resistor",
     "name": "R8",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25900",
-        "C105871",
-        "C2906869"
-      ]
+      "jlcpcb": ["C25900", "C105871", "C2906869"]
     },
     "resistance": 4700,
     "display_resistance": "4.7kΩ",
@@ -1716,13 +1232,7 @@
     "source_port_id": "source_port_91",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_21",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
@@ -1732,13 +1242,7 @@
     "source_port_id": "source_port_92",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_21",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -1749,11 +1253,7 @@
     "ftype": "simple_capacitor",
     "name": "C1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1525",
-        "C307331",
-        "C60474"
-      ]
+      "jlcpcb": ["C1525", "C307331", "C60474"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100nF",
@@ -1765,13 +1265,7 @@
     "source_port_id": "source_port_93",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_22",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -1781,13 +1275,7 @@
     "source_port_id": "source_port_94",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_22",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -1798,11 +1286,7 @@
     "ftype": "simple_resistor",
     "name": "R9",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25744",
-        "C60490",
-        "C25531"
-      ]
+      "jlcpcb": ["C25744", "C60490", "C25531"]
     },
     "resistance": 10000,
     "display_resistance": "10kΩ",
@@ -1814,11 +1298,7 @@
     "source_port_id": "source_port_95",
     "name": "A",
     "pin_number": 1,
-    "port_hints": [
-      "A",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["A", "pin1", "1"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_4",
     "must_be_connected": true,
@@ -1829,11 +1309,7 @@
     "source_port_id": "source_port_96",
     "name": "B",
     "pin_number": 2,
-    "port_hints": [
-      "B",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["B", "pin2", "2"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1847,9 +1323,7 @@
     "name": "SW1",
     "manufacturer_part_number": "B3U_1000P",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C231329"
-      ]
+      "jlcpcb": ["C231329"]
     },
     "source_group_id": "source_group_2"
   },
@@ -1858,13 +1332,7 @@
     "source_port_id": "source_port_97",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_24",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -1874,13 +1342,7 @@
     "source_port_id": "source_port_98",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_24",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -1891,11 +1353,7 @@
     "ftype": "simple_capacitor",
     "name": "C6",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C1525",
-        "C307331",
-        "C60474"
-      ]
+      "jlcpcb": ["C1525", "C307331", "C60474"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100nF",
@@ -1907,11 +1365,7 @@
     "source_port_id": "source_port_99",
     "name": "BLUE_K",
     "pin_number": 1,
-    "port_hints": [
-      "BLUE_K",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["BLUE_K", "pin1", "1"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -1922,11 +1376,7 @@
     "source_port_id": "source_port_100",
     "name": "RED_K",
     "pin_number": 2,
-    "port_hints": [
-      "RED_K",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["RED_K", "pin2", "2"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -1937,11 +1387,7 @@
     "source_port_id": "source_port_101",
     "name": "GREEN_K",
     "pin_number": 3,
-    "port_hints": [
-      "GREEN_K",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["GREEN_K", "pin3", "3"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_ground": true,
@@ -1952,11 +1398,7 @@
     "source_port_id": "source_port_102",
     "name": "ANODE_G",
     "pin_number": 4,
-    "port_hints": [
-      "ANODE_G",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["ANODE_G", "pin4", "4"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1967,11 +1409,7 @@
     "source_port_id": "source_port_103",
     "name": "ANODE_R",
     "pin_number": 5,
-    "port_hints": [
-      "ANODE_R",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["ANODE_R", "pin5", "5"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1982,11 +1420,7 @@
     "source_port_id": "source_port_104",
     "name": "ANODE_B",
     "pin_number": 6,
-    "port_hints": [
-      "ANODE_B",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["ANODE_B", "pin6", "6"],
     "source_component_id": "source_component_25",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -1999,9 +1433,7 @@
     "name": "LED1",
     "manufacturer_part_number": "XL_5050RGBC",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2843868"
-      ]
+      "jlcpcb": ["C2843868"]
     },
     "source_group_id": "source_group_3"
   },
@@ -2010,13 +1442,7 @@
     "source_port_id": "source_port_105",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_26",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net14"
@@ -2026,13 +1452,7 @@
     "source_port_id": "source_port_106",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_26",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net15"
@@ -2043,11 +1463,7 @@
     "ftype": "simple_resistor",
     "name": "R7",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25879",
-        "C114762",
-        "C2906920"
-      ]
+      "jlcpcb": ["C25879", "C114762", "C2906920"]
     },
     "resistance": 2200,
     "display_resistance": "2.2kΩ",
@@ -2059,13 +1475,7 @@
     "source_port_id": "source_port_107",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_27",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net16"
@@ -2075,13 +1485,7 @@
     "source_port_id": "source_port_108",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_27",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net17"
@@ -2092,11 +1496,7 @@
     "ftype": "simple_resistor",
     "name": "R6",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25908",
-        "C163457",
-        "C2909364"
-      ]
+      "jlcpcb": ["C25908", "C163457", "C2909364"]
     },
     "resistance": 5600,
     "display_resistance": "5.6kΩ",
@@ -2108,13 +1508,7 @@
     "source_port_id": "source_port_109",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_28",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net18"
@@ -2124,13 +1518,7 @@
     "source_port_id": "source_port_110",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_28",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net19"
@@ -2141,11 +1529,7 @@
     "ftype": "simple_resistor",
     "name": "R5",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25879",
-        "C114762",
-        "C2906920"
-      ]
+      "jlcpcb": ["C25879", "C114762", "C2906920"]
     },
     "resistance": 2200,
     "display_resistance": "2.2kΩ",
@@ -2157,11 +1541,7 @@
     "source_port_id": "source_port_111",
     "name": "3V3",
     "pin_number": 1,
-    "port_hints": [
-      "3V3",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["3V3", "pin1", "1"],
     "source_component_id": "source_component_29",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -2171,11 +1551,7 @@
     "source_port_id": "source_port_112",
     "name": "SWDIO",
     "pin_number": 2,
-    "port_hints": [
-      "SWDIO",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["SWDIO", "pin2", "2"],
     "source_component_id": "source_component_29",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net20"
@@ -2185,11 +1561,7 @@
     "source_port_id": "source_port_113",
     "name": "SWCLK",
     "pin_number": 3,
-    "port_hints": [
-      "SWCLK",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["SWCLK", "pin3", "3"],
     "source_component_id": "source_component_29",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net21"
@@ -2199,11 +1571,7 @@
     "source_port_id": "source_port_114",
     "name": "NRST",
     "pin_number": 4,
-    "port_hints": [
-      "NRST",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["NRST", "pin4", "4"],
     "source_component_id": "source_component_29",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
@@ -2213,11 +1581,7 @@
     "source_port_id": "source_port_115",
     "name": "GND",
     "pin_number": 5,
-    "port_hints": [
-      "GND",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["GND", "pin5", "5"],
     "source_component_id": "source_component_29",
     "subcircuit_id": "subcircuit_source_group_4",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2228,11 +1592,7 @@
     "ftype": "simple_pin_header",
     "name": "J1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C50950",
-        "C7499358",
-        "C541852"
-      ]
+      "jlcpcb": ["C50950", "C7499358", "C541852"]
     },
     "pin_count": 5,
     "gender": "female",
@@ -2244,11 +1604,7 @@
     "source_port_id": "source_port_116",
     "name": "VBUS",
     "pin_number": 1,
-    "port_hints": [
-      "VBUS",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["VBUS", "pin1", "1"],
     "source_component_id": "source_component_30",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -2259,11 +1615,7 @@
     "source_port_id": "source_port_117",
     "name": "GND",
     "pin_number": 2,
-    "port_hints": [
-      "GND",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["GND", "pin2", "2"],
     "source_component_id": "source_component_30",
     "subcircuit_id": "subcircuit_source_group_4",
     "requires_power": true,
@@ -2277,9 +1629,7 @@
     "name": "CN1",
     "manufacturer_part_number": "WJ2EDGVC_5_08_02P_14_00A",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C8445"
-      ]
+      "jlcpcb": ["C8445"]
     },
     "source_group_id": "source_group_4"
   },
@@ -2368,12 +1718,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_0",
-    "connected_source_port_ids": [
-      "source_port_14"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_14"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.VBUS_A to net.VBUS",
     "min_trace_thickness": 0.9,
@@ -2382,12 +1728,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_1",
-    "connected_source_port_ids": [
-      "source_port_15"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_15"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.VBUS_B to net.VBUS",
     "min_trace_thickness": 0.9,
@@ -2396,12 +1738,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_2",
-    "connected_source_port_ids": [
-      "source_port_12"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_12"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.GND_A to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2409,12 +1747,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_3",
-    "connected_source_port_ids": [
-      "source_port_13"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_13"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.GND_B to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2422,12 +1756,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_4",
-    "connected_source_port_ids": [
-      "source_port_0"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_0"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.SHIELD_A to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2435,12 +1765,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_5",
-    "connected_source_port_ids": [
-      "source_port_1"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_1"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.SHIELD_B to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2448,12 +1774,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_6",
-    "connected_source_port_ids": [
-      "source_port_2"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_2"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.SHIELD_C to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2461,12 +1783,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_7",
-    "connected_source_port_ids": [
-      "source_port_3"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_3"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.SHIELD_D to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2474,10 +1792,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_8",
-    "connected_source_port_ids": [
-      "source_port_11",
-      "source_port_16"
-    ],
+    "connected_source_port_ids": ["source_port_11", "source_port_16"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.CC2 to R1.pin1",
@@ -2486,10 +1801,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_9",
-    "connected_source_port_ids": [
-      "source_port_5",
-      "source_port_18"
-    ],
+    "connected_source_port_ids": ["source_port_5", "source_port_18"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "USB2.CC1 to R2.pin1",
@@ -2498,10 +1810,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_10",
-    "connected_source_port_ids": [
-      "source_port_17",
-      "source_port_41"
-    ],
+    "connected_source_port_ids": ["source_port_17", "source_port_41"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R1.pin2 to U1.CC2_A",
@@ -2510,10 +1819,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_11",
-    "connected_source_port_ids": [
-      "source_port_17",
-      "source_port_28"
-    ],
+    "connected_source_port_ids": ["source_port_17", "source_port_28"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R1.pin2 to U1.CC2_B",
@@ -2522,10 +1828,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_12",
-    "connected_source_port_ids": [
-      "source_port_17",
-      "source_port_24"
-    ],
+    "connected_source_port_ids": ["source_port_17", "source_port_24"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
@@ -2535,12 +1838,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_13",
-    "connected_source_port_ids": [
-      "source_port_25"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_25"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C9.pin2 to net.GND",
@@ -2549,10 +1848,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_14",
-    "connected_source_port_ids": [
-      "source_port_19",
-      "source_port_38"
-    ],
+    "connected_source_port_ids": ["source_port_19", "source_port_38"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R2.pin2 to U1.CC1_A",
@@ -2561,10 +1857,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_15",
-    "connected_source_port_ids": [
-      "source_port_19",
-      "source_port_37"
-    ],
+    "connected_source_port_ids": ["source_port_19", "source_port_37"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R2.pin2 to U1.CC1_B",
@@ -2573,10 +1866,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_16",
-    "connected_source_port_ids": [
-      "source_port_19",
-      "source_port_26"
-    ],
+    "connected_source_port_ids": ["source_port_19", "source_port_26"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
@@ -2586,12 +1876,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_17",
-    "connected_source_port_ids": [
-      "source_port_27"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_27"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C10.pin2 to net.GND",
@@ -2600,10 +1886,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_18",
-    "connected_source_port_ids": [
-      "source_port_17",
-      "source_port_20"
-    ],
+    "connected_source_port_ids": ["source_port_17", "source_port_20"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R1.pin2 to D1.pin1",
@@ -2612,12 +1895,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_19",
-    "connected_source_port_ids": [
-      "source_port_21"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_21"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "D1.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2625,10 +1904,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_20",
-    "connected_source_port_ids": [
-      "source_port_19",
-      "source_port_22"
-    ],
+    "connected_source_port_ids": ["source_port_19", "source_port_22"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R2.pin2 to D2.pin1",
@@ -2637,12 +1913,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_21",
-    "connected_source_port_ids": [
-      "source_port_23"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_23"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "D2.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2650,12 +1922,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_22",
-    "connected_source_port_ids": [
-      "source_port_29"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_29"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.VBUS to net.VBUS",
     "min_trace_thickness": 0.4,
@@ -2664,12 +1932,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_23",
-    "connected_source_port_ids": [
-      "source_port_30"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_30"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.VDD_A to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -2677,12 +1941,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_24",
-    "connected_source_port_ids": [
-      "source_port_31"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_31"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.VDD_B to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -2690,12 +1950,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_25",
-    "connected_source_port_ids": [
-      "source_port_43"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_43"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C7.pin1 to net.V3_3",
@@ -2704,12 +1960,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_26",
-    "connected_source_port_ids": [
-      "source_port_44"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_44"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C7.pin2 to net.GND",
@@ -2718,12 +1970,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_27",
-    "connected_source_port_ids": [
-      "source_port_45"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_45"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C8.pin1 to net.V3_3",
@@ -2732,12 +1980,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_28",
-    "connected_source_port_ids": [
-      "source_port_46"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_46"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C8.pin2 to net.GND",
@@ -2746,12 +1990,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_29",
-    "connected_source_port_ids": [
-      "source_port_35"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_35"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.GND_A to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2759,12 +1999,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_30",
-    "connected_source_port_ids": [
-      "source_port_36"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_36"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.GND_B to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2772,12 +2008,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_31",
-    "connected_source_port_ids": [
-      "source_port_42"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_42"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.EP to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2785,12 +2017,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_32",
-    "connected_source_port_ids": [
-      "source_port_32"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_32"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.INT_N to net.INT",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -2798,12 +2026,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_33",
-    "connected_source_port_ids": [
-      "source_port_33"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_33"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.SCL to net.SCL",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -2811,12 +2035,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_34",
-    "connected_source_port_ids": [
-      "source_port_34"
-    ],
-    "connected_source_net_ids": [
-      "source_net_5"
-    ],
+    "connected_source_port_ids": ["source_port_34"],
+    "connected_source_net_ids": ["source_net_5"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U1.SDA to net.SDA",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -2824,12 +2044,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_35",
-    "connected_source_port_ids": [
-      "source_port_47"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_47"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C2.pin1 to net.VBUS",
@@ -2839,12 +2055,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_36",
-    "connected_source_port_ids": [
-      "source_port_48"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_48"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C2.pin2 to net.GND",
@@ -2853,12 +2065,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_37",
-    "connected_source_port_ids": [
-      "source_port_49"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_49"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C4.pin1 to net.VBUS",
@@ -2868,12 +2076,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_38",
-    "connected_source_port_ids": [
-      "source_port_50"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_50"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C4.pin2 to net.GND",
@@ -2882,12 +2086,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_39",
-    "connected_source_port_ids": [
-      "source_port_53"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_53"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U3.VIN to net.VBUS",
     "min_trace_thickness": 0.8,
@@ -2896,12 +2096,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_40",
-    "connected_source_port_ids": [
-      "source_port_52"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_52"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U3.EN to net.VBUS",
     "min_trace_thickness": 0.35,
@@ -2910,12 +2106,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_41",
-    "connected_source_port_ids": [
-      "source_port_54"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_54"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U3.GND to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -2923,10 +2115,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_42",
-    "connected_source_port_ids": [
-      "source_port_55",
-      "source_port_59"
-    ],
+    "connected_source_port_ids": ["source_port_55", "source_port_59"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U3.SW to L1.pin1",
@@ -2935,12 +2124,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_43",
-    "connected_source_port_ids": [
-      "source_port_60"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_60"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "L1.pin2 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -2948,12 +2133,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_44",
-    "connected_source_port_ids": [
-      "source_port_51"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_51"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U3.FB to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -2961,10 +2142,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_45",
-    "connected_source_port_ids": [
-      "source_port_56",
-      "source_port_57"
-    ],
+    "connected_source_port_ids": ["source_port_56", "source_port_57"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
@@ -2974,10 +2152,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_46",
-    "connected_source_port_ids": [
-      "source_port_58",
-      "source_port_55"
-    ],
+    "connected_source_port_ids": ["source_port_58", "source_port_55"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
@@ -2987,12 +2162,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_47",
-    "connected_source_port_ids": [
-      "source_port_61"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_61"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C5.pin1 to net.V3_3",
@@ -3001,12 +2172,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_48",
-    "connected_source_port_ids": [
-      "source_port_62"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_62"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C5.pin2 to net.GND",
@@ -3015,12 +2182,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_49",
-    "connected_source_port_ids": [
-      "source_port_63"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_63"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C3.pin1 to net.V3_3",
@@ -3029,12 +2192,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_50",
-    "connected_source_port_ids": [
-      "source_port_64"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_64"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C3.pin2 to net.GND",
@@ -3043,12 +2202,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_51",
-    "connected_source_port_ids": [
-      "source_port_80"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_80"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.VDD to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3056,12 +2211,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_52",
-    "connected_source_port_ids": [
-      "source_port_69"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_69"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.VDDA to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3069,12 +2220,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_53",
-    "connected_source_port_ids": [
-      "source_port_79"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_79"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.VSS to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -3082,12 +2229,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_54",
-    "connected_source_port_ids": [
-      "source_port_65"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_65"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.BOOT0 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -3095,10 +2238,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_55",
-    "connected_source_port_ids": [
-      "source_port_68",
-      "source_port_91"
-    ],
+    "connected_source_port_ids": ["source_port_68", "source_port_91"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
@@ -3108,12 +2248,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_56",
-    "connected_source_port_ids": [
-      "source_port_92"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_92"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C1.pin2 to net.GND",
@@ -3122,12 +2258,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_57",
-    "connected_source_port_ids": [
-      "source_port_81"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_81"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PA9_SCL to net.SCL",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -3135,12 +2267,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_58",
-    "connected_source_port_ids": [
-      "source_port_82"
-    ],
-    "connected_source_net_ids": [
-      "source_net_5"
-    ],
+    "connected_source_port_ids": ["source_port_82"],
+    "connected_source_net_ids": ["source_net_5"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PA10_SDA to net.SDA",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -3148,12 +2276,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_59",
-    "connected_source_port_ids": [
-      "source_port_78"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_78"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PB1_INT to net.INT",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -3161,12 +2285,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_60",
-    "connected_source_port_ids": [
-      "source_port_67"
-    ],
-    "connected_source_net_ids": [
-      "source_net_6"
-    ],
+    "connected_source_port_ids": ["source_port_67"],
+    "connected_source_net_ids": ["source_net_6"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PF1_OSC_OUT to net.BTN",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -3174,12 +2294,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_61",
-    "connected_source_port_ids": [
-      "source_port_85"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_85"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R3.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3187,12 +2303,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_62",
-    "connected_source_port_ids": [
-      "source_port_86"
-    ],
-    "connected_source_net_ids": [
-      "source_net_5"
-    ],
+    "connected_source_port_ids": ["source_port_86"],
+    "connected_source_net_ids": ["source_net_5"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R3.pin2 to net.SDA",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
@@ -3200,12 +2312,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_63",
-    "connected_source_port_ids": [
-      "source_port_87"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_87"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R4.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3213,12 +2321,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_64",
-    "connected_source_port_ids": [
-      "source_port_88"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_88"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R4.pin2 to net.SCL",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
@@ -3226,12 +2330,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_65",
-    "connected_source_port_ids": [
-      "source_port_89"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_89"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R8.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3239,12 +2339,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_66",
-    "connected_source_port_ids": [
-      "source_port_90"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_90"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R8.pin2 to net.INT",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
@@ -3252,12 +2348,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_67",
-    "connected_source_port_ids": [
-      "source_port_93"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_93"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R9.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3265,12 +2357,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_68",
-    "connected_source_port_ids": [
-      "source_port_94"
-    ],
-    "connected_source_net_ids": [
-      "source_net_6"
-    ],
+    "connected_source_port_ids": ["source_port_94"],
+    "connected_source_net_ids": ["source_net_6"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R9.pin2 to net.BTN",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -3278,12 +2366,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_69",
-    "connected_source_port_ids": [
-      "source_port_95"
-    ],
-    "connected_source_net_ids": [
-      "source_net_6"
-    ],
+    "connected_source_port_ids": ["source_port_95"],
+    "connected_source_net_ids": ["source_net_6"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "SW1.A to net.BTN",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
@@ -3291,12 +2375,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_70",
-    "connected_source_port_ids": [
-      "source_port_96"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_96"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "SW1.B to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -3304,12 +2384,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_71",
-    "connected_source_port_ids": [
-      "source_port_97"
-    ],
-    "connected_source_net_ids": [
-      "source_net_6"
-    ],
+    "connected_source_port_ids": ["source_port_97"],
+    "connected_source_net_ids": ["source_net_6"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C6.pin1 to net.BTN",
@@ -3318,12 +2394,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_72",
-    "connected_source_port_ids": [
-      "source_port_98"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_98"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "max_length": null,
     "display_name": "C6.pin2 to net.GND",
@@ -3332,12 +2404,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_73",
-    "connected_source_port_ids": [
-      "source_port_102"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_102"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "LED1.ANODE_G to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3345,12 +2413,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_74",
-    "connected_source_port_ids": [
-      "source_port_103"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_103"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "LED1.ANODE_R to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3358,12 +2422,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_75",
-    "connected_source_port_ids": [
-      "source_port_104"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_104"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "LED1.ANODE_B to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3371,10 +2431,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_76",
-    "connected_source_port_ids": [
-      "source_port_77",
-      "source_port_105"
-    ],
+    "connected_source_port_ids": ["source_port_77", "source_port_105"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PA7_LED_B to R7.pin1",
@@ -3383,10 +2440,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_77",
-    "connected_source_port_ids": [
-      "source_port_106",
-      "source_port_99"
-    ],
+    "connected_source_port_ids": ["source_port_106", "source_port_99"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R7.pin2 to LED1.BLUE_K",
@@ -3395,10 +2449,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_78",
-    "connected_source_port_ids": [
-      "source_port_76",
-      "source_port_107"
-    ],
+    "connected_source_port_ids": ["source_port_76", "source_port_107"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PA6_LED_G to R6.pin1",
@@ -3407,10 +2458,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_79",
-    "connected_source_port_ids": [
-      "source_port_108",
-      "source_port_101"
-    ],
+    "connected_source_port_ids": ["source_port_108", "source_port_101"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R6.pin2 to LED1.GREEN_K",
@@ -3419,10 +2467,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_80",
-    "connected_source_port_ids": [
-      "source_port_75",
-      "source_port_109"
-    ],
+    "connected_source_port_ids": ["source_port_75", "source_port_109"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "U2.PA5_LED_R to R5.pin1",
@@ -3431,10 +2476,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_81",
-    "connected_source_port_ids": [
-      "source_port_110",
-      "source_port_100"
-    ],
+    "connected_source_port_ids": ["source_port_110", "source_port_100"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "R5.pin2 to LED1.RED_K",
@@ -3443,12 +2485,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_82",
-    "connected_source_port_ids": [
-      "source_port_111"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_111"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "J1.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
@@ -3456,10 +2494,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_83",
-    "connected_source_port_ids": [
-      "source_port_112",
-      "source_port_83"
-    ],
+    "connected_source_port_ids": ["source_port_112", "source_port_83"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "J1.pin2 to U2.PA13_SWDIO",
@@ -3468,10 +2503,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_84",
-    "connected_source_port_ids": [
-      "source_port_113",
-      "source_port_84"
-    ],
+    "connected_source_port_ids": ["source_port_113", "source_port_84"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "J1.pin3 to U2.PA14_SWCLK",
@@ -3480,10 +2512,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_85",
-    "connected_source_port_ids": [
-      "source_port_114",
-      "source_port_68"
-    ],
+    "connected_source_port_ids": ["source_port_114", "source_port_68"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "J1.pin4 to U2.NRST",
@@ -3492,12 +2521,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_86",
-    "connected_source_port_ids": [
-      "source_port_115"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_115"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "J1.pin5 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -3505,12 +2530,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_87",
-    "connected_source_port_ids": [
-      "source_port_116"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_116"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "CN1.VBUS to net.VBUS",
     "min_trace_thickness": 1,
@@ -3519,12 +2540,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_88",
-    "connected_source_port_ids": [
-      "source_port_117"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_117"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_4",
     "display_name": "CN1.GND to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
@@ -3781,21 +2798,11 @@
         "direction": "top-to-bottom"
       },
       "right_side": {
-        "pins": [
-          "CC2_B",
-          "VBUS",
-          "VDD_A",
-          "VDD_B",
-          "INT_N",
-          "SCL",
-          "SDA"
-        ],
+        "pins": ["CC2_B", "VBUS", "VDD_A", "VDD_B", "INT_N", "SCL", "SDA"],
         "direction": "top-to-bottom"
       },
       "bottom_side": {
-        "pins": [
-          "EP"
-        ],
+        "pins": ["EP"],
         "direction": "left-to-right"
       }
     },
@@ -3945,19 +2952,11 @@
     },
     "port_arrangement": {
       "left_side": {
-        "pins": [
-          "VIN",
-          "EN",
-          "FB"
-        ],
+        "pins": ["VIN", "EN", "FB"],
         "direction": "top-to-bottom"
       },
       "right_side": {
-        "pins": [
-          "BST",
-          "SW",
-          "GND"
-        ],
+        "pins": ["BST", "SW", "GND"],
         "direction": "top-to-bottom"
       }
     },
@@ -4397,24 +3396,15 @@
     },
     "port_arrangement": {
       "left_side": {
-        "pins": [
-          "BLUE_K",
-          "GREEN_K"
-        ],
+        "pins": ["BLUE_K", "GREEN_K"],
         "direction": "top-to-bottom"
       },
       "right_side": {
-        "pins": [
-          "RED_K"
-        ],
+        "pins": ["RED_K"],
         "direction": "top-to-bottom"
       },
       "bottom_side": {
-        "pins": [
-          "ANODE_G",
-          "ANODE_R",
-          "ANODE_B"
-        ],
+        "pins": ["ANODE_G", "ANODE_R", "ANODE_B"],
         "direction": "left-to-right"
       }
     },
@@ -4539,13 +3529,7 @@
     "port_arrangement": {
       "right_side": {
         "direction": "top-to-bottom",
-        "pins": [
-          "pin1",
-          "pin2",
-          "pin3",
-          "pin4",
-          "pin5"
-        ]
+        "pins": ["pin1", "pin2", "pin3", "pin4", "pin5"]
       }
     },
     "pin_spacing": 0.2,
@@ -4601,10 +3585,7 @@
     },
     "port_arrangement": {
       "left_side": {
-        "pins": [
-          "VBUS",
-          "GND"
-        ],
+        "pins": ["VBUS", "GND"],
         "direction": "top-to-bottom"
       }
     },
@@ -10117,16 +9098,10 @@
     "hole_width": 0.7999984,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole1",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole1", "pin2"],
     "x": -40.2741308,
     "y": -4.325111999999999,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
@@ -10166,16 +9141,10 @@
     "hole_width": 0.7999984,
     "hole_height": 1.5999968,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole2",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole2", "pin1"],
     "x": -36.0943068,
     "y": -4.325112,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
@@ -10215,16 +9184,10 @@
     "hole_width": 0.7999984,
     "hole_height": 1.5999968,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole3",
-      "pin4"
-    ],
+    "port_hints": ["unnamed_platedhole3", "pin4"],
     "x": -36.0943068,
     "y": 4.325112,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
@@ -10264,16 +9227,10 @@
     "hole_width": 0.7999984,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole4",
-      "pin3"
-    ],
+    "port_hints": ["unnamed_platedhole4", "pin3"],
     "x": -40.2741308,
     "y": 4.325112000000001,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
@@ -10312,9 +9269,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": 1.7500599999999995,
@@ -10344,9 +9299,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": 1.2499339999999997,
@@ -10376,9 +9329,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": 0.7500619999999996,
@@ -10408,9 +9359,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": 0.2499359999999996,
@@ -10440,9 +9389,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": -0.24993600000000038,
@@ -10472,9 +9419,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin10"
-    ],
+    "port_hints": ["pin10"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": -0.7500620000000005,
@@ -10504,9 +9449,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": -1.2496800000000003,
@@ -10536,9 +9479,7 @@
     "shape": "rect",
     "width": 1.2999974,
     "height": 0.2999994,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": -35.3259568,
     "y": -1.7500600000000004,
@@ -10568,9 +9509,7 @@
     "shape": "rect",
     "width": 1.3,
     "height": 0.6,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": -35.3250445,
     "y": 3.1999555999999996,
@@ -10600,9 +9539,7 @@
     "shape": "rect",
     "width": 1.3,
     "height": 0.6,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": -35.325044500000004,
     "y": -3.2000063000000005,
@@ -10632,9 +9569,7 @@
     "shape": "rect",
     "width": 1.3,
     "height": 0.6,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": -35.325044500000004,
     "y": -2.4001603000000005,
@@ -10664,9 +9599,7 @@
     "shape": "rect",
     "width": 1.3,
     "height": 0.6,
-    "port_hints": [
-      "pin16"
-    ],
+    "port_hints": ["pin16"],
     "is_covered_with_solder_mask": false,
     "x": -35.3250445,
     "y": 2.3999570999999995,
@@ -10823,10 +9756,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -26.01,
     "y": -4.5,
@@ -10856,10 +9786,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -24.99,
     "y": -4.5,
@@ -10947,10 +9874,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -26.01,
     "y": 4.5,
@@ -10980,10 +9904,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -24.99,
     "y": 4.5,
@@ -11071,9 +9992,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 0.7999984,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -24.295024,
     "y": -8,
@@ -11103,9 +10022,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 0.7999984,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -26.704976,
     "y": -8,
@@ -11309,9 +10226,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 0.7999984,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -26.704976,
     "y": 8,
@@ -11341,9 +10256,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 0.7999984,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -24.295024,
     "y": 8,
@@ -11547,10 +10460,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.01,
     "y": -8,
@@ -11580,10 +10490,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -18.99,
     "y": -8,
@@ -11671,10 +10578,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.01,
     "y": 8,
@@ -11704,10 +10608,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -18.99,
     "y": 8,
@@ -11795,9 +10696,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -9.999872,
     "y": -1.177544,
@@ -11827,9 +10726,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -9.5,
     "y": -1.177544,
@@ -11859,9 +10756,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -8.999874,
     "y": -1.177544,
@@ -11891,9 +10786,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": -8.322456,
     "y": -0.750062,
@@ -11923,9 +10816,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": -8.322456,
     "y": -0.249936,
@@ -11955,9 +10846,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": -8.322456,
     "y": 0.249936,
@@ -11987,9 +10876,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "x": -8.322456,
     "y": 0.750062,
@@ -12019,9 +10906,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "x": -8.999874,
     "y": 1.177544,
@@ -12051,9 +10936,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": -9.5,
     "y": 1.177544,
@@ -12083,9 +10966,7 @@
     "shape": "rect",
     "width": 0.2800096,
     "height": 0.5050028,
-    "port_hints": [
-      "pin10"
-    ],
+    "port_hints": ["pin10"],
     "is_covered_with_solder_mask": false,
     "x": -9.999872,
     "y": 1.177544,
@@ -12115,9 +10996,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": -10.677544,
     "y": 0.750062,
@@ -12147,9 +11026,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": -10.677544,
     "y": 0.249936,
@@ -12179,9 +11056,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": -10.677544,
     "y": -0.249936,
@@ -12211,9 +11086,7 @@
     "shape": "rect",
     "width": 0.5050028,
     "height": 0.2800096,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": -10.677544,
     "y": -0.750062,
@@ -12243,9 +11116,7 @@
     "shape": "rect",
     "width": 1.3750036,
     "height": 1.3750036,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": -9.5,
     "y": 0,
@@ -12414,10 +11285,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -4.01,
     "y": -4,
@@ -12447,10 +11315,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -2.99,
     "y": -4,
@@ -12538,10 +11403,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -4.325,
     "y": 4,
@@ -12571,10 +11433,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -2.675,
     "y": 4,
@@ -12662,10 +11521,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -19.825,
     "y": 6,
@@ -12695,10 +11551,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -18.175,
     "y": 6,
@@ -12786,10 +11639,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.4625,
     "y": 14,
@@ -12819,10 +11669,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -17.5375,
     "y": 14,
@@ -12910,9 +11757,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": -10.94996,
     "y": 11.199896,
@@ -12942,9 +11787,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": -10,
     "y": 11.199896,
@@ -12974,9 +11817,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": -9.05004,
     "y": 11.199896,
@@ -13006,9 +11847,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -9.05004,
     "y": 8.800104,
@@ -13038,9 +11877,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -10,
     "y": 8.800104,
@@ -13070,9 +11907,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -10.94996,
     "y": 8.800104,
@@ -13279,10 +12114,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -10.51,
     "y": 3,
@@ -13312,10 +12144,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -9.49,
     "y": 3,
@@ -13403,9 +12232,7 @@
     "shape": "rect",
     "width": 1.1999976,
     "height": 1.999996,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 1.561973,
     "y": 10,
@@ -13435,9 +12262,7 @@
     "shape": "rect",
     "width": 1.1999976,
     "height": 1.999996,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -1.561973,
     "y": 10,
@@ -13552,10 +12377,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 6.5375,
     "y": 6,
@@ -13585,10 +12407,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 9.4625,
     "y": 6,
@@ -13676,10 +12495,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 6.5375,
     "y": 14,
@@ -13709,10 +12525,7 @@
     "shape": "rect",
     "width": 1.125,
     "height": 1.75,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 9.4625,
     "y": 14,
@@ -13800,9 +12613,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": 6.67488,
     "y": -4.000883,
@@ -13832,9 +12643,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": 7.323596,
     "y": -4.000883,
@@ -13864,9 +12673,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "x": 7.974852,
     "y": -4.000883,
@@ -13896,9 +12703,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "x": 8.624838,
     "y": -4.000883,
@@ -13928,9 +12733,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": 4.725175999999999,
     "y": 1.996057,
@@ -13960,9 +12763,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 4.725175999999999,
     "y": -4.000883,
@@ -13992,9 +12793,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": 5.374908,
     "y": -4.000883,
@@ -14024,9 +12823,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": 6.025148,
     "y": -4.000883,
@@ -14056,9 +12853,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": 9.275078,
     "y": 2.001137,
@@ -14088,9 +12883,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": 8.625092,
     "y": 2.001137,
@@ -14120,9 +12913,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": 7.975106,
     "y": 2.001137,
@@ -14152,9 +12943,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": 7.32512,
     "y": 2.001137,
@@ -14184,9 +12973,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin16"
-    ],
+    "port_hints": ["pin16"],
     "is_covered_with_solder_mask": false,
     "x": 6.675134,
     "y": 2.001137,
@@ -14216,9 +13003,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": 6.025148,
     "y": 2.001137,
@@ -14248,9 +13033,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": 9.274824,
     "y": -4.000883,
@@ -14280,9 +13063,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": 5.374908,
     "y": 1.996057,
@@ -14312,9 +13093,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": 4.074936,
     "y": -4.001137,
@@ -14344,9 +13123,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin10"
-    ],
+    "port_hints": ["pin10"],
     "is_covered_with_solder_mask": false,
     "x": 9.92481,
     "y": -4.000883,
@@ -14376,9 +13153,7 @@
     "shape": "rect",
     "width": 0.350012,
     "height": 1.49352,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": 9.925063999999999,
     "y": 2.001137,
@@ -14408,9 +13183,7 @@
     "shape": "rect",
     "width": 0.450012,
     "height": 1.49352,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": 4.074936,
     "y": 2.001137,
@@ -14601,10 +13374,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -4.01,
     "y": -8.5,
@@ -14634,10 +13404,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -2.99,
     "y": -8.5,
@@ -14725,10 +13492,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -1.51,
     "y": -3.8,
@@ -14758,10 +13522,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -0.49,
     "y": -3.8,
@@ -14849,10 +13610,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -1.51,
     "y": -0.19999999999999996,
@@ -14882,10 +13640,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -0.49,
     "y": -0.19999999999999996,
@@ -14973,10 +13728,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 14.49,
     "y": 3,
@@ -15006,10 +13758,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 15.51,
     "y": 3,
@@ -15097,10 +13846,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 18.49,
     "y": -9,
@@ -15130,10 +13876,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 19.51,
     "y": -9,
@@ -15221,9 +13964,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 1.6999966,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 20.6999966,
     "y": -14,
@@ -15253,9 +13994,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 1.6999966,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": 17.3000034,
     "y": -14,
@@ -15484,10 +14223,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 25.49,
     "y": -14,
@@ -15517,10 +14253,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 26.51,
     "y": -14,
@@ -15608,9 +14341,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": 25.22758,
     "y": 11.599946,
@@ -15640,9 +14371,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": 25.22758,
     "y": 10,
@@ -15672,9 +14401,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": 25.22758,
     "y": 8.400054,
@@ -15704,9 +14431,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": 20.77242,
     "y": 8.400054,
@@ -15736,9 +14461,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 20.77242,
     "y": 10,
@@ -15768,9 +14491,7 @@
     "shape": "rect",
     "width": 2.1049996,
     "height": 0.9800082,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": 20.77242,
     "y": 11.599946,
@@ -15885,10 +14606,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 16.49,
     "y": 13,
@@ -15918,10 +14636,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 17.51,
     "y": 13,
@@ -16009,10 +14724,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 28.49,
     "y": 7,
@@ -16042,10 +14754,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 29.51,
     "y": 7,
@@ -16133,10 +14842,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 28.49,
     "y": 13,
@@ -16166,10 +14872,7 @@
     "shape": "rect",
     "width": 0.54,
     "height": 0.64,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 29.51,
     "y": 13,
@@ -16257,16 +14960,10 @@
     "rect_pad_width": 1.5,
     "rect_pad_height": 1.5,
     "shape": "circular_hole_with_rect_pad",
-    "port_hints": [
-      "unnamed_platedhole5",
-      "1"
-    ],
+    "port_hints": ["unnamed_platedhole5", "1"],
     "x": 32,
     "y": -14.08,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4",
     "hole_offset_x": 0,
@@ -16298,16 +14995,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole6",
-      "2"
-    ],
+    "port_hints": ["unnamed_platedhole6", "2"],
     "x": 32,
     "y": -11.54,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16355,16 +15046,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole7",
-      "3"
-    ],
+    "port_hints": ["unnamed_platedhole7", "3"],
     "x": 32,
     "y": -9,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16412,16 +15097,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole8",
-      "4"
-    ],
+    "port_hints": ["unnamed_platedhole8", "4"],
     "x": 32,
     "y": -6.46,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16469,16 +15148,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole9",
-      "5"
-    ],
+    "port_hints": ["unnamed_platedhole9", "5"],
     "x": 32,
     "y": -3.92,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16556,16 +15229,10 @@
     "outer_diameter": 2.999994,
     "hole_diameter": 1.700022,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole10",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole10", "pin1"],
     "x": 36,
     "y": 7.500640000000001,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16597,16 +15264,10 @@
     "outer_diameter": 2.999994,
     "hole_diameter": 1.700022,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole11",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole11", "pin2"],
     "x": 36,
     "y": 12.49936,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_4"
   },
@@ -16883,12 +15544,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_0",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -36.0943068,
@@ -16899,12 +15555,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_1",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -40.2741308,
@@ -16915,12 +15566,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_2",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -40.2741308,
@@ -16931,12 +15577,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_3",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -36.0943068,
@@ -16947,9 +15588,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_4",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -16960,9 +15599,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_5",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -16973,9 +15610,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_6",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -16986,9 +15621,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_7",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -16999,9 +15632,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_8",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -17012,9 +15643,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_9",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -17025,9 +15654,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_10",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -17038,9 +15665,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_11",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3259568,
@@ -17051,9 +15676,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_12",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3250445,
@@ -17064,9 +15687,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_13",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.325044500000004,
@@ -17077,9 +15698,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_14",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.325044500000004,
@@ -17090,9 +15709,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_15",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -35.3250445,
@@ -17103,9 +15720,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_16",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -26.01,
@@ -17116,9 +15731,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_17",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -24.99,
@@ -17129,9 +15742,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_18",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -26.01,
@@ -17142,9 +15753,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_19",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -24.99,
@@ -17155,9 +15764,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_20",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -26.704976,
@@ -17168,9 +15775,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_21",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -24.295024,
@@ -17181,9 +15786,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_22",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -24.295024,
@@ -17194,9 +15797,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_23",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -26.704976,
@@ -17207,9 +15808,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_24",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -20.01,
@@ -17220,9 +15819,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_25",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -18.99,
@@ -17233,9 +15830,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_26",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -20.01,
@@ -17246,9 +15841,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_27",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -18.99,
@@ -17259,9 +15852,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_28",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -9.999872,
@@ -17272,9 +15863,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_29",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -9.5,
@@ -17285,9 +15874,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_30",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.999874,
@@ -17298,9 +15885,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_31",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.322456,
@@ -17311,9 +15896,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_32",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.322456,
@@ -17324,9 +15907,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_33",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.322456,
@@ -17337,9 +15918,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_34",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.322456,
@@ -17350,9 +15929,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_35",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -8.999874,
@@ -17363,9 +15940,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_36",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -9.5,
@@ -17376,9 +15951,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_37",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -9.999872,
@@ -17389,9 +15962,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_38",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -10.677544,
@@ -17402,9 +15973,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_39",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -10.677544,
@@ -17415,9 +15984,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_40",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -10.677544,
@@ -17428,9 +15995,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_41",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -10.677544,
@@ -17441,9 +16006,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_42",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -9.5,
@@ -17454,9 +16017,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_43",
     "pcb_component_id": "pcb_component_8",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -4.01,
@@ -17467,9 +16028,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_44",
     "pcb_component_id": "pcb_component_8",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -2.99,
@@ -17480,9 +16039,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_45",
     "pcb_component_id": "pcb_component_9",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -4.325,
@@ -17493,9 +16050,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_46",
     "pcb_component_id": "pcb_component_9",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_0",
     "x": -2.675,
@@ -17506,9 +16061,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_47",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -19.825,
@@ -17519,9 +16072,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_48",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -18.175,
@@ -17532,9 +16083,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_49",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -20.4625,
@@ -17545,9 +16094,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_50",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -17.5375,
@@ -17558,9 +16105,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_51",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -10.94996,
@@ -17571,9 +16116,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_52",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -10,
@@ -17584,9 +16127,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_53",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -9.05004,
@@ -17597,9 +16138,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_54",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -9.05004,
@@ -17610,9 +16149,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_55",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -10,
@@ -17623,9 +16160,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_56",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -10.94996,
@@ -17636,9 +16171,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_57",
     "pcb_component_id": "pcb_component_13",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -10.51,
@@ -17649,9 +16182,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_58",
     "pcb_component_id": "pcb_component_13",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -9.49,
@@ -17662,9 +16193,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_59",
     "pcb_component_id": "pcb_component_14",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": -1.561973,
@@ -17675,9 +16204,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_60",
     "pcb_component_id": "pcb_component_14",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": 1.561973,
@@ -17688,9 +16215,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_61",
     "pcb_component_id": "pcb_component_15",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": 6.5375,
@@ -17701,9 +16226,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_62",
     "pcb_component_id": "pcb_component_15",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": 9.4625,
@@ -17714,9 +16237,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_63",
     "pcb_component_id": "pcb_component_16",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": 6.5375,
@@ -17727,9 +16248,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_64",
     "pcb_component_id": "pcb_component_16",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_1",
     "x": 9.4625,
@@ -17740,9 +16259,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_65",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 4.074936,
@@ -17753,9 +16270,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_66",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 4.725175999999999,
@@ -17766,9 +16281,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_67",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 5.374908,
@@ -17779,9 +16292,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_68",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 6.025148,
@@ -17792,9 +16303,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_69",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 6.67488,
@@ -17805,9 +16314,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_70",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 7.323596,
@@ -17818,9 +16325,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_71",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 7.974852,
@@ -17831,9 +16336,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_72",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 8.624838,
@@ -17844,9 +16347,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_73",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 9.274824,
@@ -17857,9 +16358,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_74",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 9.92481,
@@ -17870,9 +16369,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_75",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 9.925063999999999,
@@ -17883,9 +16380,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_76",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 9.275078,
@@ -17896,9 +16391,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_77",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 8.625092,
@@ -17909,9 +16402,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_78",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 7.975106,
@@ -17922,9 +16413,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_79",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 7.32512,
@@ -17935,9 +16424,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_80",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 6.675134,
@@ -17948,9 +16435,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_81",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 6.025148,
@@ -17961,9 +16446,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_82",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 5.374908,
@@ -17974,9 +16457,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_83",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 4.725175999999999,
@@ -17987,9 +16468,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_84",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 4.074936,
@@ -18000,9 +16479,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_85",
     "pcb_component_id": "pcb_component_18",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -4.01,
@@ -18013,9 +16490,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_86",
     "pcb_component_id": "pcb_component_18",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -2.99,
@@ -18026,9 +16501,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_87",
     "pcb_component_id": "pcb_component_19",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -1.51,
@@ -18039,9 +16512,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_88",
     "pcb_component_id": "pcb_component_19",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -0.49,
@@ -18052,9 +16523,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_89",
     "pcb_component_id": "pcb_component_20",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -1.51,
@@ -18065,9 +16534,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_90",
     "pcb_component_id": "pcb_component_20",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": -0.49,
@@ -18078,9 +16545,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_91",
     "pcb_component_id": "pcb_component_21",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 14.49,
@@ -18091,9 +16556,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_92",
     "pcb_component_id": "pcb_component_21",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 15.51,
@@ -18104,9 +16567,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_93",
     "pcb_component_id": "pcb_component_22",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 18.49,
@@ -18117,9 +16578,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_94",
     "pcb_component_id": "pcb_component_22",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 19.51,
@@ -18130,9 +16589,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_95",
     "pcb_component_id": "pcb_component_23",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 17.3000034,
@@ -18143,9 +16600,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_96",
     "pcb_component_id": "pcb_component_23",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 20.6999966,
@@ -18156,9 +16611,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_97",
     "pcb_component_id": "pcb_component_24",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 25.49,
@@ -18169,9 +16622,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_98",
     "pcb_component_id": "pcb_component_24",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_2",
     "x": 26.51,
@@ -18182,9 +16633,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_99",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 20.77242,
@@ -18195,9 +16644,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_100",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 20.77242,
@@ -18208,9 +16655,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_101",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 20.77242,
@@ -18221,9 +16666,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_102",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 25.22758,
@@ -18234,9 +16677,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_103",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 25.22758,
@@ -18247,9 +16688,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_104",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 25.22758,
@@ -18260,9 +16699,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_105",
     "pcb_component_id": "pcb_component_26",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 16.49,
@@ -18273,9 +16710,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_106",
     "pcb_component_id": "pcb_component_26",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 17.51,
@@ -18286,9 +16721,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_107",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 28.49,
@@ -18299,9 +16732,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_108",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 29.51,
@@ -18312,9 +16743,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_109",
     "pcb_component_id": "pcb_component_28",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 28.49,
@@ -18325,9 +16754,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_110",
     "pcb_component_id": "pcb_component_28",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_4",
     "pcb_group_id": "pcb_group_3",
     "x": 29.51,
@@ -18338,12 +16765,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_111",
     "pcb_component_id": "pcb_component_29",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 32,
     "y": -14.08,
@@ -18353,12 +16775,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_112",
     "pcb_component_id": "pcb_component_29",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 32,
     "y": -11.54,
@@ -18368,12 +16785,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_113",
     "pcb_component_id": "pcb_component_29",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 32,
     "y": -9,
@@ -18383,12 +16795,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_114",
     "pcb_component_id": "pcb_component_29",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 32,
     "y": -6.46,
@@ -18398,12 +16805,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_115",
     "pcb_component_id": "pcb_component_29",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 32,
     "y": -3.92,
@@ -18413,12 +16815,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_116",
     "pcb_component_id": "pcb_component_30",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 36,
     "y": 7.500640000000001,
@@ -18428,12 +16825,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_117",
     "pcb_component_id": "pcb_component_30",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_4",
     "x": 36,
     "y": 12.49936,
@@ -26018,10 +24410,7 @@
     "y": -8.349,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26033,10 +24422,7 @@
     "y": -2.91,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26048,10 +24434,7 @@
     "y": -8.475,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26063,10 +24446,7 @@
     "y": -5,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "bottom"
-    ],
+    "layers": ["inner1", "bottom"],
     "from_layer": "inner1",
     "to_layer": "bottom"
   },
@@ -26078,10 +24458,7 @@
     "y": -1.853,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26093,10 +24470,7 @@
     "y": -6.134,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26108,10 +24482,7 @@
     "y": -0.364,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26123,10 +24494,7 @@
     "y": -3.149,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26138,10 +24506,7 @@
     "y": -0.048,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26153,10 +24518,7 @@
     "y": 0.853,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26168,10 +24530,7 @@
     "y": 3.6410000000000005,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26183,10 +24542,7 @@
     "y": 10.345080486683996,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26198,10 +24554,7 @@
     "y": 12.420950099999999,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26213,10 +24566,7 @@
     "y": -0.916,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26228,10 +24578,7 @@
     "y": -2.6959999999999997,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26243,10 +24590,7 @@
     "y": 7.427,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26258,10 +24602,7 @@
     "y": 3.903,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26273,10 +24614,7 @@
     "y": -11.954196052479555,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26288,10 +24626,7 @@
     "y": -9.649,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26303,10 +24638,7 @@
     "y": -8.208,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26318,10 +24650,7 @@
     "y": -7.929887770117709,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26333,10 +24662,7 @@
     "y": 7.207744801006057,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26348,10 +24674,7 @@
     "y": -7.199,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26363,10 +24686,7 @@
     "y": 6.195,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26378,10 +24698,7 @@
     "y": 7.757,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26393,10 +24710,7 @@
     "y": -2.299,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26408,10 +24722,7 @@
     "y": 1.9850338138800454,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26423,10 +24734,7 @@
     "y": 7.648990046275336,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26438,10 +24746,7 @@
     "y": 7.106,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26453,10 +24758,7 @@
     "y": 3.078897,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26468,10 +24770,7 @@
     "y": -5.079017327296704,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26483,10 +24782,7 @@
     "y": -4.988,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26498,10 +24794,7 @@
     "y": 0.952,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26513,10 +24806,7 @@
     "y": 9.494,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26528,10 +24818,7 @@
     "y": 9.823,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26543,10 +24830,7 @@
     "y": 10.416138826401884,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26558,10 +24842,7 @@
     "y": 9.07544674241174,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26573,10 +24854,7 @@
     "y": -6.198,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26588,10 +24866,7 @@
     "y": -8.19,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26603,10 +24878,7 @@
     "y": -9.978,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26618,10 +24890,7 @@
     "y": -12.35,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26633,10 +24902,7 @@
     "y": -11.690311305979039,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26648,10 +24914,7 @@
     "y": -9.649,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26663,10 +24926,7 @@
     "y": -4.475123543021038,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26678,10 +24938,7 @@
     "y": 1.427402839514281,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26693,10 +24950,7 @@
     "y": 5.706,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26708,10 +24962,7 @@
     "y": 4.756,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26723,10 +24974,7 @@
     "y": 1.9089331305096033,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26738,10 +24986,7 @@
     "y": -0.577,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26753,10 +24998,7 @@
     "y": 6.671999984308259,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26768,10 +25010,7 @@
     "y": 6.611,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26783,10 +25022,7 @@
     "y": 5.167,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26798,10 +25034,7 @@
     "y": 9.199,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26813,10 +25046,7 @@
     "y": 8.751,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26828,10 +25058,7 @@
     "y": -1.011,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26843,10 +25070,7 @@
     "y": 2.1809817415745587,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26858,10 +25082,7 @@
     "y": -6.088,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26873,10 +25094,7 @@
     "y": -5.073,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "inner2"
-    ],
+    "layers": ["inner1", "inner2"],
     "from_layer": "inner1",
     "to_layer": "inner2"
   },
@@ -26888,10 +25106,7 @@
     "y": -2.088,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26903,10 +25118,7 @@
     "y": 12.078,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -26918,10 +25130,7 @@
     "y": 8.607,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -26933,10 +25142,7 @@
     "y": 7.299,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -26948,10 +25154,7 @@
     "y": 4.625,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -26963,10 +25166,7 @@
     "y": 6.4,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -26978,10 +25178,7 @@
     "y": 6.343955717895305,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -26993,10 +25190,7 @@
     "y": -1.542,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner2"
-    ],
+    "layers": ["top", "inner2"],
     "from_layer": "top",
     "to_layer": "inner2"
   },
@@ -27008,10 +25202,7 @@
     "y": -2.109,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner2",
-      "top"
-    ],
+    "layers": ["inner2", "top"],
     "from_layer": "inner2",
     "to_layer": "top"
   },
@@ -27023,10 +25214,7 @@
     "y": -1.707,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -27038,10 +25226,7 @@
     "y": 7.295706765706981,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -27053,10 +25238,7 @@
     "y": 7.982646296237678,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -27068,10 +25250,7 @@
     "y": 1.6290668694903965,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -27083,10 +25262,7 @@
     "y": 6.367,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -27098,10 +25274,7 @@
     "y": 2.9099999999999997,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -27113,10 +25286,7 @@
     "y": 0.962,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -27128,10 +25298,7 @@
     "y": -3.68,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "top",
-      "inner1"
-    ],
+    "layers": ["top", "inner1"],
     "from_layer": "top",
     "to_layer": "inner1"
   },
@@ -27143,10 +25310,7 @@
     "y": -1.603,
     "hole_diameter": 0.3,
     "outer_diameter": 0.45,
-    "layers": [
-      "inner1",
-      "top"
-    ],
+    "layers": ["inner1", "top"],
     "from_layer": "inner1",
     "to_layer": "top"
   },
@@ -27156,10 +25320,7 @@
     "warning_type": "source_no_power_pin_defined_warning",
     "message": "L1 has no pin with requires_power=true",
     "source_component_id": "source_component_14",
-    "source_port_ids": [
-      "source_port_59",
-      "source_port_60"
-    ],
+    "source_port_ids": ["source_port_59", "source_port_60"],
     "subcircuit_id": "subcircuit_source_group_4"
   },
   {
@@ -27168,10 +25329,7 @@
     "warning_type": "source_no_ground_pin_defined_warning",
     "message": "L1 has no pin with requires_ground=true",
     "source_component_id": "source_component_14",
-    "source_port_ids": [
-      "source_port_59",
-      "source_port_60"
-    ],
+    "source_port_ids": ["source_port_59", "source_port_60"],
     "subcircuit_id": "subcircuit_source_group_4"
   },
   {

--- a/tests/assets/diy-power-delivery-trigger.circuit.json
+++ b/tests/assets/diy-power-delivery-trigger.circuit.json
@@ -1,0 +1,34820 @@
+[
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "was_automatically_named": true,
+    "parent_source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_1",
+    "was_automatically_named": true,
+    "parent_source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_2",
+    "was_automatically_named": true,
+    "parent_source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_3",
+    "was_automatically_named": true,
+    "parent_source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_4",
+    "is_subcircuit": true,
+    "was_automatically_named": true,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "SHIELD_A",
+    "pin_number": 1,
+    "port_hints": [
+      "SHIELD_A",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "SHIELD_B",
+    "pin_number": 2,
+    "port_hints": [
+      "SHIELD_B",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "SHIELD_C",
+    "pin_number": 3,
+    "port_hints": [
+      "SHIELD_C",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "SHIELD_D",
+    "pin_number": 4,
+    "port_hints": [
+      "SHIELD_D",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "SBU2",
+    "pin_number": 5,
+    "port_hints": [
+      "SBU2",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "CC1",
+    "pin_number": 6,
+    "port_hints": [
+      "CC1",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "D_N2",
+    "pin_number": 7,
+    "port_hints": [
+      "D_N2",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "D_P1",
+    "pin_number": 8,
+    "port_hints": [
+      "D_P1",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "D_N1",
+    "pin_number": 9,
+    "port_hints": [
+      "D_N1",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "D_P2",
+    "pin_number": 10,
+    "port_hints": [
+      "D_P2",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "SBU1",
+    "pin_number": 11,
+    "port_hints": [
+      "SBU1",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "CC2",
+    "pin_number": 12,
+    "port_hints": [
+      "CC2",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "GND_A",
+    "pin_number": 13,
+    "port_hints": [
+      "GND_A",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "GND_B",
+    "pin_number": 14,
+    "port_hints": [
+      "GND_B",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "VBUS_A",
+    "pin_number": 15,
+    "port_hints": [
+      "VBUS_A",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "VBUS_B",
+    "pin_number": 16,
+    "port_hints": [
+      "VBUS_B",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "USB2",
+    "manufacturer_part_number": "TYPE_C_31_M_12",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C165948"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_resistor",
+    "name": "R1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25076",
+        "C106232",
+        "C2906860"
+      ]
+    },
+    "resistance": 100,
+    "display_resistance": "100Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_resistor",
+    "name": "R2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25076",
+        "C106232",
+        "C2906860"
+      ]
+    },
+    "resistance": 100,
+    "display_resistance": "100Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_chip",
+    "name": "D1",
+    "manufacturer_part_number": "PESD5V0S1BA",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C5261083"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "ftype": "simple_chip",
+    "name": "D2",
+    "manufacturer_part_number": "PESD5V0S1BA",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C5261083"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_capacitor",
+    "name": "C9",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1530",
+        "C71693",
+        "C107001"
+      ]
+    },
+    "capacitance": 2.2e-10,
+    "display_capacitance": "220pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_capacitor",
+    "name": "C10",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1530",
+        "C71693",
+        "C107001"
+      ]
+    },
+    "capacitance": 2.2e-10,
+    "display_capacitance": "220pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "CC2_B",
+    "pin_number": 1,
+    "port_hints": [
+      "CC2_B",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "VBUS",
+    "pin_number": 2,
+    "port_hints": [
+      "VBUS",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "VDD_A",
+    "pin_number": 3,
+    "port_hints": [
+      "VDD_A",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "VDD_B",
+    "pin_number": 4,
+    "port_hints": [
+      "VDD_B",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "INT_N",
+    "pin_number": 5,
+    "port_hints": [
+      "INT_N",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "SCL",
+    "pin_number": 6,
+    "port_hints": [
+      "SCL",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "SDA",
+    "pin_number": 7,
+    "port_hints": [
+      "SDA",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "GND_A",
+    "pin_number": 8,
+    "port_hints": [
+      "GND_A",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "GND_B",
+    "pin_number": 9,
+    "port_hints": [
+      "GND_B",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "CC1_B",
+    "pin_number": 10,
+    "port_hints": [
+      "CC1_B",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "CC1_A",
+    "pin_number": 11,
+    "port_hints": [
+      "CC1_A",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "VCONN_B",
+    "pin_number": 12,
+    "port_hints": [
+      "VCONN_B",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "VCONN_A",
+    "pin_number": 13,
+    "port_hints": [
+      "VCONN_A",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "CC2_A",
+    "pin_number": 14,
+    "port_hints": [
+      "CC2_A",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "EP",
+    "pin_number": 15,
+    "port_hints": [
+      "EP",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "ftype": "simple_chip",
+    "name": "U1",
+    "manufacturer_part_number": "FUSB302BMPX",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C132291"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_8",
+    "ftype": "simple_capacitor",
+    "name": "C7",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1525",
+        "C307331",
+        "C60474"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_9",
+    "ftype": "simple_capacitor",
+    "name": "C8",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C15849",
+        "C6119852",
+        "C29936"
+      ]
+    },
+    "capacitance": 0.000001,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_10",
+    "ftype": "simple_capacitor",
+    "name": "C2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C14663",
+        "C1591",
+        "C282519"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_11",
+    "ftype": "simple_capacitor",
+    "name": "C4",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C13585",
+        "C7432781",
+        "C89632"
+      ]
+    },
+    "capacitance": 0.00001,
+    "display_capacitance": "10uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "FB",
+    "pin_number": 1,
+    "port_hints": [
+      "FB",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "EN",
+    "pin_number": 2,
+    "port_hints": [
+      "EN",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "VIN",
+    "pin_number": 3,
+    "port_hints": [
+      "VIN",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "GND",
+    "pin_number": 4,
+    "port_hints": [
+      "GND",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "SW",
+    "pin_number": 5,
+    "port_hints": [
+      "SW",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "BST",
+    "pin_number": 6,
+    "port_hints": [
+      "BST",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net11"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_12",
+    "ftype": "simple_chip",
+    "name": "U3",
+    "manufacturer_part_number": "AP63203WU_7",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C780769"
+      ]
+    },
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_13",
+    "ftype": "simple_capacitor",
+    "name": "C11",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1525",
+        "C307331",
+        "C60474"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_14",
+    "ftype": "simple_chip",
+    "name": "L1",
+    "manufacturer_part_number": "NLV32T_6R8J_PF",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C89023"
+      ]
+    },
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_15",
+    "ftype": "simple_capacitor",
+    "name": "C5",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C12891",
+        "C90146",
+        "C5177178"
+      ]
+    },
+    "capacitance": 0.000022,
+    "display_capacitance": "22uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_16",
+    "ftype": "simple_capacitor",
+    "name": "C3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C12891",
+        "C90146",
+        "C5177178"
+      ]
+    },
+    "capacitance": 0.000022,
+    "display_capacitance": "22uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "BOOT0",
+    "pin_number": 1,
+    "port_hints": [
+      "BOOT0",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "PF0_OSC_IN",
+    "pin_number": 2,
+    "port_hints": [
+      "PF0_OSC_IN",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "PF1_OSC_OUT",
+    "pin_number": 3,
+    "port_hints": [
+      "PF1_OSC_OUT",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "NRST",
+    "pin_number": 4,
+    "port_hints": [
+      "NRST",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "VDDA",
+    "pin_number": 5,
+    "port_hints": [
+      "VDDA",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "PA0",
+    "pin_number": 6,
+    "port_hints": [
+      "PA0",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "PA1",
+    "pin_number": 7,
+    "port_hints": [
+      "PA1",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "PA2_TX",
+    "pin_number": 8,
+    "port_hints": [
+      "PA2_TX",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "PA3_RX",
+    "pin_number": 9,
+    "port_hints": [
+      "PA3_RX",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "PA4",
+    "pin_number": 10,
+    "port_hints": [
+      "PA4",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "PA5_LED_R",
+    "pin_number": 11,
+    "port_hints": [
+      "PA5_LED_R",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "PA6_LED_G",
+    "pin_number": 12,
+    "port_hints": [
+      "PA6_LED_G",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "PA7_LED_B",
+    "pin_number": 13,
+    "port_hints": [
+      "PA7_LED_B",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "PB1_INT",
+    "pin_number": 14,
+    "port_hints": [
+      "PB1_INT",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "VSS",
+    "pin_number": 15,
+    "port_hints": [
+      "VSS",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "VDD",
+    "pin_number": 16,
+    "port_hints": [
+      "VDD",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "PA9_SCL",
+    "pin_number": 17,
+    "port_hints": [
+      "PA9_SCL",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "PA10_SDA",
+    "pin_number": 18,
+    "port_hints": [
+      "PA10_SDA",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "PA13_SWDIO",
+    "pin_number": 19,
+    "port_hints": [
+      "PA13_SWDIO",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "PA14_SWCLK",
+    "pin_number": 20,
+    "port_hints": [
+      "PA14_SWCLK",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net21"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_17",
+    "ftype": "simple_chip",
+    "name": "U2",
+    "manufacturer_part_number": "STM32F030F4P6TR",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C89040"
+      ]
+    },
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_18",
+    "ftype": "simple_resistor",
+    "name": "R3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25879",
+        "C114762",
+        "C2906920"
+      ]
+    },
+    "resistance": 2200,
+    "display_resistance": "2.2kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_19",
+    "ftype": "simple_resistor",
+    "name": "R4",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25879",
+        "C114762",
+        "C2906920"
+      ]
+    },
+    "resistance": 2200,
+    "display_resistance": "2.2kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_20",
+    "ftype": "simple_resistor",
+    "name": "R8",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25900",
+        "C105871",
+        "C2906869"
+      ]
+    },
+    "resistance": 4700,
+    "display_resistance": "4.7kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_21",
+    "ftype": "simple_capacitor",
+    "name": "C1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1525",
+        "C307331",
+        "C60474"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_94",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_22",
+    "ftype": "simple_resistor",
+    "name": "R9",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25744",
+        "C60490",
+        "C25531"
+      ]
+    },
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_95",
+    "name": "A",
+    "pin_number": 1,
+    "port_hints": [
+      "A",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_96",
+    "name": "B",
+    "pin_number": 2,
+    "port_hints": [
+      "B",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_23",
+    "ftype": "simple_chip",
+    "name": "SW1",
+    "manufacturer_part_number": "B3U_1000P",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C231329"
+      ]
+    },
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_97",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_98",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_24",
+    "ftype": "simple_capacitor",
+    "name": "C6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1525",
+        "C307331",
+        "C60474"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_99",
+    "name": "BLUE_K",
+    "pin_number": 1,
+    "port_hints": [
+      "BLUE_K",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_100",
+    "name": "RED_K",
+    "pin_number": 2,
+    "port_hints": [
+      "RED_K",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_101",
+    "name": "GREEN_K",
+    "pin_number": 3,
+    "port_hints": [
+      "GREEN_K",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_102",
+    "name": "ANODE_G",
+    "pin_number": 4,
+    "port_hints": [
+      "ANODE_G",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_103",
+    "name": "ANODE_R",
+    "pin_number": 5,
+    "port_hints": [
+      "ANODE_R",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_104",
+    "name": "ANODE_B",
+    "pin_number": 6,
+    "port_hints": [
+      "ANODE_B",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_25",
+    "ftype": "simple_chip",
+    "name": "LED1",
+    "manufacturer_part_number": "XL_5050RGBC",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2843868"
+      ]
+    },
+    "source_group_id": "source_group_3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_105",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_106",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net15"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_26",
+    "ftype": "simple_resistor",
+    "name": "R7",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25879",
+        "C114762",
+        "C2906920"
+      ]
+    },
+    "resistance": 2200,
+    "display_resistance": "2.2kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_107",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_108",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net17"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_27",
+    "ftype": "simple_resistor",
+    "name": "R6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25908",
+        "C163457",
+        "C2909364"
+      ]
+    },
+    "resistance": 5600,
+    "display_resistance": "5.6kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_109",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_28",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_110",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_28",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net19"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_28",
+    "ftype": "simple_resistor",
+    "name": "R5",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25879",
+        "C114762",
+        "C2906920"
+      ]
+    },
+    "resistance": 2200,
+    "display_resistance": "2.2kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_111",
+    "name": "3V3",
+    "pin_number": 1,
+    "port_hints": [
+      "3V3",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_112",
+    "name": "SWDIO",
+    "pin_number": 2,
+    "port_hints": [
+      "SWDIO",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_113",
+    "name": "SWCLK",
+    "pin_number": 3,
+    "port_hints": [
+      "SWCLK",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_114",
+    "name": "NRST",
+    "pin_number": 4,
+    "port_hints": [
+      "NRST",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_115",
+    "name": "GND",
+    "pin_number": 5,
+    "port_hints": [
+      "GND",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_29",
+    "ftype": "simple_pin_header",
+    "name": "J1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C50950",
+        "C7499358",
+        "C541852"
+      ]
+    },
+    "pin_count": 5,
+    "gender": "female",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_116",
+    "name": "VBUS",
+    "pin_number": 1,
+    "port_hints": [
+      "VBUS",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_30",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_117",
+    "name": "GND",
+    "pin_number": 2,
+    "port_hints": [
+      "GND",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_30",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "requires_power": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_30",
+    "ftype": "simple_chip",
+    "name": "CN1",
+    "manufacturer_part_number": "WJ2EDGVC_5_08_02P_14_00A",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C8445"
+      ]
+    },
+    "source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_0",
+    "name": "VBUS",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_1",
+    "name": "GND",
+    "member_source_group_ids": [],
+    "is_ground": true,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_2",
+    "name": "V3_3",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_3",
+    "name": "INT",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_4",
+    "name": "SCL",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_5",
+    "name": "SDA",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_6",
+    "name": "BTN",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_board",
+    "source_board_id": "source_board_0",
+    "source_group_id": "source_group_4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": [
+      "source_port_14"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.VBUS_A to net.VBUS",
+    "min_trace_thickness": 0.9,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": [
+      "source_port_15"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.VBUS_B to net.VBUS",
+    "min_trace_thickness": 0.9,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": [
+      "source_port_12"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.GND_A to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": [
+      "source_port_13"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.GND_B to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": [
+      "source_port_0"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.SHIELD_A to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": [
+      "source_port_1"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.SHIELD_B to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": [
+      "source_port_2"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.SHIELD_C to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": [
+      "source_port_3"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.SHIELD_D to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": [
+      "source_port_11",
+      "source_port_16"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.CC2 to R1.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": [
+      "source_port_5",
+      "source_port_18"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "USB2.CC1 to R2.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": [
+      "source_port_17",
+      "source_port_41"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R1.pin2 to U1.CC2_A",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": [
+      "source_port_17",
+      "source_port_28"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R1.pin2 to U1.CC2_B",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": [
+      "source_port_17",
+      "source_port_24"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "R1.pin2 to C9.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": [
+      "source_port_25"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C9.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": [
+      "source_port_19",
+      "source_port_38"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R2.pin2 to U1.CC1_A",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": [
+      "source_port_19",
+      "source_port_37"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R2.pin2 to U1.CC1_B",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": [
+      "source_port_19",
+      "source_port_26"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "R2.pin2 to C10.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": [
+      "source_port_27"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C10.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": [
+      "source_port_17",
+      "source_port_20"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R1.pin2 to D1.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": [
+      "source_port_21"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "D1.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": [
+      "source_port_19",
+      "source_port_22"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R2.pin2 to D2.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": [
+      "source_port_23"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "D2.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": [
+      "source_port_29"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.VBUS to net.VBUS",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_23",
+    "connected_source_port_ids": [
+      "source_port_30"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.VDD_A to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_24",
+    "connected_source_port_ids": [
+      "source_port_31"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.VDD_B to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_25",
+    "connected_source_port_ids": [
+      "source_port_43"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C7.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_26",
+    "connected_source_port_ids": [
+      "source_port_44"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C7.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_27",
+    "connected_source_port_ids": [
+      "source_port_45"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C8.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_28",
+    "connected_source_port_ids": [
+      "source_port_46"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C8.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_29",
+    "connected_source_port_ids": [
+      "source_port_35"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.GND_A to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_30",
+    "connected_source_port_ids": [
+      "source_port_36"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.GND_B to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_31",
+    "connected_source_port_ids": [
+      "source_port_42"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.EP to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_32",
+    "connected_source_port_ids": [
+      "source_port_32"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.INT_N to net.INT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_33",
+    "connected_source_port_ids": [
+      "source_port_33"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.SCL to net.SCL",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_34",
+    "connected_source_port_ids": [
+      "source_port_34"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U1.SDA to net.SDA",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_35",
+    "connected_source_port_ids": [
+      "source_port_47"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C2.pin1 to net.VBUS",
+    "min_trace_thickness": 0.8,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_36",
+    "connected_source_port_ids": [
+      "source_port_48"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C2.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_37",
+    "connected_source_port_ids": [
+      "source_port_49"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C4.pin1 to net.VBUS",
+    "min_trace_thickness": 0.8,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_38",
+    "connected_source_port_ids": [
+      "source_port_50"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C4.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_39",
+    "connected_source_port_ids": [
+      "source_port_53"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U3.VIN to net.VBUS",
+    "min_trace_thickness": 0.8,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_40",
+    "connected_source_port_ids": [
+      "source_port_52"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U3.EN to net.VBUS",
+    "min_trace_thickness": 0.35,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_41",
+    "connected_source_port_ids": [
+      "source_port_54"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U3.GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_42",
+    "connected_source_port_ids": [
+      "source_port_55",
+      "source_port_59"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U3.SW to L1.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_43",
+    "connected_source_port_ids": [
+      "source_port_60"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "L1.pin2 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_44",
+    "connected_source_port_ids": [
+      "source_port_51"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U3.FB to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_45",
+    "connected_source_port_ids": [
+      "source_port_56",
+      "source_port_57"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "U3.BST to C11.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net11"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_46",
+    "connected_source_port_ids": [
+      "source_port_58",
+      "source_port_55"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C11.pin2 to U3.SW",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net10"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_47",
+    "connected_source_port_ids": [
+      "source_port_61"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C5.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_48",
+    "connected_source_port_ids": [
+      "source_port_62"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C5.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_49",
+    "connected_source_port_ids": [
+      "source_port_63"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C3.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_50",
+    "connected_source_port_ids": [
+      "source_port_64"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C3.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_51",
+    "connected_source_port_ids": [
+      "source_port_80"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.VDD to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_52",
+    "connected_source_port_ids": [
+      "source_port_69"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.VDDA to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_53",
+    "connected_source_port_ids": [
+      "source_port_79"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.VSS to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_54",
+    "connected_source_port_ids": [
+      "source_port_65"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.BOOT0 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_55",
+    "connected_source_port_ids": [
+      "source_port_68",
+      "source_port_91"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "U2.NRST to C1.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_56",
+    "connected_source_port_ids": [
+      "source_port_92"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C1.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_57",
+    "connected_source_port_ids": [
+      "source_port_81"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PA9_SCL to net.SCL",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_58",
+    "connected_source_port_ids": [
+      "source_port_82"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PA10_SDA to net.SDA",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_59",
+    "connected_source_port_ids": [
+      "source_port_78"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PB1_INT to net.INT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_60",
+    "connected_source_port_ids": [
+      "source_port_67"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PF1_OSC_OUT to net.BTN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_61",
+    "connected_source_port_ids": [
+      "source_port_85"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R3.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_62",
+    "connected_source_port_ids": [
+      "source_port_86"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R3.pin2 to net.SDA",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net9"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_63",
+    "connected_source_port_ids": [
+      "source_port_87"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R4.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_64",
+    "connected_source_port_ids": [
+      "source_port_88"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R4.pin2 to net.SCL",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_65",
+    "connected_source_port_ids": [
+      "source_port_89"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R8.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_66",
+    "connected_source_port_ids": [
+      "source_port_90"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R8.pin2 to net.INT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_67",
+    "connected_source_port_ids": [
+      "source_port_93"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R9.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_68",
+    "connected_source_port_ids": [
+      "source_port_94"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R9.pin2 to net.BTN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_69",
+    "connected_source_port_ids": [
+      "source_port_95"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "SW1.A to net.BTN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_70",
+    "connected_source_port_ids": [
+      "source_port_96"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "SW1.B to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_71",
+    "connected_source_port_ids": [
+      "source_port_97"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C6.pin1 to net.BTN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_72",
+    "connected_source_port_ids": [
+      "source_port_98"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "max_length": null,
+    "display_name": "C6.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_73",
+    "connected_source_port_ids": [
+      "source_port_102"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "LED1.ANODE_G to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_74",
+    "connected_source_port_ids": [
+      "source_port_103"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "LED1.ANODE_R to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_75",
+    "connected_source_port_ids": [
+      "source_port_104"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "LED1.ANODE_B to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_76",
+    "connected_source_port_ids": [
+      "source_port_77",
+      "source_port_105"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PA7_LED_B to R7.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net14"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_77",
+    "connected_source_port_ids": [
+      "source_port_106",
+      "source_port_99"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R7.pin2 to LED1.BLUE_K",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net15"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_78",
+    "connected_source_port_ids": [
+      "source_port_76",
+      "source_port_107"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PA6_LED_G to R6.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net16"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_79",
+    "connected_source_port_ids": [
+      "source_port_108",
+      "source_port_101"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R6.pin2 to LED1.GREEN_K",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net17"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_80",
+    "connected_source_port_ids": [
+      "source_port_75",
+      "source_port_109"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "U2.PA5_LED_R to R5.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net18"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_81",
+    "connected_source_port_ids": [
+      "source_port_110",
+      "source_port_100"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "R5.pin2 to LED1.RED_K",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net19"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_82",
+    "connected_source_port_ids": [
+      "source_port_111"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "J1.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_83",
+    "connected_source_port_ids": [
+      "source_port_112",
+      "source_port_83"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "J1.pin2 to U2.PA13_SWDIO",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net20"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_84",
+    "connected_source_port_ids": [
+      "source_port_113",
+      "source_port_84"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "J1.pin3 to U2.PA14_SWCLK",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net21"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_85",
+    "connected_source_port_ids": [
+      "source_port_114",
+      "source_port_68"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "J1.pin4 to U2.NRST",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_86",
+    "connected_source_port_ids": [
+      "source_port_115"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "J1.pin5 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_87",
+    "connected_source_port_ids": [
+      "source_port_116"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "CN1.VBUS to net.VBUS",
+    "min_trace_thickness": 1,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_88",
+    "connected_source_port_ids": [
+      "source_port_117"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "display_name": "CN1.GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -2
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.9000000000000001,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "SHIELD_A",
+      "pin2": "SHIELD_B",
+      "pin3": "SHIELD_C",
+      "pin4": "SHIELD_D",
+      "pin5": "SBU2",
+      "pin6": "CC1",
+      "pin7": "D_N2",
+      "pin8": "D_P1",
+      "pin9": "D_N1",
+      "pin10": "D_P2",
+      "pin11": "SBU1",
+      "pin12": "CC2",
+      "pin13": "GND_A",
+      "pin14": "GND_B",
+      "pin15": "VBUS_A",
+      "pin16": "VBUS_B"
+    },
+    "source_component_id": "source_component_0",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "TYPE_C_31_M_12",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -19.95,
+      "y": -3.03
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "USB2",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -19.95,
+      "y": -0.9700000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -13,
+      "y": -3.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_1",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -13,
+      "y": 2.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_2",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -10,
+      "y": -4
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.5,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2"
+    },
+    "source_component_id": "source_component_3",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "PESD5V0S1BA",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.75,
+      "y": -4.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "D1",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.75,
+      "y": -3.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -10,
+      "y": 3
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.5,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2"
+    },
+    "source_component_id": "source_component_4",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "text": "PESD5V0S1BA",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.75,
+      "y": 2.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "text": "D2",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.75,
+      "y": 3.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -4,
+      "y": -6
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_5",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "220pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": 6
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_6",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "220pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -5,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.8000000000000003,
+      "height": 1.6
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [
+          "CC2_A",
+          "VCONN_A",
+          "VCONN_B",
+          "CC1_A",
+          "CC1_B",
+          "GND_A",
+          "GND_B"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [
+          "CC2_B",
+          "VBUS",
+          "VDD_A",
+          "VDD_B",
+          "INT_N",
+          "SCL",
+          "SDA"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "bottom_side": {
+        "pins": [
+          "EP"
+        ],
+        "direction": "left-to-right"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "CC2_B",
+      "pin2": "VBUS",
+      "pin3": "VDD_A",
+      "pin4": "VDD_B",
+      "pin5": "INT_N",
+      "pin6": "SCL",
+      "pin7": "SDA",
+      "pin8": "GND_A",
+      "pin9": "GND_B",
+      "pin10": "CC1_B",
+      "pin11": "CC1_A",
+      "pin12": "VCONN_B",
+      "pin13": "VCONN_A",
+      "pin14": "CC2_A",
+      "pin15": "EP"
+    },
+    "source_component_id": "source_component_7",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "text": "FUSB302BMPX",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.9999999999999996,
+      "y": 1.15
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "text": "U1",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.9999999999999996,
+      "y": 1.35
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -1,
+      "y": -5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_8",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 1,
+      "y": -5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_9",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "subcircuit_id": null,
+    "name": "unnamed_group1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -13,
+      "y": 10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_10",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -11,
+      "y": 10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_11",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "10uF",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -6.5,
+      "y": 10.5
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.8
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [
+          "VIN",
+          "EN",
+          "FB"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [
+          "BST",
+          "SW",
+          "GND"
+        ],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "FB",
+      "pin2": "EN",
+      "pin3": "VIN",
+      "pin4": "GND",
+      "pin5": "SW",
+      "pin6": "BST"
+    },
+    "source_component_id": "source_component_12",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_8",
+    "text": "AP63203WU_7",
+    "schematic_component_id": "schematic_component_12",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.1,
+      "y": 9.969999999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_9",
+    "text": "U3",
+    "schematic_component_id": "schematic_component_12",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.1,
+      "y": 11.030000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -4,
+      "y": 14
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_13",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -1,
+      "y": 10.5
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2"
+    },
+    "source_component_id": "source_component_14",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_10",
+    "text": "NLV32T_6R8J_PF",
+    "schematic_component_id": "schematic_component_14",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -1.6,
+      "y": 10.17
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_11",
+    "text": "L1",
+    "schematic_component_id": "schematic_component_14",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -1.6,
+      "y": 10.83
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 3,
+      "y": 12
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_15",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "22uF",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 5,
+      "y": 10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_16",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "22uF",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_1",
+    "subcircuit_id": null,
+    "name": "unnamed_group2",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_1",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 7,
+      "y": -1
+    },
+    "rotation": 0,
+    "size": {
+      "width": 2.2,
+      "height": 1.7999999999999998
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [
+          "PA0",
+          "PA1",
+          "PA2_TX",
+          "PA3_RX",
+          "PA4",
+          "PA5_LED_R",
+          "PA6_LED_G",
+          "PA7_LED_B"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [
+          "PB1_INT",
+          "PF0_OSC_IN",
+          "PF1_OSC_OUT",
+          "BOOT0",
+          "NRST",
+          "VSS"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "bottom_side": {
+        "pins": [
+          "VDDA",
+          "VDD",
+          "PA9_SCL",
+          "PA10_SDA",
+          "PA13_SWDIO",
+          "PA14_SWCLK"
+        ],
+        "direction": "left-to-right"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "BOOT0",
+      "pin2": "PF0_OSC_IN",
+      "pin3": "PF1_OSC_OUT",
+      "pin4": "NRST",
+      "pin5": "VDDA",
+      "pin6": "PA0",
+      "pin7": "PA1",
+      "pin8": "PA2_TX",
+      "pin9": "PA3_RX",
+      "pin10": "PA4",
+      "pin11": "PA5_LED_R",
+      "pin12": "PA6_LED_G",
+      "pin13": "PA7_LED_B",
+      "pin14": "PB1_INT",
+      "pin15": "VSS",
+      "pin16": "VDD",
+      "pin17": "PA9_SCL",
+      "pin18": "PA10_SDA",
+      "pin19": "PA13_SWDIO",
+      "pin20": "PA14_SWCLK"
+    },
+    "source_component_id": "source_component_17",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_12",
+    "text": "STM32F030F4P6TR",
+    "schematic_component_id": "schematic_component_17",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 8.2,
+      "y": 0.2499999999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_13",
+    "text": "U2",
+    "schematic_component_id": "schematic_component_17",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 8.2,
+      "y": 0.44999999999999996
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 1,
+      "y": -8
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_18",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "2.2kΩ",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -1,
+      "y": -8
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_19",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "2.2kΩ",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 1,
+      "y": -10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_20",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "4.7kΩ",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 12,
+      "y": 5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_21",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 3,
+      "y": 12
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_22",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": 4,
+      "y": 10
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "A",
+      "pin2": "B"
+    },
+    "source_component_id": "source_component_23",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_14",
+    "text": "B3U_1000P",
+    "schematic_component_id": "schematic_component_23",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 3.4,
+      "y": 9.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_15",
+    "text": "SW1",
+    "schematic_component_id": "schematic_component_23",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 3.4,
+      "y": 10.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": 6.5,
+      "y": 10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_24",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_2",
+    "subcircuit_id": null,
+    "name": "unnamed_group3",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_2",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 13,
+      "y": 10
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.8000000000000003,
+      "height": 0.6000000000000001
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [
+          "BLUE_K",
+          "GREEN_K"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [
+          "RED_K"
+        ],
+        "direction": "top-to-bottom"
+      },
+      "bottom_side": {
+        "pins": [
+          "ANODE_G",
+          "ANODE_R",
+          "ANODE_B"
+        ],
+        "direction": "left-to-right"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "BLUE_K",
+      "pin2": "RED_K",
+      "pin3": "GREEN_K",
+      "pin4": "ANODE_G",
+      "pin5": "ANODE_R",
+      "pin6": "ANODE_B"
+    },
+    "source_component_id": "source_component_25",
+    "schematic_group_id": "schematic_group_3"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_16",
+    "text": "XL_5050RGBC",
+    "schematic_component_id": "schematic_component_25",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 14,
+      "y": 10.65
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_17",
+    "text": "LED1",
+    "schematic_component_id": "schematic_component_25",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 14,
+      "y": 10.850000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 9.5,
+      "y": 12
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_26",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "2.2kΩ",
+    "schematic_group_id": "schematic_group_3"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 18,
+      "y": 10
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_27",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "5.6kΩ",
+    "schematic_group_id": "schematic_group_3"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": 18,
+      "y": 12
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_28",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "2.2kΩ",
+    "schematic_group_id": "schematic_group_3"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_3",
+    "subcircuit_id": null,
+    "name": "unnamed_group4",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_3",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 20,
+      "y": 6
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.6,
+      "height": 1.2000000000000002
+    },
+    "port_arrangement": {
+      "right_side": {
+        "direction": "top-to-bottom",
+        "pins": [
+          "pin1",
+          "pin2",
+          "pin3",
+          "pin4",
+          "pin5"
+        ]
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "1": "3V3",
+      "2": "SWDIO",
+      "3": "SWCLK",
+      "4": "NRST",
+      "5": "GND"
+    },
+    "source_component_id": "source_component_29",
+    "schematic_group_id": "schematic_group_4"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_18",
+    "text": "",
+    "schematic_component_id": "schematic_component_29",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 19.2,
+      "y": 5.2700000000000005
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_19",
+    "text": "J1",
+    "schematic_component_id": "schematic_component_29",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 19.2,
+      "y": 6.7299999999999995
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 20,
+      "y": -6
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.5,
+      "height": 0.6000000000000001
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [
+          "VBUS",
+          "GND"
+        ],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "VBUS",
+      "pin2": "GND"
+    },
+    "source_component_id": "source_component_30",
+    "schematic_group_id": "schematic_group_4"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_20",
+    "text": "WJ2EDGVC_5_08_02P_14_00A",
+    "schematic_component_id": "schematic_component_30",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 19.25,
+      "y": -6.43
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_21",
+    "text": "CN1",
+    "schematic_component_id": "schematic_component_30",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 19.25,
+      "y": -5.57
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_4",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "name": "unnamed_board1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_4",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -1.3
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "SHIELD_A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "SHIELD_B",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -1.7000000000000002
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "SHIELD_C",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -1.9000000000000001
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SHIELD_D",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -2.1
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "SBU2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "CC1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "D_N2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -20.35,
+      "y": -2.7
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "D_P1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -2.7
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "D_N1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "D_P2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "display_pin_label": "SBU1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -2.0999999999999996
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "display_pin_label": "CC2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -1.9
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "GND_A",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -1.7
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "GND_B",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "VBUS_A",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17.65,
+      "y": -1.3
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "VBUS_B",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -13.549999999999999,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -12.45,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -13.549999999999999,
+      "y": 2.5
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -12.45,
+      "y": 2.5
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -11.15,
+      "y": -4
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -8.85,
+      "y": -4
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -11.15,
+      "y": 3
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -8.85,
+      "y": 3
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -4.55,
+      "y": -6
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -3.45,
+      "y": -6
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4.55,
+      "y": 6
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -3.45,
+      "y": 6
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": 0.6
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 14,
+    "display_pin_label": "CC2_B",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": 0.4
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 13,
+    "display_pin_label": "VBUS",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": 0.20000000000000007
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 12,
+    "display_pin_label": "VDD_A",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": 1.1102230246251565e-16
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 11,
+    "display_pin_label": "VDD_B",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": -0.19999999999999996
+    },
+    "source_port_id": "source_port_32",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 10,
+    "display_pin_label": "INT_N",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": -0.39999999999999997
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 9,
+    "display_pin_label": "SCL",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -3.6999999999999997,
+      "y": -0.6
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 8,
+    "display_pin_label": "SDA",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": -0.4
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 5,
+    "display_pin_label": "GND_A",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": -0.6
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 6,
+    "display_pin_label": "GND_B",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": -0.20000000000000007
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 4,
+    "display_pin_label": "CC1_B",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": -1.1102230246251565e-16
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 11,
+    "true_ccw_index": 3,
+    "display_pin_label": "CC1_A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": 0.19999999999999996
+    },
+    "source_port_id": "source_port_39",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 12,
+    "true_ccw_index": 2,
+    "display_pin_label": "VCONN_B",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": 0.39999999999999997
+    },
+    "source_port_id": "source_port_40",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 13,
+    "true_ccw_index": 1,
+    "display_pin_label": "VCONN_A",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -6.300000000000001,
+      "y": 0.6
+    },
+    "source_port_id": "source_port_41",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 14,
+    "true_ccw_index": 0,
+    "display_pin_label": "CC2_A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -5,
+      "y": -1.2000000000000002
+    },
+    "source_port_id": "source_port_42",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 15,
+    "true_ccw_index": 7,
+    "display_pin_label": "EP",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -1.55,
+      "y": -5
+    },
+    "source_port_id": "source_port_43",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -0.44999999999999996,
+      "y": -5
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 0.44999999999999996,
+      "y": -5
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 1.55,
+      "y": -5
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -13.55,
+      "y": 10
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -12.45,
+      "y": 10
+    },
+    "source_port_id": "source_port_48",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -11.55,
+      "y": 10
+    },
+    "source_port_id": "source_port_49",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -10.45,
+      "y": 10
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -7.5,
+      "y": 10.3
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 2,
+    "display_pin_label": "FB",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -7.5,
+      "y": 10.5
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -7.5,
+      "y": 10.7
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 0,
+    "display_pin_label": "VIN",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -5.5,
+      "y": 10.3
+    },
+    "source_port_id": "source_port_54",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "GND",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -5.5,
+      "y": 10.5
+    },
+    "source_port_id": "source_port_55",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "SW",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -5.5,
+      "y": 10.7
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "BST",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -4.55,
+      "y": 14
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -3.45,
+      "y": 14
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -2,
+      "y": 10.5
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 0,
+      "y": 10.5
+    },
+    "source_port_id": "source_port_60",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 2.45,
+      "y": 12
+    },
+    "source_port_id": "source_port_61",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 3.55,
+      "y": 12
+    },
+    "source_port_id": "source_port_62",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 4.45,
+      "y": 10
+    },
+    "source_port_id": "source_port_63",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_64",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 5.55,
+      "y": 10
+    },
+    "source_port_id": "source_port_64",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_65",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -1.1
+    },
+    "source_port_id": "source_port_65",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 16,
+    "display_pin_label": "BOOT0",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_66",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_66",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 18,
+    "display_pin_label": "PF0_OSC_IN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_67",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -0.8999999999999999
+    },
+    "source_port_id": "source_port_67",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 17,
+    "display_pin_label": "PF1_OSC_OUT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_68",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -1.3
+    },
+    "source_port_id": "source_port_68",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 15,
+    "display_pin_label": "NRST",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_69",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 6.5,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_69",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 5,
+    "true_ccw_index": 8,
+    "display_pin_label": "VDDA",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_70",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -0.30000000000000004
+    },
+    "source_port_id": "source_port_70",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 0,
+    "display_pin_label": "PA0",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_71",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -0.5
+    },
+    "source_port_id": "source_port_71",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 1,
+    "display_pin_label": "PA1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_72",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -0.7000000000000001
+    },
+    "source_port_id": "source_port_72",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 2,
+    "display_pin_label": "PA2_TX",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_73",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -0.9000000000000001
+    },
+    "source_port_id": "source_port_73",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 3,
+    "display_pin_label": "PA3_RX",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_74",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -1.1
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 4,
+    "display_pin_label": "PA4",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_75",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -1.3
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 11,
+    "true_ccw_index": 5,
+    "display_pin_label": "PA5_LED_R",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_76",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 12,
+    "true_ccw_index": 6,
+    "display_pin_label": "PA6_LED_G",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_77",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 5.5,
+      "y": -1.7
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 13,
+    "true_ccw_index": 7,
+    "display_pin_label": "PA7_LED_B",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_78",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -0.5
+    },
+    "source_port_id": "source_port_78",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 19,
+    "display_pin_label": "PB1_INT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_79",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 8.5,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_79",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "VSS",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_80",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 6.7,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 16,
+    "true_ccw_index": 9,
+    "display_pin_label": "VDD",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_81",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 6.9,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 17,
+    "true_ccw_index": 10,
+    "display_pin_label": "PA9_SCL",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_82",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 7.1,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 18,
+    "true_ccw_index": 11,
+    "display_pin_label": "PA10_SDA",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_83",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 7.3,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_83",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 19,
+    "true_ccw_index": 12,
+    "display_pin_label": "PA13_SWDIO",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_84",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 7.5,
+      "y": -2.3
+    },
+    "source_port_id": "source_port_84",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 20,
+    "true_ccw_index": 13,
+    "display_pin_label": "PA14_SWCLK",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_85",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 0.44999999999999996,
+      "y": -8
+    },
+    "source_port_id": "source_port_85",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_86",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 1.5499999999999998,
+      "y": -8
+    },
+    "source_port_id": "source_port_86",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_87",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -1.55,
+      "y": -8
+    },
+    "source_port_id": "source_port_87",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_88",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -0.45000000000000007,
+      "y": -8
+    },
+    "source_port_id": "source_port_88",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_89",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 0.44999999999999996,
+      "y": -10
+    },
+    "source_port_id": "source_port_89",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_90",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 1.5499999999999998,
+      "y": -10
+    },
+    "source_port_id": "source_port_90",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_91",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 11.45,
+      "y": 5
+    },
+    "source_port_id": "source_port_91",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_92",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 12.55,
+      "y": 5
+    },
+    "source_port_id": "source_port_92",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_93",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 2.45,
+      "y": 12
+    },
+    "source_port_id": "source_port_93",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_94",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 3.55,
+      "y": 12
+    },
+    "source_port_id": "source_port_94",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_95",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": 3,
+      "y": 10
+    },
+    "source_port_id": "source_port_95",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_96",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": 5,
+      "y": 10
+    },
+    "source_port_id": "source_port_96",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "B",
+    "is_connected": false,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_97",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": 5.95,
+      "y": 10
+    },
+    "source_port_id": "source_port_97",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_98",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": 7.05,
+      "y": 10
+    },
+    "source_port_id": "source_port_98",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_99",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 11.7,
+      "y": 10.1
+    },
+    "source_port_id": "source_port_99",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "BLUE_K",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_100",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 14.3,
+      "y": 10
+    },
+    "source_port_id": "source_port_100",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 5,
+    "display_pin_label": "RED_K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_101",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 11.7,
+      "y": 9.9
+    },
+    "source_port_id": "source_port_101",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 1,
+    "display_pin_label": "GREEN_K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_102",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 12.8,
+      "y": 9.3
+    },
+    "source_port_id": "source_port_102",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 4,
+    "true_ccw_index": 2,
+    "display_pin_label": "ANODE_G",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_103",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 13,
+      "y": 9.3
+    },
+    "source_port_id": "source_port_103",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 5,
+    "true_ccw_index": 3,
+    "display_pin_label": "ANODE_R",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_104",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 13.2,
+      "y": 9.3
+    },
+    "source_port_id": "source_port_104",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 6,
+    "true_ccw_index": 4,
+    "display_pin_label": "ANODE_B",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_105",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 8.950000000000001,
+      "y": 12
+    },
+    "source_port_id": "source_port_105",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_106",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 10.05,
+      "y": 12
+    },
+    "source_port_id": "source_port_106",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_107",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 17.45,
+      "y": 10
+    },
+    "source_port_id": "source_port_107",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_108",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 18.55,
+      "y": 10
+    },
+    "source_port_id": "source_port_108",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_109",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": 17.45,
+      "y": 12
+    },
+    "source_port_id": "source_port_109",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_110",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": 18.55,
+      "y": 12
+    },
+    "source_port_id": "source_port_110",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_111",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 21.2,
+      "y": 6.4
+    },
+    "source_port_id": "source_port_111",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 4,
+    "display_pin_label": "3V3",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_112",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 21.2,
+      "y": 6.2
+    },
+    "source_port_id": "source_port_112",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 3,
+    "display_pin_label": "SWDIO",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_113",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 21.2,
+      "y": 6
+    },
+    "source_port_id": "source_port_113",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "SWCLK",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_114",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 21.2,
+      "y": 5.8
+    },
+    "source_port_id": "source_port_114",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 1,
+    "display_pin_label": "NRST",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_115",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": 21.2,
+      "y": 5.6
+    },
+    "source_port_id": "source_port_115",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 0,
+    "display_pin_label": "GND",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_116",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 18.85,
+      "y": -5.9
+    },
+    "source_port_id": "source_port_116",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "VBUS",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_117",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 18.85,
+      "y": -6.1
+    },
+    "source_port_id": "source_port_117",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "GND",
+    "is_connected": false,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "solver_R1.2-D1.1",
+    "edges": [
+      {
+        "from": {
+          "x": -12.45,
+          "y": -3.5
+        },
+        "to": {
+          "x": -12.25,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": -12.25,
+          "y": -3.5
+        },
+        "to": {
+          "x": -11.8,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": -11.8,
+          "y": -3.5
+        },
+        "to": {
+          "x": -11.8,
+          "y": -4
+        }
+      },
+      {
+        "from": {
+          "x": -11.8,
+          "y": -4
+        },
+        "to": {
+          "x": -11.35,
+          "y": -4
+        }
+      },
+      {
+        "from": {
+          "x": -11.35,
+          "y": -4
+        },
+        "to": {
+          "x": -11.15,
+          "y": -4
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "solver_R2.2-D2.1",
+    "edges": [
+      {
+        "from": {
+          "x": -12.45,
+          "y": 2.5
+        },
+        "to": {
+          "x": -12.25,
+          "y": 2.5
+        }
+      },
+      {
+        "from": {
+          "x": -12.25,
+          "y": 2.5
+        },
+        "to": {
+          "x": -11.8,
+          "y": 2.5
+        }
+      },
+      {
+        "from": {
+          "x": -11.8,
+          "y": 2.5
+        },
+        "to": {
+          "x": -11.8,
+          "y": 3
+        }
+      },
+      {
+        "from": {
+          "x": -11.8,
+          "y": 3
+        },
+        "to": {
+          "x": -11.35,
+          "y": 3
+        }
+      },
+      {
+        "from": {
+          "x": -11.35,
+          "y": 3
+        },
+        "to": {
+          "x": -11.15,
+          "y": 3
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "solver_U1.11-U1.10",
+    "edges": [
+      {
+        "from": {
+          "x": -6.300000000000001,
+          "y": -1.1102230246251565e-16
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -1.1102230246251565e-16
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -1.1102230246251565e-16
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -0.20000000000000007
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -0.20000000000000007
+        },
+        "to": {
+          "x": -6.300000000000001,
+          "y": -0.20000000000000007
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_3",
+    "source_trace_id": "solver_C4.2-C2.2",
+    "edges": [
+      {
+        "from": {
+          "x": -10.45,
+          "y": 10
+        },
+        "to": {
+          "x": -10.25,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": -10.25,
+          "y": 10
+        },
+        "to": {
+          "x": -10.25,
+          "y": 9.280000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -10.25,
+          "y": 9.280000000000001
+        },
+        "to": {
+          "x": -12.25,
+          "y": 9.280000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -12.25,
+          "y": 9.280000000000001
+        },
+        "to": {
+          "x": -12.25,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": -12.25,
+          "y": 10
+        },
+        "to": {
+          "x": -12.45,
+          "y": 10
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_4",
+    "source_trace_id": "solver_C8.2-C7.2",
+    "edges": [
+      {
+        "from": {
+          "x": 1.55,
+          "y": -5
+        },
+        "to": {
+          "x": 1.75,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": 1.75,
+          "y": -5
+        },
+        "to": {
+          "x": 1.75,
+          "y": -5.72
+        }
+      },
+      {
+        "from": {
+          "x": 1.75,
+          "y": -5.72
+        },
+        "to": {
+          "x": -0.24999999999999994,
+          "y": -5.72
+        }
+      },
+      {
+        "from": {
+          "x": -0.24999999999999994,
+          "y": -5.72
+        },
+        "to": {
+          "x": -0.24999999999999994,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": -0.24999999999999994,
+          "y": -5
+        },
+        "to": {
+          "x": -0.44999999999999996,
+          "y": -5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_5",
+    "source_trace_id": "solver_U1.9-U1.15",
+    "edges": [
+      {
+        "from": {
+          "x": -6.300000000000001,
+          "y": -0.6
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -0.6
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -0.6
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -1.4000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -1.4000000000000001
+        },
+        "to": {
+          "x": -5,
+          "y": -1.4000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -5,
+          "y": -1.4000000000000001
+        },
+        "to": {
+          "x": -5,
+          "y": -1.2000000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.500000000000001,
+        "y": -0.6
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_6",
+    "source_trace_id": "solver_U1.8-U1.9",
+    "edges": [
+      {
+        "from": {
+          "x": -6.300000000000001,
+          "y": -0.4
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -0.4
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -0.4
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": -0.6
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": -0.6
+        },
+        "to": {
+          "x": -6.300000000000001,
+          "y": -0.6
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.500000000000001,
+        "y": -0.6
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_7",
+    "source_trace_id": "solver_USB2.2-USB2.1",
+    "edges": [
+      {
+        "from": {
+          "x": -20.35,
+          "y": -1.5
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.5
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.5
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.3
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.3
+        },
+        "to": {
+          "x": -20.35,
+          "y": -1.3
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -20.55,
+        "y": -1.5
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_8",
+    "source_trace_id": "solver_USB2.3-USB2.2",
+    "edges": [
+      {
+        "from": {
+          "x": -20.35,
+          "y": -1.7000000000000002
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.7000000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.7000000000000002
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.5
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.5
+        },
+        "to": {
+          "x": -20.35,
+          "y": -1.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -20.55,
+        "y": -1.5
+      },
+      {
+        "x": -20.55,
+        "y": -1.7000000000000002
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_9",
+    "source_trace_id": "solver_USB2.4-USB2.3",
+    "edges": [
+      {
+        "from": {
+          "x": -20.35,
+          "y": -1.9000000000000001
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.9000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.9000000000000001
+        },
+        "to": {
+          "x": -20.55,
+          "y": -1.7000000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -20.55,
+          "y": -1.7000000000000002
+        },
+        "to": {
+          "x": -20.35,
+          "y": -1.7000000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -20.55,
+        "y": -1.7000000000000002
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_10",
+    "source_trace_id": "solver_USB2.14-USB2.13",
+    "edges": [
+      {
+        "from": {
+          "x": -17.65,
+          "y": -1.7
+        },
+        "to": {
+          "x": -17.45,
+          "y": -1.7
+        }
+      },
+      {
+        "from": {
+          "x": -17.45,
+          "y": -1.7
+        },
+        "to": {
+          "x": -17.45,
+          "y": -1.9
+        }
+      },
+      {
+        "from": {
+          "x": -17.45,
+          "y": -1.9
+        },
+        "to": {
+          "x": -17.65,
+          "y": -1.9
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_11",
+    "source_trace_id": "solver_C4.1-C2.1",
+    "edges": [
+      {
+        "from": {
+          "x": -11.55,
+          "y": 10
+        },
+        "to": {
+          "x": -11.75,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": -11.75,
+          "y": 10
+        },
+        "to": {
+          "x": -11.75,
+          "y": 9.48
+        }
+      },
+      {
+        "from": {
+          "x": -11.75,
+          "y": 9.48
+        },
+        "to": {
+          "x": -12.2125,
+          "y": 9.48
+        }
+      },
+      {
+        "from": {
+          "x": -12.2125,
+          "y": 9.48
+        },
+        "to": {
+          "x": -12.2875,
+          "y": 9.48
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -12.2875,
+          "y": 9.48
+        },
+        "to": {
+          "x": -13.75,
+          "y": 9.48
+        }
+      },
+      {
+        "from": {
+          "x": -13.75,
+          "y": 9.48
+        },
+        "to": {
+          "x": -13.75,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": -13.75,
+          "y": 10
+        },
+        "to": {
+          "x": -13.55,
+          "y": 10
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_12",
+    "source_trace_id": "solver_U3.3-U3.2",
+    "edges": [
+      {
+        "from": {
+          "x": -7.5,
+          "y": 10.7
+        },
+        "to": {
+          "x": -7.7,
+          "y": 10.7
+        }
+      },
+      {
+        "from": {
+          "x": -7.7,
+          "y": 10.7
+        },
+        "to": {
+          "x": -7.7,
+          "y": 10.5
+        }
+      },
+      {
+        "from": {
+          "x": -7.7,
+          "y": 10.5
+        },
+        "to": {
+          "x": -7.5,
+          "y": 10.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_13",
+    "source_trace_id": "solver_USB2.16-USB2.15",
+    "edges": [
+      {
+        "from": {
+          "x": -17.65,
+          "y": -1.3
+        },
+        "to": {
+          "x": -17.45,
+          "y": -1.3
+        }
+      },
+      {
+        "from": {
+          "x": -17.45,
+          "y": -1.3
+        },
+        "to": {
+          "x": -17.45,
+          "y": -1.5
+        }
+      },
+      {
+        "from": {
+          "x": -17.45,
+          "y": -1.5
+        },
+        "to": {
+          "x": -17.65,
+          "y": -1.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_14",
+    "source_trace_id": "solver_R9.1-C5.1",
+    "edges": [
+      {
+        "from": {
+          "x": 2.45,
+          "y": 12
+        },
+        "to": {
+          "x": 2.25,
+          "y": 12
+        }
+      },
+      {
+        "from": {
+          "x": 2.25,
+          "y": 12
+        },
+        "to": {
+          "x": 2.25,
+          "y": 12.2
+        }
+      },
+      {
+        "from": {
+          "x": 2.25,
+          "y": 12.2
+        },
+        "to": {
+          "x": 2.25,
+          "y": 12
+        }
+      },
+      {
+        "from": {
+          "x": 2.25,
+          "y": 12
+        },
+        "to": {
+          "x": 2.45,
+          "y": 12
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_15",
+    "source_trace_id": "solver_C8.1-C7.1",
+    "edges": [
+      {
+        "from": {
+          "x": 0.44999999999999973,
+          "y": -5
+        },
+        "to": {
+          "x": 0.24999999999999956,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": 0.24999999999999956,
+          "y": -5
+        },
+        "to": {
+          "x": 0.24999999999999956,
+          "y": -5.5200000000000005
+        }
+      },
+      {
+        "from": {
+          "x": 0.24999999999999956,
+          "y": -5.5200000000000005
+        },
+        "to": {
+          "x": -0.21250000000000047,
+          "y": -5.5200000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -0.21250000000000047,
+          "y": -5.5200000000000005
+        },
+        "to": {
+          "x": -0.2875000000000004,
+          "y": -5.5200000000000005
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -0.2875000000000004,
+          "y": -5.5200000000000005
+        },
+        "to": {
+          "x": -1.75,
+          "y": -5.5200000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -5.5200000000000005
+        },
+        "to": {
+          "x": -1.75,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -5
+        },
+        "to": {
+          "x": -1.55,
+          "y": -5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_16",
+    "source_trace_id": "solver_LED1.5-LED1.4",
+    "edges": [
+      {
+        "from": {
+          "x": 13,
+          "y": 9.3
+        },
+        "to": {
+          "x": 13,
+          "y": 9.100000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 13,
+          "y": 9.100000000000001
+        },
+        "to": {
+          "x": 12.8,
+          "y": 9.100000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 12.8,
+          "y": 9.100000000000001
+        },
+        "to": {
+          "x": 12.8,
+          "y": 9.3
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 13,
+        "y": 9.100000000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_17",
+    "source_trace_id": "solver_LED1.6-LED1.5",
+    "edges": [
+      {
+        "from": {
+          "x": 13.2,
+          "y": 9.3
+        },
+        "to": {
+          "x": 13.2,
+          "y": 9.100000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 13.2,
+          "y": 9.100000000000001
+        },
+        "to": {
+          "x": 13,
+          "y": 9.100000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 13,
+          "y": 9.100000000000001
+        },
+        "to": {
+          "x": 13,
+          "y": 9.3
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 13,
+        "y": 9.100000000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_18",
+    "source_trace_id": "solver_R4.1-R3.1",
+    "edges": [
+      {
+        "from": {
+          "x": -1.55,
+          "y": -8
+        },
+        "to": {
+          "x": -1.75,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -8
+        },
+        "to": {
+          "x": -1.75,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -7.8
+        },
+        "to": {
+          "x": 0.24999999999999956,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": 0.24999999999999956,
+          "y": -7.8
+        },
+        "to": {
+          "x": 0.24999999999999956,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": 0.24999999999999956,
+          "y": -8
+        },
+        "to": {
+          "x": 0.44999999999999973,
+          "y": -8
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 0.24999999999999956,
+        "y": -8
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_19",
+    "source_trace_id": "solver_R8.1-R3.1",
+    "edges": [
+      {
+        "from": {
+          "x": 0.44999999999999996,
+          "y": -10
+        },
+        "to": {
+          "x": 0.25,
+          "y": -10
+        }
+      },
+      {
+        "from": {
+          "x": 0.25,
+          "y": -10
+        },
+        "to": {
+          "x": 0.25,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": 0.25,
+          "y": -8
+        },
+        "to": {
+          "x": 0.44999999999999996,
+          "y": -8
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 0.25,
+        "y": -8
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_20",
+    "source_trace_id": "solver_U1.4-U1.3",
+    "edges": [
+      {
+        "from": {
+          "x": -3.6999999999999993,
+          "y": 1.1102230246251565e-16
+        },
+        "to": {
+          "x": -3.499999999999999,
+          "y": 1.1102230246251565e-16
+        }
+      },
+      {
+        "from": {
+          "x": -3.499999999999999,
+          "y": 1.1102230246251565e-16
+        },
+        "to": {
+          "x": -3.499999999999999,
+          "y": 0.20000000000000007
+        }
+      },
+      {
+        "from": {
+          "x": -3.499999999999999,
+          "y": 0.20000000000000007
+        },
+        "to": {
+          "x": -3.6999999999999993,
+          "y": 0.20000000000000007
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_21",
+    "source_trace_id": "solver_U2.5-U2.16",
+    "edges": [
+      {
+        "from": {
+          "x": 6.5,
+          "y": -2.3
+        },
+        "to": {
+          "x": 6.5,
+          "y": -2.5
+        }
+      },
+      {
+        "from": {
+          "x": 6.5,
+          "y": -2.5
+        },
+        "to": {
+          "x": 6.7,
+          "y": -2.5
+        }
+      },
+      {
+        "from": {
+          "x": 6.7,
+          "y": -2.5
+        },
+        "to": {
+          "x": 6.7,
+          "y": -2.3
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_22",
+    "source_trace_id": "solver_USB2.12-R1.1",
+    "edges": [
+      {
+        "from": {
+          "x": -17.65,
+          "y": -2.0999999999999996
+        },
+        "to": {
+          "x": -17.45,
+          "y": -2.0999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -17.45,
+          "y": -2.0999999999999996
+        },
+        "to": {
+          "x": -15.6,
+          "y": -2.0999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -15.6,
+          "y": -2.0999999999999996
+        },
+        "to": {
+          "x": -15.6,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": -15.6,
+          "y": -3.5
+        },
+        "to": {
+          "x": -13.75,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": -13.75,
+          "y": -3.5
+        },
+        "to": {
+          "x": -13.55,
+          "y": -3.5
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_23",
+    "source_trace_id": "solver_U1.14-U1.1",
+    "edges": [
+      {
+        "from": {
+          "x": -6.300000000000001,
+          "y": 0.6
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": 0.6
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": 0.6
+        },
+        "to": {
+          "x": -6.500000000000001,
+          "y": 1.4000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -6.500000000000001,
+          "y": 1.4000000000000001
+        },
+        "to": {
+          "x": -3.5,
+          "y": 1.4000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -3.5,
+          "y": 1.4000000000000001
+        },
+        "to": {
+          "x": -3.5,
+          "y": 0.6
+        }
+      },
+      {
+        "from": {
+          "x": -3.5,
+          "y": 0.6
+        },
+        "to": {
+          "x": -3.6999999999999993,
+          "y": 0.6
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_24",
+    "source_trace_id": "solver_U3.5-L1.1",
+    "edges": [
+      {
+        "from": {
+          "x": -5.5,
+          "y": 10.5
+        },
+        "to": {
+          "x": -2,
+          "y": 10.5
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_25",
+    "source_trace_id": "solver_U3.6-C11.1",
+    "edges": [
+      {
+        "from": {
+          "x": -5.5,
+          "y": 10.7
+        },
+        "to": {
+          "x": -5.3,
+          "y": 10.7
+        }
+      },
+      {
+        "from": {
+          "x": -5.3,
+          "y": 10.7
+        },
+        "to": {
+          "x": -5.025,
+          "y": 10.7
+        }
+      },
+      {
+        "from": {
+          "x": -5.025,
+          "y": 10.7
+        },
+        "to": {
+          "x": -5.025,
+          "y": 14
+        }
+      },
+      {
+        "from": {
+          "x": -5.025,
+          "y": 14
+        },
+        "to": {
+          "x": -4.75,
+          "y": 14
+        }
+      },
+      {
+        "from": {
+          "x": -4.75,
+          "y": 14
+        },
+        "to": {
+          "x": -4.55,
+          "y": 14
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_26",
+    "source_trace_id": "solver_R7.2-LED1.1",
+    "edges": [
+      {
+        "from": {
+          "x": 10.05,
+          "y": 12
+        },
+        "to": {
+          "x": 10.25,
+          "y": 12
+        }
+      },
+      {
+        "from": {
+          "x": 10.25,
+          "y": 12
+        },
+        "to": {
+          "x": 10.875,
+          "y": 12
+        }
+      },
+      {
+        "from": {
+          "x": 10.875,
+          "y": 12
+        },
+        "to": {
+          "x": 10.875,
+          "y": 10.1
+        }
+      },
+      {
+        "from": {
+          "x": 10.875,
+          "y": 10.1
+        },
+        "to": {
+          "x": 11.5,
+          "y": 10.1
+        }
+      },
+      {
+        "from": {
+          "x": 11.5,
+          "y": 10.1
+        },
+        "to": {
+          "x": 11.7,
+          "y": 10.1
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_27",
+    "source_trace_id": "solver_C10.2-U3.4",
+    "edges": [
+      {
+        "from": {
+          "x": -3.45,
+          "y": 6
+        },
+        "to": {
+          "x": -3.25,
+          "y": 6
+        }
+      },
+      {
+        "from": {
+          "x": -3.25,
+          "y": 6
+        },
+        "to": {
+          "x": -3.25,
+          "y": 10.3
+        }
+      },
+      {
+        "from": {
+          "x": -3.25,
+          "y": 10.3
+        },
+        "to": {
+          "x": -5.5,
+          "y": 10.3
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_28",
+    "source_trace_id": "solver_CN1.1-U1.2",
+    "edges": [
+      {
+        "from": {
+          "x": 18.85,
+          "y": -5.9
+        },
+        "to": {
+          "x": 18.650000000000002,
+          "y": -5.9
+        }
+      },
+      {
+        "from": {
+          "x": 18.650000000000002,
+          "y": -5.9
+        },
+        "to": {
+          "x": 13.675,
+          "y": -5.9
+        }
+      },
+      {
+        "from": {
+          "x": 13.675,
+          "y": -5.9
+        },
+        "to": {
+          "x": 13.675,
+          "y": 0.4
+        }
+      },
+      {
+        "from": {
+          "x": 13.675,
+          "y": 0.4
+        },
+        "to": {
+          "x": -3.499999999999999,
+          "y": 0.4
+        }
+      },
+      {
+        "from": {
+          "x": -3.499999999999999,
+          "y": 0.4
+        },
+        "to": {
+          "x": -3.6999999999999993,
+          "y": 0.4
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_29",
+    "source_trace_id": "solver_U2.18-R3.2",
+    "edges": [
+      {
+        "from": {
+          "x": 7.1,
+          "y": -2.3
+        },
+        "to": {
+          "x": 7.1,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": 7.1,
+          "y": -8
+        },
+        "to": {
+          "x": 1.55,
+          "y": -8
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_30",
+    "source_trace_id": "solver_C6.2-C3.2",
+    "edges": [
+      {
+        "from": {
+          "x": 7.05,
+          "y": 10
+        },
+        "to": {
+          "x": 7.25,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": 7.25,
+          "y": 10
+        },
+        "to": {
+          "x": 7.25,
+          "y": 9.38
+        }
+      },
+      {
+        "from": {
+          "x": 7.25,
+          "y": 9.38
+        },
+        "to": {
+          "x": 5.75,
+          "y": 9.38
+        }
+      },
+      {
+        "from": {
+          "x": 5.75,
+          "y": 9.38
+        },
+        "to": {
+          "x": 5.75,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": 5.75,
+          "y": 10
+        },
+        "to": {
+          "x": 5.55,
+          "y": 10
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_31",
+    "source_trace_id": "solver_U2.15-U2.1",
+    "edges": [
+      {
+        "from": {
+          "x": 8.5,
+          "y": -1.5
+        },
+        "to": {
+          "x": 8.7,
+          "y": -1.5
+        }
+      },
+      {
+        "from": {
+          "x": 8.7,
+          "y": -1.5
+        },
+        "to": {
+          "x": 8.7,
+          "y": -1.1
+        }
+      },
+      {
+        "from": {
+          "x": 8.7,
+          "y": -1.1
+        },
+        "to": {
+          "x": 8.5,
+          "y": -1.1
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit437_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_32",
+    "source_trace_id": "solver_C1.1-J1.4",
+    "edges": [
+      {
+        "from": {
+          "x": 11.45,
+          "y": 5
+        },
+        "to": {
+          "x": 11.25,
+          "y": 5
+        }
+      },
+      {
+        "from": {
+          "x": 11.25,
+          "y": 5
+        },
+        "to": {
+          "x": 11.25,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 11.25,
+          "y": 4.38
+        },
+        "to": {
+          "x": 21.4,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 21.4,
+          "y": 4.38
+        },
+        "to": {
+          "x": 21.4,
+          "y": 5.4
+        }
+      },
+      {
+        "from": {
+          "x": 21.4,
+          "y": 5.4
+        },
+        "to": {
+          "x": 21.601,
+          "y": 5.4
+        }
+      },
+      {
+        "from": {
+          "x": 21.601,
+          "y": 5.4
+        },
+        "to": {
+          "x": 21.601,
+          "y": 5.799999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 21.601,
+          "y": 5.799999999999999
+        },
+        "to": {
+          "x": 21.2,
+          "y": 5.8
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_33",
+    "source_trace_id": "solver_R9.2-SW1.1",
+    "edges": [
+      {
+        "from": {
+          "x": 3.55,
+          "y": 12
+        },
+        "to": {
+          "x": 3.75,
+          "y": 12
+        }
+      },
+      {
+        "from": {
+          "x": 3.75,
+          "y": 12
+        },
+        "to": {
+          "x": 3.75,
+          "y": 11
+        }
+      },
+      {
+        "from": {
+          "x": 3.75,
+          "y": 11
+        },
+        "to": {
+          "x": 2.8,
+          "y": 11
+        }
+      },
+      {
+        "from": {
+          "x": 2.8,
+          "y": 11
+        },
+        "to": {
+          "x": 2.8,
+          "y": 10
+        }
+      },
+      {
+        "from": {
+          "x": 2.8,
+          "y": 10
+        },
+        "to": {
+          "x": 3,
+          "y": 10
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "GND",
+    "anchor_position": {
+      "x": -20.55,
+      "y": -1.9000000000000001
+    },
+    "center": {
+      "x": -20.55,
+      "y": -1.9900000000000002
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "GND",
+    "anchor_position": {
+      "x": -17.45,
+      "y": -1.7
+    },
+    "center": {
+      "x": -17.3,
+      "y": -1.7
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "GND",
+    "anchor_position": {
+      "x": -8.85,
+      "y": -4
+    },
+    "center": {
+      "x": -8.7,
+      "y": -4
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "GND",
+    "anchor_position": {
+      "x": -8.85,
+      "y": 3
+    },
+    "center": {
+      "x": -8.7,
+      "y": 3
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "GND",
+    "anchor_position": {
+      "x": -3.45,
+      "y": -6
+    },
+    "center": {
+      "x": -3.3000000000000003,
+      "y": -6
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "GND",
+    "anchor_position": {
+      "x": -3.25,
+      "y": 6
+    },
+    "center": {
+      "x": -3.25,
+      "y": 5.91
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "GND",
+    "anchor_position": {
+      "x": -6.500000000000001,
+      "y": -1.4000000000000001
+    },
+    "center": {
+      "x": -6.500000000000001,
+      "y": -1.4900000000000002
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "GND",
+    "anchor_position": {
+      "x": 1.75,
+      "y": -5.72
+    },
+    "center": {
+      "x": 1.75,
+      "y": -5.81
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "GND",
+    "anchor_position": {
+      "x": -10.25,
+      "y": 9.280000000000001
+    },
+    "center": {
+      "x": -10.25,
+      "y": 9.190000000000001
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "GND",
+    "anchor_position": {
+      "x": 3.55,
+      "y": 12
+    },
+    "center": {
+      "x": 3.6999999999999997,
+      "y": 12
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "GND",
+    "anchor_position": {
+      "x": 7.25,
+      "y": 9.38
+    },
+    "center": {
+      "x": 7.25,
+      "y": 9.290000000000001
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "GND",
+    "anchor_position": {
+      "x": 8.7,
+      "y": -1.5
+    },
+    "center": {
+      "x": 8.7,
+      "y": -1.59
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "GND",
+    "anchor_position": {
+      "x": 12.55,
+      "y": 5
+    },
+    "center": {
+      "x": 12.700000000000001,
+      "y": 5
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "GND",
+    "anchor_position": {
+      "x": 5,
+      "y": 10
+    },
+    "center": {
+      "x": 5.15,
+      "y": 10
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "GND",
+    "anchor_position": {
+      "x": 21.2,
+      "y": 5.6
+    },
+    "center": {
+      "x": 21.349999999999998,
+      "y": 5.6
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "GND",
+    "anchor_position": {
+      "x": 18.85,
+      "y": -6.1
+    },
+    "center": {
+      "x": 18.700000000000003,
+      "y": -6.1
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "USB2_CC1/R2_pin1",
+    "anchor_position": {
+      "x": -20.35,
+      "y": -2.3
+    },
+    "center": {
+      "x": -21.150000000000002,
+      "y": -2.3
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "USB2_CC1/R2_pin1",
+    "anchor_position": {
+      "x": -13.55,
+      "y": 2.5
+    },
+    "center": {
+      "x": -14.350000000000001,
+      "y": 2.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_18",
+    "text": "USB2_CC2/R1_pin1",
+    "anchor_position": {
+      "x": -17.45,
+      "y": -2.0999999999999996
+    },
+    "center": {
+      "x": -17.45,
+      "y": -2.1899999999999995
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_19",
+    "text": "VBUS",
+    "anchor_position": {
+      "x": -17.45,
+      "y": -1.3
+    },
+    "center": {
+      "x": -17.45,
+      "y": -1.21
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_0",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_20",
+    "text": "VBUS",
+    "anchor_position": {
+      "x": 13.675,
+      "y": 0.4
+    },
+    "center": {
+      "x": 13.675,
+      "y": 0.49
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_0",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_21",
+    "text": "VBUS",
+    "anchor_position": {
+      "x": -11.75,
+      "y": 10
+    },
+    "center": {
+      "x": -11.75,
+      "y": 10.09
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_0",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_22",
+    "text": "VBUS",
+    "anchor_position": {
+      "x": -7.7,
+      "y": 10.7
+    },
+    "center": {
+      "x": -7.7,
+      "y": 10.79
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_0",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_23",
+    "text": "R1_pin2/D1_pin1/C9_pin1/U1_CC2_B/U1_CC2_A",
+    "anchor_position": {
+      "x": -6.500000000000001,
+      "y": 0.6
+    },
+    "center": {
+      "x": -6.500000000000001,
+      "y": 0.51
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_24",
+    "text": "R1_pin2/D1_pin1/C9_pin1/U1_CC2_B/U1_CC2_A",
+    "anchor_position": {
+      "x": -4.55,
+      "y": -6
+    },
+    "center": {
+      "x": -6.6,
+      "y": -6
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_25",
+    "text": "R2_pin2/D2_pin1/C10_pin1/U1_CC1_B/U1_CC1_A",
+    "anchor_position": {
+      "x": -4.55,
+      "y": 6
+    },
+    "center": {
+      "x": -6.65,
+      "y": 6
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_26",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": -3.499999999999999,
+      "y": 1.1102230246251565e-16
+    },
+    "center": {
+      "x": -3.499999999999999,
+      "y": -0.08999999999999989
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_27",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 0.34999999999999964,
+      "y": -5
+    },
+    "center": {
+      "x": 0.34999999999999964,
+      "y": -4.91
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_2",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_28",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": -7.5,
+      "y": 10.3
+    },
+    "center": {
+      "x": -7.7,
+      "y": 10.3
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_29",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 0,
+      "y": 10.5
+    },
+    "center": {
+      "x": 0.2,
+      "y": 10.5
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_30",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 2.25,
+      "y": 12
+    },
+    "center": {
+      "x": 2.25,
+      "y": 11.91
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_31",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 4.45,
+      "y": 10
+    },
+    "center": {
+      "x": 4.25,
+      "y": 10
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_32",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 6.5,
+      "y": -2.5
+    },
+    "center": {
+      "x": 6.3,
+      "y": -2.5
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_33",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": -1.75,
+      "y": -7.8
+    },
+    "center": {
+      "x": -1.75,
+      "y": -7.71
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_2",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_34",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 13,
+      "y": 9.100000000000001
+    },
+    "center": {
+      "x": 13,
+      "y": 9.010000000000002
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_35",
+    "text": "V3_3",
+    "anchor_position": {
+      "x": 21.2,
+      "y": 6.4
+    },
+    "center": {
+      "x": 21.4,
+      "y": 6.4
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_36",
+    "text": "INT",
+    "anchor_position": {
+      "x": -3.6999999999999993,
+      "y": -0.19999999999999996
+    },
+    "center": {
+      "x": -3.5499999999999994,
+      "y": -0.19999999999999996
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_3"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_37",
+    "text": "INT",
+    "anchor_position": {
+      "x": 8.5,
+      "y": -0.5
+    },
+    "center": {
+      "x": 8.65,
+      "y": -0.5
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_3"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_38",
+    "text": "INT",
+    "anchor_position": {
+      "x": 1.55,
+      "y": -10
+    },
+    "center": {
+      "x": 1.7000000000000002,
+      "y": -10
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_3"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_39",
+    "text": "SCL",
+    "anchor_position": {
+      "x": -3.6999999999999993,
+      "y": -0.39999999999999997
+    },
+    "center": {
+      "x": -3.5499999999999994,
+      "y": -0.39999999999999997
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_40",
+    "text": "SCL",
+    "anchor_position": {
+      "x": 6.9,
+      "y": -2.3
+    },
+    "center": {
+      "x": 6.9,
+      "y": -2.3899999999999997
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_41",
+    "text": "SCL",
+    "anchor_position": {
+      "x": -0.44999999999999996,
+      "y": -8
+    },
+    "center": {
+      "x": -0.29999999999999993,
+      "y": -8
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_42",
+    "text": "SDA",
+    "anchor_position": {
+      "x": -3.6999999999999993,
+      "y": -0.6
+    },
+    "center": {
+      "x": -3.5499999999999994,
+      "y": -0.6
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_5"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_43",
+    "text": "SDA",
+    "anchor_position": {
+      "x": 7.1,
+      "y": -5.15
+    },
+    "center": {
+      "x": 6.949999999999999,
+      "y": -5.15
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_5"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_44",
+    "text": "U3_SW/C11_pin2/L1_pin1",
+    "anchor_position": {
+      "x": -3.75,
+      "y": 10.5
+    },
+    "center": {
+      "x": -3.75,
+      "y": 10.59
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_45",
+    "text": "U3_SW/C11_pin2/L1_pin1",
+    "anchor_position": {
+      "x": -3.45,
+      "y": 14
+    },
+    "center": {
+      "x": -2.35,
+      "y": 14
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_46",
+    "text": "U3_BST/C11_pin1",
+    "anchor_position": {
+      "x": -5.3,
+      "y": 10.7
+    },
+    "center": {
+      "x": -5.3,
+      "y": 10.79
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_47",
+    "text": "BTN",
+    "anchor_position": {
+      "x": 8.5,
+      "y": -0.8999999999999999
+    },
+    "center": {
+      "x": 8.65,
+      "y": -0.8999999999999999
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_6"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_48",
+    "text": "BTN",
+    "anchor_position": {
+      "x": 3.75,
+      "y": 12
+    },
+    "center": {
+      "x": 3.9,
+      "y": 12
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_6"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_49",
+    "text": "BTN",
+    "anchor_position": {
+      "x": 5.95,
+      "y": 10
+    },
+    "center": {
+      "x": 5.8,
+      "y": 10
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_6"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_50",
+    "text": "U2_NRST/C1_pin1/J1_NRST",
+    "anchor_position": {
+      "x": 8.5,
+      "y": -1.3
+    },
+    "center": {
+      "x": 9.65,
+      "y": -1.3
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_51",
+    "text": "U2_NRST/C1_pin1/J1_NRST",
+    "anchor_position": {
+      "x": 11.25,
+      "y": 5
+    },
+    "center": {
+      "x": 11.25,
+      "y": 5.09
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_52",
+    "text": "U2_PA5_LED_R/R5_pin1",
+    "anchor_position": {
+      "x": 5.5,
+      "y": -1.3
+    },
+    "center": {
+      "x": 4.5,
+      "y": -1.3
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_53",
+    "text": "U2_PA5_LED_R/R5_pin1",
+    "anchor_position": {
+      "x": 17.45,
+      "y": 12
+    },
+    "center": {
+      "x": 16.45,
+      "y": 12
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_54",
+    "text": "U2_PA6_LED_G/R6_pin1",
+    "anchor_position": {
+      "x": 5.5,
+      "y": -1.5
+    },
+    "center": {
+      "x": 4.5,
+      "y": -1.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_55",
+    "text": "U2_PA6_LED_G/R6_pin1",
+    "anchor_position": {
+      "x": 17.45,
+      "y": 10
+    },
+    "center": {
+      "x": 16.45,
+      "y": 10
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_56",
+    "text": "U2_PA7_LED_B/R7_pin1",
+    "anchor_position": {
+      "x": 5.5,
+      "y": -1.7
+    },
+    "center": {
+      "x": 4.5,
+      "y": -1.7
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_57",
+    "text": "U2_PA7_LED_B/R7_pin1",
+    "anchor_position": {
+      "x": 8.95,
+      "y": 12
+    },
+    "center": {
+      "x": 7.949999999999999,
+      "y": 12
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_58",
+    "text": "U2_PA13_SWDIO/J1_SWDIO",
+    "anchor_position": {
+      "x": 21.2,
+      "y": 6.2
+    },
+    "center": {
+      "x": 22.3,
+      "y": 6.2
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_59",
+    "text": "U2_PA13_SWDIO/J1_SWDIO",
+    "anchor_position": {
+      "x": 7.3,
+      "y": -2.3
+    },
+    "center": {
+      "x": 7.3,
+      "y": -2.3899999999999997
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_60",
+    "text": "U2_PA14_SWCLK/J1_SWCLK",
+    "anchor_position": {
+      "x": 21.2,
+      "y": 6
+    },
+    "center": {
+      "x": 22.3,
+      "y": 6
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_61",
+    "text": "U2_PA14_SWCLK/J1_SWCLK",
+    "anchor_position": {
+      "x": 7.5,
+      "y": -2.3
+    },
+    "center": {
+      "x": 7.5,
+      "y": -2.3899999999999997
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_62",
+    "text": "LED1_BLUE_K/R7_pin2",
+    "anchor_position": {
+      "x": 10.25,
+      "y": 12
+    },
+    "center": {
+      "x": 10.25,
+      "y": 12.09
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_63",
+    "text": "LED1_RED_K/R5_pin2",
+    "anchor_position": {
+      "x": 18.55,
+      "y": 12
+    },
+    "center": {
+      "x": 19.45,
+      "y": 12
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_64",
+    "text": "LED1_RED_K/R5_pin2",
+    "anchor_position": {
+      "x": 14.3,
+      "y": 10
+    },
+    "center": {
+      "x": 15.200000000000001,
+      "y": 10
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_65",
+    "text": "LED1_GREEN_K/R6_pin2",
+    "anchor_position": {
+      "x": 18.55,
+      "y": 10
+    },
+    "center": {
+      "x": 19.55,
+      "y": 10
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_66",
+    "text": "LED1_GREEN_K/R6_pin2",
+    "anchor_position": {
+      "x": 11.7,
+      "y": 9.9
+    },
+    "center": {
+      "x": 10.7,
+      "y": 9.9
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": -37.949587050000005,
+      "y": 0
+    },
+    "width": 5.8490851000000035,
+    "height": 10.65022,
+    "layer": "top",
+    "rotation": 270,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": -11,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": -25.5,
+      "y": -4.5
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 1,
+    "display_offset_y": -4.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": -25.5,
+      "y": 4.5
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 1,
+    "display_offset_y": 4.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": -25.5,
+      "y": -8
+    },
+    "width": 3.2099503999999968,
+    "height": 0.7999983999999998,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 1,
+    "display_offset_y": -8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "center": {
+      "x": -25.5,
+      "y": 8
+    },
+    "width": 3.2099503999999968,
+    "height": 0.7999983999999998,
+    "layer": "top",
+    "rotation": 180,
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 1,
+    "display_offset_y": 8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_5",
+    "center": {
+      "x": -19.5,
+      "y": -8
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 7,
+    "display_offset_y": -8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_6",
+    "center": {
+      "x": -19.5,
+      "y": 8
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 7,
+    "display_offset_y": 8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_7",
+    "center": {
+      "x": -9.5,
+      "y": 0
+    },
+    "width": 2.8600907999999983,
+    "height": 2.8600908,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 17,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_8",
+    "center": {
+      "x": -3.5,
+      "y": -4
+    },
+    "width": 1.5599999999999992,
+    "height": 0.6400000000000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 23,
+    "display_offset_y": -4
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_9",
+    "center": {
+      "x": -3.5,
+      "y": 4
+    },
+    "width": 2.4500000000000006,
+    "height": 0.9499999999999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_0",
+    "display_offset_x": 23,
+    "display_offset_y": 4
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "name": "unnamed_group1",
+    "anchor_position": {
+      "x": -26.5,
+      "y": 0
+    },
+    "center": {
+      "x": -26.5,
+      "y": 0
+    },
+    "width": 38.599129600000005,
+    "height": 16.7999984,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_0",
+    "anchor_alignment": null,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -26.5,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_10",
+    "center": {
+      "x": -19,
+      "y": 6
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": -9,
+    "display_offset_y": -4
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_11",
+    "center": {
+      "x": -19,
+      "y": 14
+    },
+    "width": 4.049999999999997,
+    "height": 1.75,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": -9,
+    "display_offset_y": 4
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_12",
+    "center": {
+      "x": -10,
+      "y": 10
+    },
+    "width": 2.449931600000003,
+    "height": 3.499789800000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": 0,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_13",
+    "center": {
+      "x": -10,
+      "y": 3
+    },
+    "width": 1.5599999999999987,
+    "height": 0.6399999999999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": 0,
+    "display_offset_y": -7
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_14",
+    "center": {
+      "x": 0,
+      "y": 10
+    },
+    "width": 4.3239436,
+    "height": 1.9999959999999994,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": 10,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_15",
+    "center": {
+      "x": 8,
+      "y": 6
+    },
+    "width": 4.050000000000001,
+    "height": 1.75,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": 18,
+    "display_offset_y": -4
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_16",
+    "center": {
+      "x": 8,
+      "y": 14
+    },
+    "width": 4.050000000000001,
+    "height": 1.75,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_1",
+    "display_offset_x": 18,
+    "display_offset_y": 4
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "name": "unnamed_group2",
+    "anchor_position": {
+      "x": -10,
+      "y": 10
+    },
+    "center": {
+      "x": -10,
+      "y": 10
+    },
+    "width": 31.049999999999997,
+    "height": 12.195,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_1",
+    "anchor_alignment": null,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -10,
+    "display_offset_y": 10
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_17",
+    "center": {
+      "x": 6.975,
+      "y": -1
+    },
+    "width": 6.250139999999998,
+    "height": 7.495794,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": 0,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_18",
+    "center": {
+      "x": -3.5,
+      "y": -8.5
+    },
+    "width": 1.5599999999999992,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": -10.5,
+    "display_offset_y": -7.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_19",
+    "center": {
+      "x": -1,
+      "y": -3.8
+    },
+    "width": 1.56,
+    "height": 0.6400000000000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": -8,
+    "display_offset_y": -2.8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_20",
+    "center": {
+      "x": -1,
+      "y": -0.19999999999999998
+    },
+    "width": 1.56,
+    "height": 0.6400000000000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": -8,
+    "display_offset_y": 0.8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_21",
+    "center": {
+      "x": 15,
+      "y": 3
+    },
+    "width": 1.5599999999999987,
+    "height": 0.6399999999999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": 8,
+    "display_offset_y": 4
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_22",
+    "center": {
+      "x": 19,
+      "y": -9
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": 12,
+    "display_offset_y": -8
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_23",
+    "center": {
+      "x": 19,
+      "y": -14
+    },
+    "width": 4.199991599999997,
+    "height": 1.6999965999999986,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": 12,
+    "display_offset_y": -13
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_24",
+    "center": {
+      "x": 26,
+      "y": -14
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_2",
+    "display_offset_x": 19,
+    "display_offset_y": -13
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "name": "unnamed_group3",
+    "anchor_position": {
+      "x": 7,
+      "y": -1
+    },
+    "center": {
+      "x": 7,
+      "y": -1
+    },
+    "width": 31.060000000000002,
+    "height": 18.1699983,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_2",
+    "anchor_alignment": null,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 7,
+    "display_offset_y": -1
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_25",
+    "center": {
+      "x": 23,
+      "y": 10
+    },
+    "width": 6.560159599999999,
+    "height": 4.179900199999999,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "pcb_group_id": "pcb_group_3",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_3",
+    "display_offset_x": 0,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_26",
+    "center": {
+      "x": 17,
+      "y": 13
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_3",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_3",
+    "display_offset_x": -6,
+    "display_offset_y": 3
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_27",
+    "center": {
+      "x": 29,
+      "y": 7
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_3",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_3",
+    "display_offset_x": 6,
+    "display_offset_y": -3
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_28",
+    "center": {
+      "x": 29,
+      "y": 13
+    },
+    "width": 1.5600000000000023,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_28",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_3",
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_group_id": "pcb_group_3",
+    "display_offset_x": 6,
+    "display_offset_y": 3
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "name": "unnamed_group4",
+    "anchor_position": {
+      "x": 23,
+      "y": 10
+    },
+    "center": {
+      "x": 23,
+      "y": 10
+    },
+    "width": 13.560000000000002,
+    "height": 6.640000000000001,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_3",
+    "anchor_alignment": null,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 23,
+    "display_offset_y": 10
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_29",
+    "center": {
+      "x": 32,
+      "y": -9
+    },
+    "width": 1.5,
+    "height": 11.66,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 32,
+    "display_offset_y": -9
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_30",
+    "center": {
+      "x": 36,
+      "y": 10
+    },
+    "width": 2.999994000000001,
+    "height": 7.998714,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_30",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 36,
+    "display_offset_y": 10
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "source_board_id": "source_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "thickness": 1.4,
+    "num_layers": 4,
+    "width": 86,
+    "height": 36,
+    "material": "fr4",
+    "min_trace_width": 0.1,
+    "min_via_hole_diameter": 0.3,
+    "min_via_pad_diameter": 0.45,
+    "min_via_hole_edge_to_via_hole_edge_clearance": 0.1,
+    "min_trace_to_pad_edge_clearance": 0.1,
+    "min_pad_edge_to_pad_edge_clearance": 0.1,
+    "min_plated_hole_drill_edge_to_drill_edge_clearance": 0.15,
+    "min_board_edge_clearance": 0.2
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.7500112,
+    "x": -36.5944328,
+    "y": 2.899918,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.7500112,
+    "x": -36.5944328,
+    "y": -2.899918,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.7999984,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole1",
+      "pin2"
+    ],
+    "x": -40.2741308,
+    "y": -4.325111999999999,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -40.2741308,
+    "y": -4.325111999999999,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -40.2741308,
+    "y": -4.325111999999999,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "outer_width": 1.1999976,
+    "outer_height": 1.999996,
+    "hole_width": 0.7999984,
+    "hole_height": 1.5999968,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole2",
+      "pin1"
+    ],
+    "x": -36.0943068,
+    "y": -4.325112,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -36.0943068,
+    "y": -4.325112,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -36.0943068,
+    "y": -4.325112,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "outer_width": 1.1999976,
+    "outer_height": 1.999996,
+    "hole_width": 0.7999984,
+    "hole_height": 1.5999968,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole3",
+      "pin4"
+    ],
+    "x": -36.0943068,
+    "y": 4.325112,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -36.0943068,
+    "y": 4.325112,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -36.0943068,
+    "y": 4.325112,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.7999984,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole4",
+      "pin3"
+    ],
+    "x": -40.2741308,
+    "y": 4.325112000000001,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -40.2741308,
+    "y": 4.325112000000001,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -40.2741308,
+    "y": 4.325112000000001,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": 1.7500599999999995,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": 1.7500599999999995,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": 1.2499339999999997,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": 1.2499339999999997,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": 0.7500619999999996,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": 0.7500619999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": 0.2499359999999996,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": 0.2499359999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": -0.24993600000000038,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": -0.24993600000000038,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": -0.7500620000000005,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": -0.7500620000000005,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": -1.2496800000000003,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": -1.2496800000000003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2999974,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3259568,
+    "y": -1.7500600000000004,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.90999818,
+    "height": 0.20999958000000002,
+    "x": -35.3259568,
+    "y": -1.7500600000000004,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3,
+    "height": 0.6,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3250445,
+    "y": 3.1999555999999996,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9099999999999999,
+    "height": 0.42,
+    "x": -35.3250445,
+    "y": 3.1999555999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3,
+    "height": 0.6,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.325044500000004,
+    "y": -3.2000063000000005,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9099999999999999,
+    "height": 0.42,
+    "x": -35.325044500000004,
+    "y": -3.2000063000000005,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3,
+    "height": 0.6,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.325044500000004,
+    "y": -2.4001603000000005,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9099999999999999,
+    "height": 0.42,
+    "x": -35.325044500000004,
+    "y": -2.4001603000000005,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3,
+    "height": 0.6,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -35.3250445,
+    "y": 2.3999570999999995,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9099999999999999,
+    "height": 0.42,
+    "x": -35.3250445,
+    "y": 2.3999570999999995,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -39.175758599999995,
+        "y": 4.4689776000000165
+      },
+      {
+        "x": -37.312846400000126,
+        "y": 4.4689776000000165
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -42.89414080000006,
+        "y": -4.471009600000115
+      },
+      {
+        "x": -42.89414080000006,
+        "y": 4.468977600000017
+      },
+      {
+        "x": -41.41283820000001,
+        "y": 4.468977600000017
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -39.17611420000003,
+        "y": -4.471009600000116
+      },
+      {
+        "x": -37.31249079999998,
+        "y": -4.471009600000116
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -42.89414080000006,
+        "y": -4.471009600000115
+      },
+      {
+        "x": -41.4124826000002,
+        "y": -4.471009600000115
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -33.6713988,
+      "y": -0.0027940000000007035
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "USB2",
+    "ccw_rotation": -90.00000000000001,
+    "pcb_component_id": "pcb_component_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -34.421398800000134,
+        "y": 5.174805999999875
+      },
+      {
+        "x": -34.421398800000134,
+        "y": -5.180394000000093
+      },
+      {
+        "x": -43.150998800000025,
+        "y": -5.180394000000091
+      },
+      {
+        "x": -43.150998800000025,
+        "y": 5.174805999999877
+      },
+      {
+        "x": -34.421398800000134,
+        "y": 5.174805999999875
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -26.01,
+    "y": -4.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -26.01,
+    "y": -4.5,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -24.99,
+    "y": -4.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -24.99,
+    "y": -4.5,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": -24.99,
+        "y": -3.7800000000000002
+      },
+      {
+        "x": -26.48,
+        "y": -3.7800000000000002
+      },
+      {
+        "x": -26.48,
+        "y": -5.22
+      },
+      {
+        "x": -24.99,
+        "y": -5.22
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -25.5,
+      "y": -3.2800000000000002
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_0",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "center": {
+      "x": -25.5,
+      "y": -4.5
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -26.01,
+    "y": 4.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -26.01,
+    "y": 4.5,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -24.99,
+    "y": 4.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -24.99,
+    "y": 4.5,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -24.99,
+        "y": 5.22
+      },
+      {
+        "x": -26.48,
+        "y": 5.22
+      },
+      {
+        "x": -26.48,
+        "y": 3.7800000000000002
+      },
+      {
+        "x": -24.99,
+        "y": 3.7800000000000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -25.5,
+      "y": 5.72
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_1",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "center": {
+      "x": -25.5,
+      "y": 4.5
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 0.7999984,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -24.295024,
+    "y": -8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.55999888,
+    "x": -24.295024,
+    "y": -8,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 0.7999984,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -26.704976,
+    "y": -8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.55999888,
+    "x": -26.704976,
+    "y": -8,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.505968999999936,
+        "y": -7.858318800000006
+      },
+      {
+        "x": -25.505968999999936,
+        "y": -8.11231880000014
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.378968999999984,
+        "y": -7.985318799999959
+      },
+      {
+        "x": -25.509017000000085,
+        "y": -7.985318799999959
+      },
+      {
+        "x": -25.75996900000007,
+        "y": -8.11231880000014
+      },
+      {
+        "x": -25.75996900000007,
+        "y": -7.858318800000006
+      },
+      {
+        "x": -25.75996900000007,
+        "y": -7.858318800000006
+      },
+      {
+        "x": -25.508204200000023,
+        "y": -7.9823215999999775
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.632969000000116,
+        "y": -7.985318799999959
+      },
+      {
+        "x": -25.502921000000015,
+        "y": -7.985318799999959
+      },
+      {
+        "x": -25.25196900000003,
+        "y": -7.858318800000006
+      },
+      {
+        "x": -25.25196900000003,
+        "y": -8.11231880000014
+      },
+      {
+        "x": -25.25196900000003,
+        "y": -8.11231880000014
+      },
+      {
+        "x": -25.503733800000077,
+        "y": -7.988392200000021
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -26.355116400000043,
+        "y": -8.684834799999976
+      },
+      {
+        "x": -24.655094400000053,
+        "y": -8.684834799999976
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_10",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -26.355116400000043,
+        "y": -7.284837599999946
+      },
+      {
+        "x": -24.655094400000053,
+        "y": -7.284837599999946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -25.507112,
+      "y": -6.293626
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "D1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_1",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -27.357312000000093,
+        "y": -7.043625999999904
+      },
+      {
+        "x": -23.656912000000148,
+        "y": -7.043625999999904
+      },
+      {
+        "x": -23.656912000000148,
+        "y": -8.940625999999952
+      },
+      {
+        "x": -27.357312000000093,
+        "y": -8.940625999999952
+      },
+      {
+        "x": -27.357312000000093,
+        "y": -7.043625999999904
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 0.7999984,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -26.704976,
+    "y": 8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.55999888,
+    "x": -26.704976,
+    "y": 8,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 0.7999984,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -24.295024,
+    "y": 8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.55999888,
+    "x": -24.295024,
+    "y": 8,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_11",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.494031000000064,
+        "y": 7.858318800000006
+      },
+      {
+        "x": -25.494031000000064,
+        "y": 8.11231880000014
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_12",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.621031000000016,
+        "y": 7.985318799999959
+      },
+      {
+        "x": -25.490982999999915,
+        "y": 7.985318799999959
+      },
+      {
+        "x": -25.24003099999993,
+        "y": 8.11231880000014
+      },
+      {
+        "x": -25.24003099999993,
+        "y": 7.858318800000006
+      },
+      {
+        "x": -25.24003099999993,
+        "y": 7.858318800000006
+      },
+      {
+        "x": -25.491795799999977,
+        "y": 7.9823215999999775
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_13",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -25.367030999999884,
+        "y": 7.985318799999959
+      },
+      {
+        "x": -25.497078999999985,
+        "y": 7.985318799999959
+      },
+      {
+        "x": -25.74803099999997,
+        "y": 7.858318800000006
+      },
+      {
+        "x": -25.74803099999997,
+        "y": 8.11231880000014
+      },
+      {
+        "x": -25.74803099999997,
+        "y": 8.11231880000014
+      },
+      {
+        "x": -25.496266199999923,
+        "y": 7.988392200000021
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_14",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -24.644883599999957,
+        "y": 8.684834799999976
+      },
+      {
+        "x": -26.344905599999947,
+        "y": 8.684834799999976
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_15",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -24.644883599999957,
+        "y": 7.284837599999946
+      },
+      {
+        "x": -26.344905599999947,
+        "y": 7.284837599999946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_4",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -25.492888,
+      "y": 6.293626
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "D2",
+    "ccw_rotation": 180,
+    "pcb_component_id": "pcb_component_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_2",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -23.642687999999907,
+        "y": 7.043625999999904
+      },
+      {
+        "x": -27.343087999999852,
+        "y": 7.043625999999904
+      },
+      {
+        "x": -27.343087999999852,
+        "y": 8.940625999999952
+      },
+      {
+        "x": -23.642687999999907,
+        "y": 8.940625999999952
+      },
+      {
+        "x": -23.642687999999907,
+        "y": 7.043625999999904
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.01,
+    "y": -8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -20.01,
+    "y": -8,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -18.99,
+    "y": -8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -18.99,
+    "y": -8,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_16",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": -18.99,
+        "y": -7.28
+      },
+      {
+        "x": -20.48,
+        "y": -7.28
+      },
+      {
+        "x": -20.48,
+        "y": -8.72
+      },
+      {
+        "x": -18.99,
+        "y": -8.72
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_5",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19.5,
+      "y": -6.78
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C9",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_5",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_2",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "center": {
+      "x": -19.5,
+      "y": -8
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.01,
+    "y": 8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -20.01,
+    "y": 8,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -18.99,
+    "y": 8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -18.99,
+    "y": 8,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_17",
+    "pcb_component_id": "pcb_component_6",
+    "layer": "top",
+    "route": [
+      {
+        "x": -18.99,
+        "y": 8.72
+      },
+      {
+        "x": -20.48,
+        "y": 8.72
+      },
+      {
+        "x": -20.48,
+        "y": 7.28
+      },
+      {
+        "x": -18.99,
+        "y": 7.28
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_6",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19.5,
+      "y": 9.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C10",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_6",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_3",
+    "pcb_component_id": "pcb_component_6",
+    "layer": "top",
+    "center": {
+      "x": -19.5,
+      "y": 8
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.999872,
+    "y": -1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -9.999872,
+    "y": -1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.5,
+    "y": -1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -9.5,
+    "y": -1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.999874,
+    "y": -1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -8.999874,
+    "y": -1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.322456,
+    "y": -0.750062,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -8.322456,
+    "y": -0.750062,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.322456,
+    "y": -0.249936,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -8.322456,
+    "y": -0.249936,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.322456,
+    "y": 0.249936,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -8.322456,
+    "y": 0.249936,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.322456,
+    "y": 0.750062,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -8.322456,
+    "y": 0.750062,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.999874,
+    "y": 1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -8.999874,
+    "y": 1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.5,
+    "y": 1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -9.5,
+    "y": 1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2800096,
+    "height": 0.5050028,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.999872,
+    "y": 1.177544,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.19600672,
+    "height": 0.35350195999999995,
+    "x": -9.999872,
+    "y": 1.177544,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.677544,
+    "y": 0.750062,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -10.677544,
+    "y": 0.750062,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.677544,
+    "y": 0.249936,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -10.677544,
+    "y": 0.249936,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.677544,
+    "y": -0.249936,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -10.677544,
+    "y": -0.249936,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5050028,
+    "height": 0.2800096,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.677544,
+    "y": -0.750062,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.35350195999999995,
+    "height": 0.19600672,
+    "x": -10.677544,
+    "y": -0.750062,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3750036,
+    "height": 1.3750036,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.5,
+    "y": 0,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.96250252,
+    "height": 0.96250252,
+    "x": -9.5,
+    "y": 0,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_18",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": -10.826210200000105,
+        "y": 1.0804906000000756
+      },
+      {
+        "x": -10.826210200000105,
+        "y": 1.326210200000105
+      },
+      {
+        "x": -10.330503799999974,
+        "y": 1.326210200000105
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_19",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.173789800000009,
+        "y": 1.0804906000000756
+      },
+      {
+        "x": -8.173789800000009,
+        "y": 1.326210200000105
+      },
+      {
+        "x": -8.669496200000026,
+        "y": 1.326210200000105
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_20",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": -10.826210200000105,
+        "y": -1.0804906000000756
+      },
+      {
+        "x": -10.826210200000105,
+        "y": -1.326210200000105
+      },
+      {
+        "x": -10.330503799999974,
+        "y": -1.326210200000105
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_21",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.173789800000009,
+        "y": -1.0804906000000756
+      },
+      {
+        "x": -8.173789800000009,
+        "y": -1.326210200000105
+      },
+      {
+        "x": -8.669496200000026,
+        "y": -1.326210200000105
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_7",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -9.4873,
+      "y": 2.4224
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_7",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_3",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -11.172400000000039,
+        "y": 1.672399999999925
+      },
+      {
+        "x": -7.802199999999971,
+        "y": 1.672399999999925
+      },
+      {
+        "x": -7.802199999999971,
+        "y": -2.053399999999897
+      },
+      {
+        "x": -11.172400000000039,
+        "y": -2.053399999999897
+      },
+      {
+        "x": -11.172400000000039,
+        "y": 1.672399999999925
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.01,
+    "y": -4,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_47",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -4.01,
+    "y": -4,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.99,
+    "y": -4,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_48",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -2.99,
+    "y": -4,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_22",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": -2.99,
+        "y": -3.2800000000000002
+      },
+      {
+        "x": -4.48,
+        "y": -3.2800000000000002
+      },
+      {
+        "x": -4.48,
+        "y": -4.72
+      },
+      {
+        "x": -2.99,
+        "y": -4.72
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_8",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -3.5,
+      "y": -2.7800000000000002
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C7",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_8",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_4",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "center": {
+      "x": -3.5,
+      "y": -4
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.325,
+    "y": 4,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_49",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -4.325,
+    "y": 4,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.675,
+    "y": 4,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_50",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -2.675,
+    "y": 4,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_23",
+    "pcb_component_id": "pcb_component_9",
+    "layer": "top",
+    "route": [
+      {
+        "x": -2.675,
+        "y": 4.875
+      },
+      {
+        "x": -4.925,
+        "y": 4.875
+      },
+      {
+        "x": -4.925,
+        "y": 3.125
+      },
+      {
+        "x": -2.675,
+        "y": 3.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_9",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -3.5,
+      "y": 5.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C8",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_9",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_5",
+    "pcb_component_id": "pcb_component_9",
+    "layer": "top",
+    "center": {
+      "x": -3.5,
+      "y": 4
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_47",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -19.825,
+    "y": 6,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_51",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -19.825,
+    "y": 6,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_48",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -18.175,
+    "y": 6,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -18.175,
+    "y": 6,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_24",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "route": [
+      {
+        "x": -18.175,
+        "y": 6.875
+      },
+      {
+        "x": -20.425,
+        "y": 6.875
+      },
+      {
+        "x": -20.425,
+        "y": 5.125
+      },
+      {
+        "x": -18.175,
+        "y": 5.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_10",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19,
+      "y": 7.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_10",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_6",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "center": {
+      "x": -19,
+      "y": 6
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_49",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.4625,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": -20.4625,
+    "y": 14,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_50",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -17.5375,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": -17.5375,
+    "y": 14,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_25",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "route": [
+      {
+        "x": -17.5375,
+        "y": 15.275
+      },
+      {
+        "x": -21.225,
+        "y": 15.275
+      },
+      {
+        "x": -21.225,
+        "y": 12.725
+      },
+      {
+        "x": -17.5375,
+        "y": 12.725
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_11",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19,
+      "y": 15.775
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_11",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_7",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "center": {
+      "x": -19,
+      "y": 14
+    },
+    "width": 4.56,
+    "height": 2.26,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.94996,
+    "y": 11.199896,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -10.94996,
+    "y": 11.199896,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10,
+    "y": 11.199896,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -10,
+    "y": 11.199896,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.05004,
+    "y": 11.199896,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -9.05004,
+    "y": 11.199896,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.05004,
+    "y": 8.800104,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -9.05004,
+    "y": 8.800104,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10,
+    "y": 8.800104,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -10,
+    "y": 8.800104,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_51",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.94996,
+    "y": 8.800104,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_60",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -10.94996,
+    "y": 8.800104,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_26",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.500003000000106,
+        "y": 9.428144400000065
+      },
+      {
+        "x": -8.500003000000106,
+        "y": 9.20000159999995
+      },
+      {
+        "x": -8.570894400000043,
+        "y": 9.20000159999995
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_27",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.500003000000106,
+        "y": 10.571855600000049
+      },
+      {
+        "x": -8.500003000000106,
+        "y": 10.79999840000005
+      },
+      {
+        "x": -8.570894400000043,
+        "y": 10.79999840000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_28",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -11.499997000000008,
+        "y": 9.427941199999964
+      },
+      {
+        "x": -11.499997000000008,
+        "y": 9.20000159999995
+      },
+      {
+        "x": -11.42910560000007,
+        "y": 9.20000159999995
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_29",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -11.499997000000008,
+        "y": 10.572262000000137
+      },
+      {
+        "x": -11.499997000000008,
+        "y": 10.79999840000005
+      },
+      {
+        "x": -11.42910560000007,
+        "y": 10.79999840000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_30",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.500003000000106,
+        "y": 10.571855600000049
+      },
+      {
+        "x": -8.500003000000106,
+        "y": 9.428144400000065
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_31",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -11.499997000000008,
+        "y": 9.427941199999964
+      },
+      {
+        "x": -11.499997000000008,
+        "y": 10.572262000000137
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_12",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -10,
+      "y": 12.752600000000001
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_12",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_4",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -11.748600000000124,
+        "y": 12.00260000000003
+      },
+      {
+        "x": -8.25139999999999,
+        "y": 12.00260000000003
+      },
+      {
+        "x": -8.25139999999999,
+        "y": 7.9973999999999705
+      },
+      {
+        "x": -11.748600000000124,
+        "y": 7.9973999999999705
+      },
+      {
+        "x": -11.748600000000124,
+        "y": 12.00260000000003
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.51,
+    "y": 3,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_61",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -10.51,
+    "y": 3,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.49,
+    "y": 3,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -9.49,
+    "y": 3,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_32",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": -9.49,
+        "y": 3.7199999999999998
+      },
+      {
+        "x": -10.98,
+        "y": 3.7199999999999998
+      },
+      {
+        "x": -10.98,
+        "y": 2.2800000000000002
+      },
+      {
+        "x": -9.49,
+        "y": 2.2800000000000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_13",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -10,
+      "y": 4.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C11",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_13",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_8",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "center": {
+      "x": -10,
+      "y": 3
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_60",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.561973,
+    "y": 10,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 1.3999972,
+    "x": 1.561973,
+    "y": 10,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.561973,
+    "y": 10,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_64",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 1.3999972,
+    "x": -1.561973,
+    "y": 10,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_33",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": -1.4349730000001273,
+        "y": 11.270000000000095
+      },
+      {
+        "x": 1.3590269999999691,
+        "y": 11.270000000000095
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_34",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": -1.56197300000008,
+        "y": 8.730000000000018
+      },
+      {
+        "x": 1.4860269999999218,
+        "y": 8.730000000000018
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_14",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -0.012573,
+      "y": 12.27
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "L1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_14",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_5",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -2.4215729999999667,
+        "y": 11.520000000000095
+      },
+      {
+        "x": 2.396427000000017,
+        "y": 11.520000000000095
+      },
+      {
+        "x": 2.396427000000017,
+        "y": 8.480000000000018
+      },
+      {
+        "x": -2.4215729999999667,
+        "y": 8.480000000000018
+      },
+      {
+        "x": -2.4215729999999667,
+        "y": 11.520000000000095
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_61",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.5375,
+    "y": 6,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_65",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": 6.5375,
+    "y": 6,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.4625,
+    "y": 6,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_66",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": 9.4625,
+    "y": 6,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_35",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.4625,
+        "y": 7.275
+      },
+      {
+        "x": 5.775,
+        "y": 7.275
+      },
+      {
+        "x": 5.775,
+        "y": 4.725
+      },
+      {
+        "x": 9.4625,
+        "y": 4.725
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_15",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 8,
+      "y": 7.775
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C5",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_15",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_9",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "center": {
+      "x": 8,
+      "y": 6
+    },
+    "width": 4.56,
+    "height": 2.26,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.5375,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_67",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": 6.5375,
+    "y": 14,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_64",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.125,
+    "height": 1.75,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.4625,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_68",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7875,
+    "height": 1.2249999999999999,
+    "x": 9.4625,
+    "y": 14,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_36",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.4625,
+        "y": 15.275
+      },
+      {
+        "x": 5.775,
+        "y": 15.275
+      },
+      {
+        "x": 5.775,
+        "y": 12.725
+      },
+      {
+        "x": 9.4625,
+        "y": 12.725
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_16",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 8,
+      "y": 15.775
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_16",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_10",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "center": {
+      "x": 8,
+      "y": 14
+    },
+    "width": 4.56,
+    "height": 2.26,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_69",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.67488,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_69",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 6.67488,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_70",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.323596,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_70",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 7.323596,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_71",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.974852,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_71",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 7.974852,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_72",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.624838,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_72",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 8.624838,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_83",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.725175999999999,
+    "y": 1.996057,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_73",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 4.725175999999999,
+    "y": 1.996057,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_66",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.725175999999999,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_74",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 4.725175999999999,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_67",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.374908,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_75",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 5.374908,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_68",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.025148,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 6.025148,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.275078,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 9.275078,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.625092,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 8.625092,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.975106,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 7.975106,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.32512,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_80",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 7.32512,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_80",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.675134,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_81",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 6.675134,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_81",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.025148,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_82",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 6.025148,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_73",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.274824,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_83",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 9.274824,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_82",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.374908,
+    "y": 1.996057,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_84",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 5.374908,
+    "y": 1.996057,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_65",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.074936,
+    "y": -4.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_85",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 4.074936,
+    "y": -4.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_74",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.92481,
+    "y": -4.000883,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_86",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 9.92481,
+    "y": -4.000883,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_75",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.350012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.925063999999999,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_87",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2450084,
+    "height": 1.045464,
+    "x": 9.925063999999999,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_84",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.450012,
+    "height": 1.49352,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.074936,
+    "y": 2.001137,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_88",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.3150084,
+    "height": 1.045464,
+    "x": 4.074936,
+    "y": 2.001137,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_37",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.310636000000159,
+        "y": -2.9721829999999727
+      },
+      {
+        "x": 3.7091760000000704,
+        "y": -2.9721829999999727
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_38",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.310636000000159,
+        "y": 0.9140169999999443
+      },
+      {
+        "x": 3.6812360000000126,
+        "y": 0.9140169999999443
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_39",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.310636000000159,
+        "y": -2.9721829999999727
+      },
+      {
+        "x": 10.310636000000159,
+        "y": 0.9140169999999443
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_40",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 3.6812360000000126,
+        "y": -2.9721829999999727
+      },
+      {
+        "x": 3.6812360000000126,
+        "y": -1.6005830000000287
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_41",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 3.6812360000000126,
+        "y": -0.48298299999999017
+      },
+      {
+        "x": 3.6812360000000126,
+        "y": 0.9140169999999443
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_42",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": 3.6812360000000126,
+        "y": -0.48298299999999017
+      },
+      {
+        "x": 3.6812360000000126,
+        "y": -1.575208400000065
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_17",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 6.89078,
+      "y": 3.755517
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_6",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 3.224480000000085,
+        "y": 3.0055169999999407
+      },
+      {
+        "x": 10.557080000000155,
+        "y": 3.0055169999999407
+      },
+      {
+        "x": 10.557080000000155,
+        "y": -4.9874829999999974
+      },
+      {
+        "x": 3.224480000000085,
+        "y": -4.9874829999999974
+      },
+      {
+        "x": 3.224480000000085,
+        "y": 3.0055169999999407
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_85",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.01,
+    "y": -8.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -4.01,
+    "y": -8.5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_86",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.99,
+    "y": -8.5,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -2.99,
+    "y": -8.5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_43",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "route": [
+      {
+        "x": -2.99,
+        "y": -7.78
+      },
+      {
+        "x": -4.48,
+        "y": -7.78
+      },
+      {
+        "x": -4.48,
+        "y": -9.22
+      },
+      {
+        "x": -2.99,
+        "y": -9.22
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_18",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -3.5,
+      "y": -7.28
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_18",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_11",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "center": {
+      "x": -3.5,
+      "y": -8.5
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_87",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.51,
+    "y": -3.8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -1.51,
+    "y": -3.8,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_88",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.49,
+    "y": -3.8,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -0.49,
+    "y": -3.8,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_44",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "route": [
+      {
+        "x": -0.49,
+        "y": -3.08
+      },
+      {
+        "x": -1.98,
+        "y": -3.08
+      },
+      {
+        "x": -1.98,
+        "y": -4.52
+      },
+      {
+        "x": -0.49,
+        "y": -4.52
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_19",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -1,
+      "y": -2.58
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_19",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_12",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "center": {
+      "x": -1,
+      "y": -3.8
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "pcb_component_id": "pcb_component_20",
+    "pcb_port_id": "pcb_port_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.51,
+    "y": -0.19999999999999996,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -1.51,
+    "y": -0.19999999999999996,
+    "pcb_component_id": "pcb_component_20",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "pcb_component_id": "pcb_component_20",
+    "pcb_port_id": "pcb_port_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.49,
+    "y": -0.19999999999999996,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": -0.49,
+    "y": -0.19999999999999996,
+    "pcb_component_id": "pcb_component_20",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_45",
+    "pcb_component_id": "pcb_component_20",
+    "layer": "top",
+    "route": [
+      {
+        "x": -0.49,
+        "y": 0.52
+      },
+      {
+        "x": -1.98,
+        "y": 0.52
+      },
+      {
+        "x": -1.98,
+        "y": -0.9199999999999999
+      },
+      {
+        "x": -0.49,
+        "y": -0.9199999999999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_20",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -1,
+      "y": 1.02
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R8",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_20",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_13",
+    "pcb_component_id": "pcb_component_20",
+    "layer": "top",
+    "center": {
+      "x": -1,
+      "y": -0.19999999999999996
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 14.49,
+    "y": 3,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 14.49,
+    "y": 3,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 15.51,
+    "y": 3,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 15.51,
+    "y": 3,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_46",
+    "pcb_component_id": "pcb_component_21",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.51,
+        "y": 3.7199999999999998
+      },
+      {
+        "x": 14.02,
+        "y": 3.7199999999999998
+      },
+      {
+        "x": 14.02,
+        "y": 2.2800000000000002
+      },
+      {
+        "x": 15.51,
+        "y": 2.2800000000000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_21",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 15,
+      "y": 4.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_21",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_14",
+    "pcb_component_id": "pcb_component_21",
+    "layer": "top",
+    "center": {
+      "x": 15,
+      "y": 3
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 18.49,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 18.49,
+    "y": -9,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 19.51,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 19.51,
+    "y": -9,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_47",
+    "pcb_component_id": "pcb_component_22",
+    "layer": "top",
+    "route": [
+      {
+        "x": 19.51,
+        "y": -8.28
+      },
+      {
+        "x": 18.02,
+        "y": -8.28
+      },
+      {
+        "x": 18.02,
+        "y": -9.72
+      },
+      {
+        "x": 19.51,
+        "y": -9.72
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_22",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 19,
+      "y": -7.78
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R9",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_22",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_15",
+    "pcb_component_id": "pcb_component_22",
+    "layer": "top",
+    "center": {
+      "x": 19,
+      "y": -9
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "pcb_component_id": "pcb_component_23",
+    "pcb_port_id": "pcb_port_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 1.6999966,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 20.6999966,
+    "y": -14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 1.18999762,
+    "x": 20.6999966,
+    "y": -14,
+    "pcb_component_id": "pcb_component_23",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "pcb_component_id": "pcb_component_23",
+    "pcb_port_id": "pcb_port_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 1.6999966,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 17.3000034,
+    "y": -14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 1.18999762,
+    "x": 17.3000034,
+    "y": -14,
+    "pcb_component_id": "pcb_component_23",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_48",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.500002999999992,
+        "y": -12.750015199999893
+      },
+      {
+        "x": 20.499996999999894,
+        "y": -12.750040600000034
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_49",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.500002999999992,
+        "y": -15.250035600000047
+      },
+      {
+        "x": 20.499996999999894,
+        "y": -15.250010199999906
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_50",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.500002999999992,
+        "y": -12.918849000000023
+      },
+      {
+        "x": 17.500002999999992,
+        "y": -12.750015199999893
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_51",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.500002999999992,
+        "y": -12.750015199999893
+      },
+      {
+        "x": 20.499996999999894,
+        "y": -12.750015199999893
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_52",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.499996999999894,
+        "y": -12.750015199999893
+      },
+      {
+        "x": 20.499996999999894,
+        "y": -12.918874399999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_53",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.499996999999894,
+        "y": -15.081150999999977
+      },
+      {
+        "x": 20.499996999999894,
+        "y": -15.250010199999906
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_54",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.499996999999894,
+        "y": -15.250010199999906
+      },
+      {
+        "x": 17.500002999999992,
+        "y": -15.250010199999906
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_55",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.500002999999992,
+        "y": -15.250010199999906
+      },
+      {
+        "x": 17.500002999999992,
+        "y": -15.086865999999873
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_23",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 18.983744,
+      "y": -11.73
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "SW1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_23",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_7",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 16.6382440000001,
+        "y": -12.480000000000018
+      },
+      {
+        "x": 21.329244000000017,
+        "y": -12.480000000000018
+      },
+      {
+        "x": 21.329244000000017,
+        "y": -15.519999999999982
+      },
+      {
+        "x": 16.6382440000001,
+        "y": -15.519999999999982
+      },
+      {
+        "x": 16.6382440000001,
+        "y": -12.480000000000018
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 25.49,
+    "y": -14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 25.49,
+    "y": -14,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 26.51,
+    "y": -14,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 26.51,
+    "y": -14,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_56",
+    "pcb_component_id": "pcb_component_24",
+    "layer": "top",
+    "route": [
+      {
+        "x": 26.51,
+        "y": -13.28
+      },
+      {
+        "x": 25.02,
+        "y": -13.28
+      },
+      {
+        "x": 25.02,
+        "y": -14.72
+      },
+      {
+        "x": 26.51,
+        "y": -14.72
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_24",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 26,
+      "y": -12.78
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C6",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_24",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_16",
+    "pcb_component_id": "pcb_component_24",
+    "layer": "top",
+    "center": {
+      "x": 26,
+      "y": -14
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 25.22758,
+    "y": 11.599946,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 25.22758,
+    "y": 11.599946,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 25.22758,
+    "y": 10,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 25.22758,
+    "y": 10,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 25.22758,
+    "y": 8.400054,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 25.22758,
+    "y": 8.400054,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 20.77242,
+    "y": 8.400054,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 20.77242,
+    "y": 8.400054,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 20.77242,
+    "y": 10,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 20.77242,
+    "y": 10,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.1049996,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 20.77242,
+    "y": 11.599946,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.47349972,
+    "height": 0.6860057399999999,
+    "x": 20.77242,
+    "y": 11.599946,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_57",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.42377959999976,
+        "y": 12.576220400000011
+      },
+      {
+        "x": 25.57622040000001,
+        "y": 12.576220400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_58",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.42377959999976,
+        "y": 7.423779599999989
+      },
+      {
+        "x": 25.57622040000001,
+        "y": 7.423779599999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_25",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 22.7841,
+      "y": 13.5908
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "LED1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_25",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_8",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 19.041600000000017,
+        "y": 12.840799999999945
+      },
+      {
+        "x": 26.526599999999917,
+        "y": 12.840799999999945
+      },
+      {
+        "x": 26.526599999999917,
+        "y": 7.159199999999828
+      },
+      {
+        "x": 19.041600000000017,
+        "y": 7.159199999999828
+      },
+      {
+        "x": 19.041600000000017,
+        "y": 12.840799999999945
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_101",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_port_id": "pcb_port_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 16.49,
+    "y": 13,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 16.49,
+    "y": 13,
+    "pcb_component_id": "pcb_component_26",
+    "pcb_smtpad_id": "pcb_smtpad_101",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_102",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_port_id": "pcb_port_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 17.51,
+    "y": 13,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 17.51,
+    "y": 13,
+    "pcb_component_id": "pcb_component_26",
+    "pcb_smtpad_id": "pcb_smtpad_102",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_59",
+    "pcb_component_id": "pcb_component_26",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.51,
+        "y": 13.72
+      },
+      {
+        "x": 16.02,
+        "y": 13.72
+      },
+      {
+        "x": 16.02,
+        "y": 12.28
+      },
+      {
+        "x": 17.51,
+        "y": 12.28
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_26",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 17,
+      "y": 14.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R7",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_26",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_17",
+    "pcb_component_id": "pcb_component_26",
+    "layer": "top",
+    "center": {
+      "x": 17,
+      "y": 13
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_103",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 28.49,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_111",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 28.49,
+    "y": 7,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_103",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_104",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 29.51,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_112",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 29.51,
+    "y": 7,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_104",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_60",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 29.51,
+        "y": 7.72
+      },
+      {
+        "x": 28.02,
+        "y": 7.72
+      },
+      {
+        "x": 28.02,
+        "y": 6.28
+      },
+      {
+        "x": 29.51,
+        "y": 6.28
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_27",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 29,
+      "y": 8.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R6",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_27",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_18",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "center": {
+      "x": 29,
+      "y": 7
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_105",
+    "pcb_component_id": "pcb_component_28",
+    "pcb_port_id": "pcb_port_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 28.49,
+    "y": 13,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_113",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 28.49,
+    "y": 13,
+    "pcb_component_id": "pcb_component_28",
+    "pcb_smtpad_id": "pcb_smtpad_105",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_106",
+    "pcb_component_id": "pcb_component_28",
+    "pcb_port_id": "pcb_port_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 29.51,
+    "y": 13,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_114",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 29.51,
+    "y": 13,
+    "pcb_component_id": "pcb_component_28",
+    "pcb_smtpad_id": "pcb_smtpad_106",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_61",
+    "pcb_component_id": "pcb_component_28",
+    "layer": "top",
+    "route": [
+      {
+        "x": 29.51,
+        "y": 13.72
+      },
+      {
+        "x": 28.02,
+        "y": 13.72
+      },
+      {
+        "x": 28.02,
+        "y": 12.28
+      },
+      {
+        "x": 29.51,
+        "y": 12.28
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_28",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 29,
+      "y": 14.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R5",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_28",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_19",
+    "pcb_component_id": "pcb_component_28",
+    "layer": "top",
+    "center": {
+      "x": 29,
+      "y": 13
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_4",
+    "pcb_component_id": "pcb_component_29",
+    "pcb_port_id": "pcb_port_111",
+    "hole_diameter": 1,
+    "rect_pad_width": 1.5,
+    "rect_pad_height": 1.5,
+    "shape": "circular_hole_with_rect_pad",
+    "port_hints": [
+      "unnamed_platedhole5",
+      "1"
+    ],
+    "x": 32,
+    "y": -14.08,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4",
+    "hole_offset_x": 0,
+    "hole_offset_y": 0,
+    "rect_border_radius": 0,
+    "rect_ccw_rotation": 90
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_29",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.875,
+      "y": -14.08
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "3V3",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_5",
+    "pcb_component_id": "pcb_component_29",
+    "pcb_port_id": "pcb_port_112",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole6",
+      "2"
+    ],
+    "x": 32,
+    "y": -11.54,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_115",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -11.54,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_116",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -11.54,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_30",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.875,
+      "y": -11.54
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "SWDIO",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_6",
+    "pcb_component_id": "pcb_component_29",
+    "pcb_port_id": "pcb_port_113",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole7",
+      "3"
+    ],
+    "x": 32,
+    "y": -9,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_117",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_118",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_31",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.875,
+      "y": -9
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "SWCLK",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_7",
+    "pcb_component_id": "pcb_component_29",
+    "pcb_port_id": "pcb_port_114",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole8",
+      "4"
+    ],
+    "x": 32,
+    "y": -6.46,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_119",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -6.46,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_120",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -6.46,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_32",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.875,
+      "y": -6.46
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "NRST",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_8",
+    "pcb_component_id": "pcb_component_29",
+    "pcb_port_id": "pcb_port_115",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole9",
+      "5"
+    ],
+    "x": 32,
+    "y": -3.92,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_121",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -3.92,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_122",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 32,
+    "y": -3.92,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_33",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.875,
+      "y": -3.92
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "GND",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_34",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 29.46,
+      "y": -9
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.7,
+    "layer": "top",
+    "text": "J1",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_29",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_20",
+    "pcb_component_id": "pcb_component_29",
+    "layer": "top",
+    "center": {
+      "x": 32,
+      "y": -9
+    },
+    "width": 13.7,
+    "height": 3.54,
+    "ccw_rotation": 90,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_9",
+    "pcb_component_id": "pcb_component_30",
+    "pcb_port_id": "pcb_port_116",
+    "outer_diameter": 2.999994,
+    "hole_diameter": 1.700022,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole10",
+      "pin1"
+    ],
+    "x": 36,
+    "y": 7.500640000000001,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_123",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 36,
+    "y": 7.500640000000001,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_124",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 36,
+    "y": 7.500640000000001,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_10",
+    "pcb_component_id": "pcb_component_30",
+    "pcb_port_id": "pcb_port_117",
+    "outer_diameter": 2.999994,
+    "hole_diameter": 1.700022,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole11",
+      "pin2"
+    ],
+    "x": 36,
+    "y": 12.49936,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_125",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 36,
+    "y": 12.49936,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_126",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 36,
+    "y": 12.49936,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_62",
+    "pcb_component_id": "pcb_component_30",
+    "layer": "top",
+    "route": [
+      {
+        "x": 38.83893260000001,
+        "y": 14.236694599999993
+      },
+      {
+        "x": 38.83893260000001,
+        "y": 14.826025399999992
+      },
+      {
+        "x": 33.2060254,
+        "y": 14.826025399999992
+      },
+      {
+        "x": 33.2060254,
+        "y": 5.3010254
+      },
+      {
+        "x": 38.79402540000001,
+        "y": 5.3010254
+      },
+      {
+        "x": 38.79402540000001,
+        "y": 5.809025399999996
+      },
+      {
+        "x": 38.79402540000001,
+        "y": 5.935974600000009
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_63",
+    "pcb_component_id": "pcb_component_30",
+    "layer": "top",
+    "route": [
+      {
+        "x": 38.83893260000001,
+        "y": 9.237974600000001
+      },
+      {
+        "x": 38.83893260000001,
+        "y": 10.9346946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_64",
+    "pcb_component_id": "pcb_component_30",
+    "layer": "top",
+    "route": [
+      {
+        "x": 38.83893260000001,
+        "y": 9.237974600000001
+      },
+      {
+        "x": 39.01958786656786,
+        "y": 9.065090217638485
+      },
+      {
+        "x": 39.17914664747347,
+        "y": 8.872564036460062
+      },
+      {
+        "x": 39.31548866103074,
+        "y": 8.662954422314186
+      },
+      {
+        "x": 39.42680213935857,
+        "y": 8.43904675262469
+      },
+      {
+        "x": 39.51160790388606,
+        "y": 8.203816403166684
+      },
+      {
+        "x": 39.568779021276285,
+        "y": 7.960389210068655
+      },
+      {
+        "x": 39.597555778572726,
+        "y": 7.711999932436299
+      },
+      {
+        "x": 39.597555778572726,
+        "y": 7.461949267563696
+      },
+      {
+        "x": 39.568779021276285,
+        "y": 7.213559989931326
+      },
+      {
+        "x": 39.51160790388606,
+        "y": 6.970132796833312
+      },
+      {
+        "x": 39.42680213935857,
+        "y": 6.734902447375305
+      },
+      {
+        "x": 39.31548866103074,
+        "y": 6.510994777685795
+      },
+      {
+        "x": 39.17914664747347,
+        "y": 6.301385163539919
+      },
+      {
+        "x": 39.01958786656786,
+        "y": 6.108858982361525
+      },
+      {
+        "x": 38.83893260000001,
+        "y": 5.935974600000009
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_65",
+    "pcb_component_id": "pcb_component_30",
+    "layer": "top",
+    "route": [
+      {
+        "x": 38.83893260000001,
+        "y": 14.236694599999993
+      },
+      {
+        "x": 39.01958786656786,
+        "y": 14.063810217638476
+      },
+      {
+        "x": 39.17914664747347,
+        "y": 13.871284036460068
+      },
+      {
+        "x": 39.31548866103074,
+        "y": 13.661674422314206
+      },
+      {
+        "x": 39.42680213935857,
+        "y": 13.437766752624697
+      },
+      {
+        "x": 39.51160790388606,
+        "y": 13.20253640316669
+      },
+      {
+        "x": 39.568779021276285,
+        "y": 12.959109210068647
+      },
+      {
+        "x": 39.597555778572726,
+        "y": 12.71071993243632
+      },
+      {
+        "x": 39.597555778572726,
+        "y": 12.460669267563688
+      },
+      {
+        "x": 39.568779021276285,
+        "y": 12.212279989931332
+      },
+      {
+        "x": 39.51160790388606,
+        "y": 11.968852796833318
+      },
+      {
+        "x": 39.42680213935857,
+        "y": 11.733622447375296
+      },
+      {
+        "x": 39.31548866103074,
+        "y": 11.509714777685787
+      },
+      {
+        "x": 39.17914664747347,
+        "y": 11.30010516353991
+      },
+      {
+        "x": 39.01958786656786,
+        "y": 11.107578982361531
+      },
+      {
+        "x": 38.83893260000001,
+        "y": 10.9346946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_35",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 30.417332000000002,
+      "y": 10.027940000000001
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "CN1",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_30",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_9",
+    "pcb_component_id": "pcb_component_30",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 31.167332000000002,
+        "y": 3.6946399999999926
+      },
+      {
+        "x": 31.167332000000002,
+        "y": 16.361239999999995
+      },
+      {
+        "x": 40.150932,
+        "y": 16.361239999999995
+      },
+      {
+        "x": 40.150932,
+        "y": 3.6946399999999926
+      },
+      {
+        "x": 31.167332000000002,
+        "y": 3.6946399999999926
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -36.0943068,
+    "y": -4.325112,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -40.2741308,
+    "y": -4.325111999999999,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -40.2741308,
+    "y": 4.325112000000001,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -36.0943068,
+    "y": 4.325112,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": 1.7500599999999995,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": 1.2499339999999997,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": 0.7500619999999996,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": 0.2499359999999996,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": -0.24993600000000038,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": -0.7500620000000005,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": -1.2496800000000003,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3259568,
+    "y": -1.7500600000000004,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3250445,
+    "y": 3.1999555999999996,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.325044500000004,
+    "y": -3.2000063000000005,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.325044500000004,
+    "y": -2.4001603000000005,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -35.3250445,
+    "y": 2.3999570999999995,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -26.01,
+    "y": -4.5,
+    "source_port_id": "source_port_16"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -24.99,
+    "y": -4.5,
+    "source_port_id": "source_port_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -26.01,
+    "y": 4.5,
+    "source_port_id": "source_port_18"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -24.99,
+    "y": 4.5,
+    "source_port_id": "source_port_19"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -26.704976,
+    "y": -8,
+    "source_port_id": "source_port_20"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -24.295024,
+    "y": -8,
+    "source_port_id": "source_port_21"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -24.295024,
+    "y": 8,
+    "source_port_id": "source_port_22"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -26.704976,
+    "y": 8,
+    "source_port_id": "source_port_23"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -20.01,
+    "y": -8,
+    "source_port_id": "source_port_24"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -18.99,
+    "y": -8,
+    "source_port_id": "source_port_25"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -20.01,
+    "y": 8,
+    "source_port_id": "source_port_26"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -18.99,
+    "y": 8,
+    "source_port_id": "source_port_27"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -9.999872,
+    "y": -1.177544,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -9.5,
+    "y": -1.177544,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.999874,
+    "y": -1.177544,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.322456,
+    "y": -0.750062,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.322456,
+    "y": -0.249936,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.322456,
+    "y": 0.249936,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.322456,
+    "y": 0.750062,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -8.999874,
+    "y": 1.177544,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -9.5,
+    "y": 1.177544,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -9.999872,
+    "y": 1.177544,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -10.677544,
+    "y": 0.750062,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_39",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -10.677544,
+    "y": 0.249936,
+    "source_port_id": "source_port_39"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_40",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -10.677544,
+    "y": -0.249936,
+    "source_port_id": "source_port_40"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_41",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -10.677544,
+    "y": -0.750062,
+    "source_port_id": "source_port_41"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_42",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -9.5,
+    "y": 0,
+    "source_port_id": "source_port_42"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_43",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -4.01,
+    "y": -4,
+    "source_port_id": "source_port_43"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_44",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -2.99,
+    "y": -4,
+    "source_port_id": "source_port_44"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_45",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -4.325,
+    "y": 4,
+    "source_port_id": "source_port_45"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_46",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_0",
+    "x": -2.675,
+    "y": 4,
+    "source_port_id": "source_port_46"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_47",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -19.825,
+    "y": 6,
+    "source_port_id": "source_port_47"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_48",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -18.175,
+    "y": 6,
+    "source_port_id": "source_port_48"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_49",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -20.4625,
+    "y": 14,
+    "source_port_id": "source_port_49"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_50",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -17.5375,
+    "y": 14,
+    "source_port_id": "source_port_50"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_51",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -10.94996,
+    "y": 8.800104,
+    "source_port_id": "source_port_51"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_52",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -10,
+    "y": 8.800104,
+    "source_port_id": "source_port_52"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_53",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -9.05004,
+    "y": 8.800104,
+    "source_port_id": "source_port_53"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_54",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -9.05004,
+    "y": 11.199896,
+    "source_port_id": "source_port_54"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_55",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -10,
+    "y": 11.199896,
+    "source_port_id": "source_port_55"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_56",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -10.94996,
+    "y": 11.199896,
+    "source_port_id": "source_port_56"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_57",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -10.51,
+    "y": 3,
+    "source_port_id": "source_port_57"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_58",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -9.49,
+    "y": 3,
+    "source_port_id": "source_port_58"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_59",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": -1.561973,
+    "y": 10,
+    "source_port_id": "source_port_59"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_60",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": 1.561973,
+    "y": 10,
+    "source_port_id": "source_port_60"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_61",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": 6.5375,
+    "y": 6,
+    "source_port_id": "source_port_61"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_62",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": 9.4625,
+    "y": 6,
+    "source_port_id": "source_port_62"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_63",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": 6.5375,
+    "y": 14,
+    "source_port_id": "source_port_63"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_64",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_1",
+    "x": 9.4625,
+    "y": 14,
+    "source_port_id": "source_port_64"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_65",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 4.074936,
+    "y": -4.001137,
+    "source_port_id": "source_port_65"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_66",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 4.725175999999999,
+    "y": -4.000883,
+    "source_port_id": "source_port_66"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_67",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 5.374908,
+    "y": -4.000883,
+    "source_port_id": "source_port_67"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_68",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 6.025148,
+    "y": -4.000883,
+    "source_port_id": "source_port_68"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_69",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 6.67488,
+    "y": -4.000883,
+    "source_port_id": "source_port_69"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_70",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7.323596,
+    "y": -4.000883,
+    "source_port_id": "source_port_70"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_71",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7.974852,
+    "y": -4.000883,
+    "source_port_id": "source_port_71"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_72",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 8.624838,
+    "y": -4.000883,
+    "source_port_id": "source_port_72"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_73",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 9.274824,
+    "y": -4.000883,
+    "source_port_id": "source_port_73"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_74",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 9.92481,
+    "y": -4.000883,
+    "source_port_id": "source_port_74"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_75",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 9.925063999999999,
+    "y": 2.001137,
+    "source_port_id": "source_port_75"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_76",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 9.275078,
+    "y": 2.001137,
+    "source_port_id": "source_port_76"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_77",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 8.625092,
+    "y": 2.001137,
+    "source_port_id": "source_port_77"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_78",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7.975106,
+    "y": 2.001137,
+    "source_port_id": "source_port_78"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_79",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7.32512,
+    "y": 2.001137,
+    "source_port_id": "source_port_79"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_80",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 6.675134,
+    "y": 2.001137,
+    "source_port_id": "source_port_80"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_81",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 6.025148,
+    "y": 2.001137,
+    "source_port_id": "source_port_81"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_82",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 5.374908,
+    "y": 1.996057,
+    "source_port_id": "source_port_82"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_83",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 4.725175999999999,
+    "y": 1.996057,
+    "source_port_id": "source_port_83"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_84",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 4.074936,
+    "y": 2.001137,
+    "source_port_id": "source_port_84"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_85",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -4.01,
+    "y": -8.5,
+    "source_port_id": "source_port_85"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_86",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.99,
+    "y": -8.5,
+    "source_port_id": "source_port_86"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_87",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -1.51,
+    "y": -3.8,
+    "source_port_id": "source_port_87"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_88",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -0.49,
+    "y": -3.8,
+    "source_port_id": "source_port_88"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_89",
+    "pcb_component_id": "pcb_component_20",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -1.51,
+    "y": -0.19999999999999996,
+    "source_port_id": "source_port_89"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_90",
+    "pcb_component_id": "pcb_component_20",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": -0.49,
+    "y": -0.19999999999999996,
+    "source_port_id": "source_port_90"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_91",
+    "pcb_component_id": "pcb_component_21",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 14.49,
+    "y": 3,
+    "source_port_id": "source_port_91"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_92",
+    "pcb_component_id": "pcb_component_21",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 15.51,
+    "y": 3,
+    "source_port_id": "source_port_92"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_93",
+    "pcb_component_id": "pcb_component_22",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 18.49,
+    "y": -9,
+    "source_port_id": "source_port_93"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_94",
+    "pcb_component_id": "pcb_component_22",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 19.51,
+    "y": -9,
+    "source_port_id": "source_port_94"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_95",
+    "pcb_component_id": "pcb_component_23",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 17.3000034,
+    "y": -14,
+    "source_port_id": "source_port_95"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_96",
+    "pcb_component_id": "pcb_component_23",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 20.6999966,
+    "y": -14,
+    "source_port_id": "source_port_96"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_97",
+    "pcb_component_id": "pcb_component_24",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 25.49,
+    "y": -14,
+    "source_port_id": "source_port_97"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_98",
+    "pcb_component_id": "pcb_component_24",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_2",
+    "x": 26.51,
+    "y": -14,
+    "source_port_id": "source_port_98"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_99",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 20.77242,
+    "y": 11.599946,
+    "source_port_id": "source_port_99"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_100",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 20.77242,
+    "y": 10,
+    "source_port_id": "source_port_100"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_101",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 20.77242,
+    "y": 8.400054,
+    "source_port_id": "source_port_101"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_102",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 25.22758,
+    "y": 8.400054,
+    "source_port_id": "source_port_102"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_103",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 25.22758,
+    "y": 10,
+    "source_port_id": "source_port_103"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_104",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 25.22758,
+    "y": 11.599946,
+    "source_port_id": "source_port_104"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_105",
+    "pcb_component_id": "pcb_component_26",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 16.49,
+    "y": 13,
+    "source_port_id": "source_port_105"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_106",
+    "pcb_component_id": "pcb_component_26",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 17.51,
+    "y": 13,
+    "source_port_id": "source_port_106"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_107",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 28.49,
+    "y": 7,
+    "source_port_id": "source_port_107"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_108",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 29.51,
+    "y": 7,
+    "source_port_id": "source_port_108"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_109",
+    "pcb_component_id": "pcb_component_28",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 28.49,
+    "y": 13,
+    "source_port_id": "source_port_109"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_110",
+    "pcb_component_id": "pcb_component_28",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "pcb_group_id": "pcb_group_3",
+    "x": 29.51,
+    "y": 13,
+    "source_port_id": "source_port_110"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_111",
+    "pcb_component_id": "pcb_component_29",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 32,
+    "y": -14.08,
+    "source_port_id": "source_port_111"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_112",
+    "pcb_component_id": "pcb_component_29",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 32,
+    "y": -11.54,
+    "source_port_id": "source_port_112"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_113",
+    "pcb_component_id": "pcb_component_29",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 32,
+    "y": -9,
+    "source_port_id": "source_port_113"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_114",
+    "pcb_component_id": "pcb_component_29",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 32,
+    "y": -6.46,
+    "source_port_id": "source_port_114"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_115",
+    "pcb_component_id": "pcb_component_29",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 32,
+    "y": -3.92,
+    "source_port_id": "source_port_115"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_116",
+    "pcb_component_id": "pcb_component_30",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 36,
+    "y": 7.500640000000001,
+    "source_port_id": "source_port_116"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_117",
+    "pcb_component_id": "pcb_component_30",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "x": 36,
+    "y": 12.49936,
+    "source_port_id": "source_port_117"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": -37.949587050000005,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C165948.obj?uuid=617b05f9bba7410b96c001093d8189e4&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C165948.step?uuid=617b05f9bba7410b96c001093d8189e4&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": -2.4499977999999945,
+      "z": 0.000010999999999872223
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": -25.5,
+      "y": -4.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": -25.5,
+      "y": 4.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": -25.5,
+      "y": -8,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5261083.obj?uuid=5284e5723bda45e1a33dc55b8531c926&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5261083.step?uuid=5284e5723bda45e1a33dc55b8531c926&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_4",
+    "position": {
+      "x": -25.5,
+      "y": 8,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5261083.obj?uuid=5284e5723bda45e1a33dc55b8531c926&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5261083.step?uuid=5284e5723bda45e1a33dc55b8531c926&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_5",
+    "position": {
+      "x": -19.5,
+      "y": -8,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_5",
+    "source_component_id": "source_component_5",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_6",
+    "position": {
+      "x": -19.5,
+      "y": 8,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_6",
+    "source_component_id": "source_component_6",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_7",
+    "position": {
+      "x": -9.5,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_7",
+    "source_component_id": "source_component_7",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C132291.obj?uuid=15f87957851c46e8a4907d2de7265707&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C132291.step?uuid=15f87957851c46e8a4907d2de7265707&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_8",
+    "position": {
+      "x": -3.5,
+      "y": -4,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_8",
+    "source_component_id": "source_component_8",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_9",
+    "position": {
+      "x": -3.5,
+      "y": 4,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_9",
+    "source_component_id": "source_component_9",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_10",
+    "position": {
+      "x": -19,
+      "y": 6,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_10",
+    "source_component_id": "source_component_10",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_11",
+    "position": {
+      "x": -19,
+      "y": 14,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_11",
+    "source_component_id": "source_component_11",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "1206"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_12",
+    "position": {
+      "x": -10,
+      "y": 10,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_12",
+    "source_component_id": "source_component_12",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C780769.obj?uuid=2b6da6256cae46a8bf22c2998bde16a5&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C780769.step?uuid=2b6da6256cae46a8bf22c2998bde16a5&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": -0.62
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_13",
+    "position": {
+      "x": -10,
+      "y": 3,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_13",
+    "source_component_id": "source_component_13",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_14",
+    "position": {
+      "x": 0,
+      "y": 10,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_14",
+    "source_component_id": "source_component_14",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C89023.obj?uuid=9068841e93dc49a4a4c155ffc16c3f52&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C89023.step?uuid=9068841e93dc49a4a4c155ffc16c3f52&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": -0.08
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_15",
+    "position": {
+      "x": 8,
+      "y": 6,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_15",
+    "source_component_id": "source_component_15",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "1206"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_16",
+    "position": {
+      "x": 8,
+      "y": 14,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_16",
+    "source_component_id": "source_component_16",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "1206"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_17",
+    "position": {
+      "x": 6.975,
+      "y": -1,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_17",
+    "source_component_id": "source_component_17",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C89040.obj?uuid=249766f0d87f42aa9cac81470f61c365&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C89040.step?uuid=249766f0d87f42aa9cac81470f61c365&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": -0.1
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_18",
+    "position": {
+      "x": -3.5,
+      "y": -8.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_18",
+    "source_component_id": "source_component_18",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_19",
+    "position": {
+      "x": -1,
+      "y": -3.8,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_19",
+    "source_component_id": "source_component_19",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_20",
+    "position": {
+      "x": -1,
+      "y": -0.19999999999999998,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_20",
+    "source_component_id": "source_component_20",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_21",
+    "position": {
+      "x": 15,
+      "y": 3,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_21",
+    "source_component_id": "source_component_21",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_22",
+    "position": {
+      "x": 19,
+      "y": -9,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_22",
+    "source_component_id": "source_component_22",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_23",
+    "position": {
+      "x": 19,
+      "y": -14,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_23",
+    "source_component_id": "source_component_23",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C231329.obj?uuid=d904b040d8194ce99b3ace65083437b8&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C231329.step?uuid=d904b040d8194ce99b3ace65083437b8&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0,
+      "z": -0.01
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_24",
+    "position": {
+      "x": 26,
+      "y": -14,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_24",
+    "source_component_id": "source_component_24",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_25",
+    "position": {
+      "x": 17,
+      "y": 13,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_26",
+    "source_component_id": "source_component_26",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_26",
+    "position": {
+      "x": 29,
+      "y": 7,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_27",
+    "source_component_id": "source_component_27",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_27",
+    "position": {
+      "x": 29,
+      "y": 13,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_28",
+    "source_component_id": "source_component_28",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_28",
+    "position": {
+      "x": 32,
+      "y": -9,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_29",
+    "source_component_id": "source_component_29",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "pinrow5_p2.54"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_29",
+    "position": {
+      "x": 36,
+      "y": 10,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 270
+    },
+    "pcb_component_id": "pcb_component_30",
+    "source_component_id": "source_component_30",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C8445.obj?uuid=0a1343c7c59747e08d9fc33a31abb7dd&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C8445.step?uuid=0a1343c7c59747e08d9fc33a31abb7dd&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 2.54,
+      "y": 4.075492800000002,
+      "z": -6.100007
+    }
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_3U7RJieeBr",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#59 name=\".C10\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1530 (copper IoU 0.7249).",
+    "source_component_id": "source_component_6",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1530",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_whcaKATKV8",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#216 name=\".R4\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25879 (copper IoU 0.7741).",
+    "source_component_id": "source_component_19",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25879",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_lLlf7ppFOB",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#204 name=\".R3\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25879 (copper IoU 0.7741).",
+    "source_component_id": "source_component_18",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25879",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_N3MoYL7xCw",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#287 name=\".R7\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25879 (copper IoU 0.7741).",
+    "source_component_id": "source_component_26",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_group_id": "pcb_group_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25879",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_x4lLK5YacL",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#267 name=\".C6\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1525 (copper IoU 0.7249).",
+    "source_component_id": "source_component_24",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1525",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_u2J63nagTI",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#311 name=\".R5\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25879 (copper IoU 0.7741).",
+    "source_component_id": "source_component_28",
+    "pcb_component_id": "pcb_component_28",
+    "pcb_group_id": "pcb_group_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25879",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_OFzSAkYCzb",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#299 name=\".R6\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25908 (copper IoU 0.7741).",
+    "source_component_id": "source_component_27",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_group_id": "pcb_group_3",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25908",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_A5Chpn2Vt0",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#228 name=\".R8\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25900 (copper IoU 0.7741).",
+    "source_component_id": "source_component_20",
+    "pcb_component_id": "pcb_component_20",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25900",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_5xqJ8qRd4D",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#29 name=\".R2\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25076 (copper IoU 0.7741).",
+    "source_component_id": "source_component_2",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25076",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_YODeFRQX5P",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#87 name=\".C7\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1525 (copper IoU 0.7249).",
+    "source_component_id": "source_component_8",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1525",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_U3UGfjoyc8",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#252 name=\".R9\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25744 (copper IoU 0.7741).",
+    "source_component_id": "source_component_22",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25744",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_1tMNAEHBl8",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#143 name=\".C11\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1525 (copper IoU 0.7249).",
+    "source_component_id": "source_component_13",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_group_id": "pcb_group_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1525",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_QL3bb3LwWU",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#47 name=\".C9\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1530 (copper IoU 0.7249).",
+    "source_component_id": "source_component_5",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1530",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_CMgDXW9c7K",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#240 name=\".C1\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1525 (copper IoU 0.7249).",
+    "source_component_id": "source_component_21",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1525",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_x0PvAFuhby",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<resistor#17 name=\".R1\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C25076 (copper IoU 0.7741).",
+    "source_component_id": "source_component_1",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C25076",
+    "footprint_copper_intersection_over_union": 0.7741
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_6_mst0_0",
+    "connection_name": "source_net_6",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 17.3,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_95"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.3,
+        "y": -11.21,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.51,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_94"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_6_mst1_0",
+    "connection_name": "source_net_6",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 25.49,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_97"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.491878361081085,
+        "y": -13.767195430167606,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.12225975815704,
+        "y": -10.39246621121695,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.90689905414844,
+        "y": -10.396899054148438,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.51,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_94"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_6_mst2_0",
+    "connection_name": "source_net_6",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 19.51,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_94"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.51,
+        "y": -8.523123302518778,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.526286630115173,
+        "y": -8.506836672403606,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.526286630115173,
+        "y": -8.445713369884826,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.556968670857522,
+        "y": -8.349,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 19.556968670857522,
+        "y": -8.349,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 19.556968670857522,
+        "y": -8.349,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.320743216083201,
+        "y": -8.437,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.523338199489455,
+        "y": -3.639594983406254,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.056594983406255,
+        "y": -3.639594983406254,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.328306267443364,
+        "y": -2.9113062674433636,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.327,
+        "y": -2.91,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 4.327,
+        "y": -2.91,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 4.327,
+        "y": -2.91,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.893791152606526,
+        "y": -2.91,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.278093101230791,
+        "y": -3.2943019486242653,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.278093101230791,
+        "y": -3.9040931012307913,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.375,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_67"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst0_0",
+    "connection_name": "source_net_5",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.99,
+        "y": -8.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_86"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.519,
+        "y": -8.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.498876786508575,
+        "y": -8.479876786508575,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3890000000000002,
+        "y": -8.475,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.3890000000000002,
+        "y": -8.475,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3890000000000002,
+        "y": -8.475,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.494,
+        "y": -7.778243819122327,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.18252420429976,
+        "y": -5.089719614822568,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.18252420429976,
+        "y": -5.01647579570024,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.199,
+        "y": -5,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -5.199,
+        "y": -5,
+        "from_layer": "inner1",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -5.199,
+        "y": -5,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.199,
+        "y": -2.0165367640399436,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.20915728036114,
+        "y": -2.0063794836788036,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.20915728036114,
+        "y": -1.8548427196388604,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.211,
+        "y": -1.853,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -5.211,
+        "y": -1.853,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -5.211,
+        "y": -1.853,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.211,
+        "y": -1.046623878087105,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.923367671160981,
+        "y": 0.6657437930738754,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.237743793073875,
+        "y": 0.6657437930738754,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.322,
+        "y": 0.75,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_34"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_5"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst1_0",
+    "connection_name": "source_net_5",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.99,
+        "y": -8.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_86"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9781659697753295,
+        "y": -8.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.3113940045591135,
+        "y": -6.210440025665557,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.3395599743344433,
+        "y": -6.210440025665557,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.416,
+        "y": -6.134,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.416,
+        "y": -6.134,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 1.416,
+        "y": -6.134,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.8892422467756558,
+        "y": -6.134,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.0681846250421945,
+        "y": -2.9550576217334616,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.0681846250421945,
+        "y": -0.6577857245883645,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.784699450226915,
+        "y": -0.3743005497730852,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.795,
+        "y": -0.364,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 4.795,
+        "y": -0.364,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 4.795,
+        "y": -0.364,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.375,
+        "y": 0.21600000000000008,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.375,
+        "y": 1.996,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_82"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_5"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst0_0",
+    "connection_name": "source_net_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_88"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.8422948850995307,
+        "y": -1.4677051149004692,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.8422948850995309,
+        "y": 1.2338386172486016,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5360689690741447,
+        "y": 1.5400645332739877,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5360689690741447,
+        "y": 2.8565150181101604,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.6428436844642809,
+        "y": 2.9632897335002966,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.678869068195431,
+        "y": 2.9632897335002966,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.025,
+        "y": 2.6171588016957275,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.025,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_81"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst1_0",
+    "connection_name": "source_net_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_88"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -3.3074224143357207,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.4950450734297769,
+        "y": -3.302377340905944,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.4950450734297769,
+        "y": -3.2919549265702233,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.555,
+        "y": -3.149,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -0.555,
+        "y": -3.149,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -0.555,
+        "y": -3.149,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.437374670291948,
+        "y": -3.232,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.110776459799925,
+        "y": -1.5585982104920235,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.110776459799925,
+        "y": -0.7672235402000757,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.786537266582293,
+        "y": -0.09146273341770723,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.83,
+        "y": -0.048,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -6.83,
+        "y": -0.048,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -6.83,
+        "y": -0.048,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.128,
+        "y": 0.25,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.322,
+        "y": 0.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_33"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -0.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_90"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -0.650129646504664,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.1160667089393814,
+        "y": -2.2761963554440454,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.04616181509945,
+        "y": -2.2761963554440454,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.072358170543495,
+        "y": -0.25,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.322,
+        "y": -0.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_32"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.49,
+        "y": -0.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_90"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.35399999999999987,
+        "y": -0.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.3479191137289177,
+        "y": 0.7939191137289178,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.407,
+        "y": 0.853,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.407,
+        "y": 0.853,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 1.407,
+        "y": 0.853,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.040343233693947,
+        "y": 3.4863432336939466,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.195195033195512,
+        "y": 3.4863432336939466,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.195195033195512,
+        "y": 3.560195033195513,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.276,
+        "y": 3.6410000000000005,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 8.276,
+        "y": 3.6410000000000005,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 8.276,
+        "y": 3.6410000000000005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.975,
+        "y": 3.3400000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.975,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_78"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst0_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -8.322,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_31"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.572,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9,
+        "y": -1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_30"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst1_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 25.228,
+        "y": 8.4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_102"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.228,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_103"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst2_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 25.228,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_103"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.13318012392177,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.846752314947317,
+        "y": 10.28642780897445,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.795553609875903,
+        "y": 10.28642780897445,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.732151090101958,
+        "y": 10.345080486683996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 23.732151090101958,
+        "y": 10.345080486683996,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 23.732151090101958,
+        "y": 10.345080486683996,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.732151297341822,
+        "y": 10.585558777320074,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.332460451748627,
+        "y": 12.185867931726879,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.332460451748627,
+        "y": 12.342539548251374,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.292,
+        "y": 12.420950099999999,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 25.292,
+        "y": 12.420950099999999,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 25.292,
+        "y": 12.420950099999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.292,
+        "y": 11.664,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.228,
+        "y": 11.6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_104"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst3_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_87"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9897381204382925,
+        "y": -3.3202618795617074,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.01,
+        "y": -3.3202618795617074,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.01,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_43"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -0.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_89"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -0.6980496386257641,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5086974799029949,
+        "y": -0.6993521587227692,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5086974799029949,
+        "y": -0.9103025200970051,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.503,
+        "y": -0.916,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -1.503,
+        "y": -0.916,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -1.503,
+        "y": -0.916,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.503,
+        "y": -2.661475763448691,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5007436565222658,
+        "y": -2.6637321069264255,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5007436565222658,
+        "y": -2.6957436565222657,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.501,
+        "y": -2.6959999999999997,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -1.501,
+        "y": -2.6959999999999997,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -1.501,
+        "y": -2.6959999999999997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.501,
+        "y": -3.7909999999999995,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_87"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst5_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_80"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": 5.863,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.538,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_61"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst6_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -4.01,
+        "y": -8.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_85"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.01,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_43"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst7_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -0.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_89"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": 1.1849999999999996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.325,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_45"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst8_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -4.01,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_43"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.071999999999999,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.322,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_31"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst9_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_80"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": -1.4018248825705109,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.277566891536807,
+        "y": -2.0043917741073183,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.277566891536807,
+        "y": -2.6754762097188167,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.691772058984691,
+        "y": -3.261271042270933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.691772058984691,
+        "y": -3.984227941015309,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_69"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst10_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.538,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_61"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.562,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.562,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_60"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst11_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.538,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_63"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.562,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.562,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_60"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst12_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.95,
+        "y": 8.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_51"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.95,
+        "y": 7.7026647636020105,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.84210944600381,
+        "y": 7.594774209605822,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.84210944600381,
+        "y": 7.49710944600381,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.772,
+        "y": 7.427,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -10.772,
+        "y": 7.427,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -10.772,
+        "y": 7.427,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.18564530242021,
+        "y": 7.427,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.745555547888271,
+        "y": 3.9869102454680605,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.664910245468061,
+        "y": 3.9869102454680605,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.581,
+        "y": 3.903,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -6.581,
+        "y": 3.903,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -6.581,
+        "y": 3.903,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.422000000000001,
+        "y": 3.903,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.325,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_45"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst13_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.51,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_87"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3270061641425792,
+        "y": -3.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.1028914096010254,
+        "y": -4.024114754541554,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9748208095107894,
+        "y": -4.247662249644881,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.7392759316716129,
+        "y": -4.326362526886166,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5000699022015597,
+        "y": -4.3100000000000005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.29019902635406686,
+        "y": -4.321246407508385,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.0641730852226251,
+        "y": -4.290369714200918,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.01929576483944953,
+        "y": -4.224322231803266,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.313859481795728,
+        "y": -4.224322231803266,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.9321931477020735,
+        "y": -1.6059885658969208,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.958513583942838,
+        "y": -1.6059885658969208,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.238900771960616,
+        "y": -1.886375753914699,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.238900771960616,
+        "y": -2.8103287398254264,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.657223808564664,
+        "y": -3.3920057032213786,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.657223808564664,
+        "y": -3.9832238085646647,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_69"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst14_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 18.49,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_93"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.566188444871601,
+        "y": -3.069372297413966,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.854034070373291,
+        "y": -3.0572173245544625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.854017952879651,
+        "y": -3.8219820471203487,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.675,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_69"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst15_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -14.08,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_111"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.55139015309134,
+        "y": -14.08,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.570577344645155,
+        "y": -12.099187191553813,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.570577344645155,
+        "y": -12.066577344645154,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.45399972667971,
+        "y": -11.954196052479555,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 28.45399972667971,
+        "y": -11.954196052479555,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 28.45399972667971,
+        "y": -11.954196052479555,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.454,
+        "y": -10.796999999999999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.326221763594173,
+        "y": -9.669221763594171,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.306,
+        "y": -9.649,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 27.306,
+        "y": -9.649,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 27.306,
+        "y": -9.649,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.092494996096686,
+        "y": -9.649,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.65433429052587,
+        "y": -8.210839294429183,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.602839294429184,
+        "y": -8.210839294429183,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.6,
+        "y": -8.208,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 24.6,
+        "y": -8.208,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 24.6,
+        "y": -8.208,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.23609396594806,
+        "y": -7.84409396594806,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.30290603405194,
+        "y": -7.84409396594806,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.16503132914248,
+        "y": -7.929887770117709,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 19.16503132914248,
+        "y": -7.929887770117709,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 19.16503132914248,
+        "y": -7.929887770117709,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.49,
+        "y": -8.657000000000004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.49,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_93"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst16_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 25.228,
+        "y": 8.4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_102"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.646103816494055,
+        "y": 8.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.466892950412223,
+        "y": 7.22078913391817,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.447868279573388,
+        "y": 7.207744801006057,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 23.447868279573388,
+        "y": 7.207744801006057,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 23.447868279573388,
+        "y": 7.207744801006057,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.447868529307794,
+        "y": -2.5560006468390686,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.850174282292542,
+        "y": -7.15369489385432,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.850174282292542,
+        "y": -7.153825717707457,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.805,
+        "y": -7.199,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 18.805,
+        "y": -7.199,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 18.805,
+        "y": -7.199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.805,
+        "y": -8.684999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.49,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_93"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst0_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.5,
+        "y": 1.178,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_36"
+      },
+      {
+        "route_type": "wire",
+        "x": -9,
+        "y": 1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_35"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst1_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.5,
+        "y": 0,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_42"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.5,
+        "y": 1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_36"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst2_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": -4.325,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": -3.9689999999999985,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_13"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst3_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": 4.325,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_3"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": 3.9689999999999985,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": 3.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_12"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.175,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_48"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.431,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.264827438826686,
+        "y": 6.166172561173315,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.236,
+        "y": 6.195,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -17.236,
+        "y": 6.195,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -17.236,
+        "y": 6.195,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.236,
+        "y": 7.658548399456242,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.25872580027188,
+        "y": 7.68127419972812,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.183,
+        "y": 7.757,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "via",
+        "x": -17.183,
+        "y": 7.757,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -17.183,
+        "y": 7.757,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.747,
+        "y": 7.757,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_27"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst5_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": -4.325,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -40.274,
+        "y": -4.325,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_1"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst6_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -40.274,
+        "y": 4.325,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_2"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.094,
+        "y": 4.325,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_3"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst7_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.325,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_79"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.325,
+        "y": 3.862000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.463,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_62"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst8_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_25"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.520146933179284,
+        "y": -8.530146933179283,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.764853066820717,
+        "y": -8.530146933179283,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.295,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_21"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst9_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 26.51,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_98"
+      },
+      {
+        "route_type": "wire",
+        "x": 25.97986274622113,
+        "y": -14.530137253778872,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.23013725377887,
+        "y": -14.530137253778872,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.7,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_96"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst10_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_27"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": 12.547500000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.5375,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_50"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst11_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_13"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.18634427790837,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.41176893298171,
+        "y": -2.425424655073342,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.41176893298171,
+        "y": -2.423768932981709,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.287,
+        "y": -2.299,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -33.287,
+        "y": -2.299,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -33.287,
+        "y": -2.299,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.287,
+        "y": 1.7414548334208537,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.248077527214484,
+        "y": 1.7803773062063688,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.248077527214484,
+        "y": 1.8900775272144827,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.21676921968396,
+        "y": 1.9850338138800454,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "via",
+        "x": -33.21676921968396,
+        "y": 1.9850338138800454,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -33.21676921968396,
+        "y": 1.9850338138800454,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.558,
+        "y": 3.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": 3.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_12"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 15.51,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_92"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.00139114383888,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.42162547474839,
+        "y": 4.42023433090951,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.42336649178661,
+        "y": 6.111817168159153,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.19449803806894,
+        "y": 7.339807471050064,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.605833308681976,
+        "y": 7.338505316273582,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.315267581031412,
+        "y": 7.629071043924148,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.295348578680223,
+        "y": 7.648990046275336,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 14.295348578680223,
+        "y": 7.648990046275336,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 14.295348578680223,
+        "y": 7.648990046275336,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.702555878390903,
+        "y": 7.648990046275336,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.239180923596649,
+        "y": 7.185615091481082,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.155615091481081,
+        "y": 7.185615091481082,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.076,
+        "y": 7.106,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 11.076,
+        "y": 7.106,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 11.076,
+        "y": 7.106,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.568999999999999,
+        "y": 7.106,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.463,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_62"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst13_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.32512,
+        "y": 2.001137,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_79"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.32512,
+        "y": 2.751137,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.32512,
+        "y": 2.9581199999999996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.347,
+        "y": 3.078897,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 7.347,
+        "y": 3.078897,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 7.347,
+        "y": 3.078897,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.347,
+        "y": -3.871897579190615,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.356426584660326,
+        "y": -4.862470994530289,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.356426584660326,
+        "y": -4.880573415339674,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.2762529829672955,
+        "y": -5.079017327296704,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "via",
+        "x": 6.2762529829672955,
+        "y": -5.079017327296704,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 6.2762529829672955,
+        "y": -5.079017327296704,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.316171953376362,
+        "y": -4.976,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.748253326600523,
+        "y": -4.408081373224162,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.748253326600523,
+        "y": -4.3278196733994765,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.074936,
+        "y": -4.001137,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_65"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.675,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_46"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.344594618405769,
+        "y": 4.669594618405769,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.6418502230177205,
+        "y": 4.669594618405769,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9,
+        "y": 2.31144484142349,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9,
+        "y": 1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_35"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst15_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3.8999300000000003,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_65"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.3849214234216283,
+        "y": -4.560024090155219,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4538073086820495,
+        "y": -4.602638677245246,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4738422727163956,
+        "y": -4.516157727283605,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.99,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_44"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.99,
+        "y": -4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_44"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.99,
+        "y": -4.199392452129551,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.247292403947831,
+        "y": -4.94210004818172,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.247292403947831,
+        "y": -4.97770759605217,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.237,
+        "y": -4.988,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.237,
+        "y": -4.988,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -2.237,
+        "y": -4.988,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.237,
+        "y": -3.0744356269790156,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.186015718846698,
+        "y": 0.8745800918676824,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.186015718846698,
+        "y": 0.8870157188466976,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.251,
+        "y": 0.952,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "via",
+        "x": -6.251,
+        "y": 0.952,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -6.251,
+        "y": 0.952,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.427661505213594,
+        "y": 1.1286615052135933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.925726038523353,
+        "y": 1.1286615052135933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.925726038523353,
+        "y": 0.5742739614766474,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.5,
+        "y": 0,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_42"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_27"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.99,
+        "y": 8.641454825494469,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.75826789936081,
+        "y": 9.40972272485528,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.806722724855277,
+        "y": 9.40972272485528,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.891,
+        "y": 9.494,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -19.891,
+        "y": 9.494,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -19.891,
+        "y": 9.494,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.252030936157798,
+        "y": 9.494,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.52636624260386,
+        "y": 9.768335306446062,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.53433530644606,
+        "y": 9.768335306446062,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.589,
+        "y": 9.823,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -21.589,
+        "y": 9.823,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -21.589,
+        "y": 9.823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.881999999999998,
+        "y": 9.823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.705,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_23"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst18_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 9.463,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_64"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.463,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_62"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst19_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_54"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 11.47524075922618,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.0006627396445,
+        "y": 14.42590349887068,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.111096501129317,
+        "y": 14.42590349887068,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.537,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_50"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_54"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.811801479879097,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.096414801022824,
+        "y": 10.484613321143726,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.0854284535438286,
+        "y": 10.484613321143726,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.016953958801986,
+        "y": 10.416138826401884,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -6.016953958801986,
+        "y": 10.416138826401884,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -6.016953958801986,
+        "y": 10.416138826401884,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.016953958801986,
+        "y": 9.534040742772635,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.581716870736105,
+        "y": 9.098803654706753,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.566873719143585,
+        "y": 9.07544674241174,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "via",
+        "x": -5.566873719143585,
+        "y": 9.07544674241174,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -5.566873719143585,
+        "y": 9.07544674241174,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.562616702676938,
+        "y": 6.887616702676938,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.675,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_46"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst21_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -26.704976,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_23"
+      },
+      {
+        "route_type": "wire",
+        "x": -30.525000000000002,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": 3.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_12"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst22_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -3.92,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_115"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.75929064694471,
+        "y": -5.1607093530552905,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.75929064694471,
+        "y": -6.155709353055291,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.717,
+        "y": -6.198,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 30.717,
+        "y": -6.198,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 30.717,
+        "y": -6.198,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.717,
+        "y": -7.575732409162802,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.277706489212918,
+        "y": -8.015025919949883,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.277706489212918,
+        "y": -8.03629351078708,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.124,
+        "y": -8.19,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 30.124,
+        "y": -8.19,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 30.124,
+        "y": -8.19,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.124,
+        "y": -8.73,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.917374839059274,
+        "y": -9.936625160940725,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.876,
+        "y": -9.978,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 28.876,
+        "y": -9.978,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 28.876,
+        "y": -9.978,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.876,
+        "y": -10.492595081971626,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.12069421739974,
+        "y": -12.247900864571886,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.12069421739974,
+        "y": -12.255305782600258,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.026,
+        "y": -12.35,
+        "width": 0.15,
+        "layer": "inner1",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_0"
+      },
+      {
+        "route_type": "via",
+        "x": 27.026,
+        "y": -12.35,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 27.026,
+        "y": -12.35,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.026,
+        "y": -13.484000000000002,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.51,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_98"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst23_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -24.295,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_21"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.88179278458126,
+        "y": -8.588749142621177,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.301843741811428,
+        "y": -8.590872535680978,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.301788837035105,
+        "y": -6.646189999977805,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.5499939094049,
+        "y": -4.910100929148686,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.550002309981036,
+        "y": -3.995713357660058,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.29701952121527,
+        "y": -3.2623373493922316,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.26266265060777,
+        "y": -3.2623373493922316,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_13"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst24_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 36,
+        "y": 12.499,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_117"
+      },
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": 8.499,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -3.92,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_115"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst25_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 20.7,
+        "y": -14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_96"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.7,
+        "y": -13.77373389057436,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.661257530872348,
+        "y": -11.81247635970201,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.709523640297988,
+        "y": -11.81247635970201,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.831687040795956,
+        "y": -11.690311305979039,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 22.831687040795956,
+        "y": -11.690311305979039,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 22.831687040795956,
+        "y": -11.690311305979039,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.838,
+        "y": -10.37698697569217,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.5035498041401,
+        "y": -9.71143717155207,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.5035498041401,
+        "y": -9.705450195859898,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.56,
+        "y": -9.649,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "via",
+        "x": 23.56,
+        "y": -9.649,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 23.56,
+        "y": -9.649,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.56,
+        "y": -9.382956793930058,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.799847128705974,
+        "y": -4.622803922636033,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.788972061179898,
+        "y": -4.622803922636033,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.6412916815649,
+        "y": -4.475123543021038,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 18.6412916815649,
+        "y": -4.475123543021038,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 18.6412916815649,
+        "y": -4.475123543021038,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.6412916815649,
+        "y": -0.3940022674055794,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.933663244222025,
+        "y": 1.3136261699372969,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.933663244222025,
+        "y": 1.3643040773793498,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.870564482087094,
+        "y": 1.427402839514281,
+        "width": 0.15,
+        "layer": "bottom",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_2"
+      },
+      {
+        "route_type": "via",
+        "x": 16.870564482087094,
+        "y": 1.427402839514281,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 16.870564482087094,
+        "y": 1.427402839514281,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.870564482087094,
+        "y": 1.639435517912906,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.51,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_92"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst0_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 8.8,
+        "width": 1,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_52"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 8.8,
+        "width": 1,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_53"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst1_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": 2.4,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_15"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.90377773354335,
+        "y": 2.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.48061131397896,
+        "y": 1.9907973128398087,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.48618910276969,
+        "y": -2.067766671800196,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.826174971005294,
+        "y": -2.3993375251264393,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.324337525126445,
+        "y": -2.3993375251264393,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": -2.4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_14"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -20.462,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_49"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.47040875709374,
+        "y": 8.029674263995519,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.543547582802397,
+        "y": 6.948872345126345,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.542200464444406,
+        "y": 6.346879466428199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.141820699643862,
+        "y": 5.946499701627655,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.878500298372344,
+        "y": 5.946499701627655,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.825,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_47"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst3_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 8.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_53"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 7.858999999999998,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.177587079778915,
+        "y": 5.731412920221084,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.203,
+        "y": 5.706,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -11.203,
+        "y": 5.706,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -11.203,
+        "y": 5.706,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.455927769164944,
+        "y": 5.706,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.336983049435029,
+        "y": 4.824944719729916,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.346055280270082,
+        "y": 4.824944719729916,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.415,
+        "y": 4.756,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -12.415,
+        "y": 4.756,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -12.415,
+        "y": 4.756,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.415,
+        "y": 2.591939856716159,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.994469928358079,
+        "y": 2.012469928358079,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.824879428775517,
+        "y": 1.9089331305096033,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -12.824879428775517,
+        "y": 1.9089331305096033,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -12.824879428775517,
+        "y": 1.9089331305096033,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.87,
+        "y": -0.023681073254129048,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.455995908004283,
+        "y": -0.43768516524984524,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.455995908004283,
+        "y": -0.4660040919957176,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.345,
+        "y": -0.577,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -12.345,
+        "y": -0.577,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -12.345,
+        "y": -0.577,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.259671594378279,
+        "y": -1.6623284056217225,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.511158278039048,
+        "y": -1.6623284056217225,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.511158278039048,
+        "y": -1.1891582780390477,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.5,
+        "y": -1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_29"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst4_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 8.8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_52"
+      },
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 7.606122267439424,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.745636274707225,
+        "y": 6.860485992732199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.2325140072678,
+        "y": 6.860485992732199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.418219878083729,
+        "y": 6.674780121916271,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.419495030093904,
+        "y": 6.671999984308259,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -11.419495030093904,
+        "y": 6.671999984308259,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -11.419495030093904,
+        "y": 6.671999984308259,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.35810583836145,
+        "y": 6.672,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.401893682289112,
+        "y": 6.628212156072339,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.588787843927662,
+        "y": 6.628212156072339,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.606,
+        "y": 6.611,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "via",
+        "x": -12.606,
+        "y": 6.611,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -12.606,
+        "y": 6.611,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.701282558703298,
+        "y": 6.706282558703298,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.1187174412967,
+        "y": 6.706282558703298,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.825,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_47"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst5_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -19.825,
+        "y": 6,
+        "width": 0.575,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_47"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.91311595214288,
+        "y": 0.9118840478571162,
+        "width": 0.575,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.00223801989999,
+        "y": 0.8768958004072398,
+        "width": 0.575,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.48338974579263,
+        "y": 2.371954433569831,
+        "width": 0.575,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.325,
+        "y": 2.4,
+        "width": 0.575,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_15"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst6_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 36,
+        "y": 7.501,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_116"
+      },
+      {
+        "route_type": "wire",
+        "x": 34.75,
+        "y": 7.501,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 34.700003,
+        "y": 7.501,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "through_obstacle",
+        "start": {
+          "x": 34.700003,
+          "y": 7.501
+        },
+        "end": {
+          "x": 34.700003,
+          "y": 7.501
+        },
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "width": 0.15
+      },
+      {
+        "route_type": "wire",
+        "x": 34.700003,
+        "y": 7.501,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": 33.99043123439299,
+        "y": 6.790682925585784,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.495014663112332,
+        "y": 6.7898417824105755,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.3392387691325,
+        "y": 6.9472041283728245,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.061040560269086,
+        "y": 6.9472041283728245,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.32188040191422,
+        "y": 5.2080439700179575,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.0350439700179574,
+        "y": 5.2080439700179575,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.994,
+        "y": 5.167,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 4.994,
+        "y": 5.167,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 4.994,
+        "y": 5.167,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.079252218260903,
+        "y": 5.167162923303422,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.4405596593437515,
+        "y": 9.536331983473445,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057468123663551,
+        "y": 9.532238376486017,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.329349155456407,
+        "y": 9.26035734469316,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.33064265530684,
+        "y": 9.26035734469316,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.392,
+        "y": 9.199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -6.392,
+        "y": 9.199,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -6.392,
+        "y": 9.199,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.529,
+        "y": 9.199,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.957136077138312,
+        "y": 8.770863922861688,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.977,
+        "y": 8.751,
+        "width": 0.15,
+        "layer": "inner2",
+        "is_inside_copper_pour": true,
+        "copper_pour_id": "pcb_copper_pour_1"
+      },
+      {
+        "route_type": "via",
+        "x": -7.977,
+        "y": 8.751,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -7.977,
+        "y": 8.751,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.001,
+        "y": 8.751,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.05,
+        "y": 8.8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_53"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_84_0",
+    "connection_name": "source_trace_84",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_113"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.360146689773448,
+        "y": -1.3601466897734484,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.414803867320167,
+        "y": -1.3601466897734484,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.158647769938401,
+        "y": -1.3601466897734484,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.809872705844747,
+        "y": -1.0113716256797947,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.805371625679795,
+        "y": -1.0113716256797947,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.805,
+        "y": -1.011,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 11.805,
+        "y": -1.011,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 11.805,
+        "y": -1.011,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.617328842613542,
+        "y": 2.1766711573864583,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.1274727417519723,
+        "y": 2.1766711573864588,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0640705119778344,
+        "y": 2.1766711573864588,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0597599277897345,
+        "y": 2.1809817415745587,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 2.0597599277897345,
+        "y": 2.1809817415745587,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0597599277897345,
+        "y": 2.1809817415745587,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.8950182584254414,
+        "y": 2.1809817415745587,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.075,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_84"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_84"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_83_0",
+    "connection_name": "source_trace_83",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -11.54,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_112"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.891665972837945,
+        "y": -11.538165745160825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.488616327568025,
+        "y": -6.136950474081472,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.456950474081474,
+        "y": -6.136950474081472,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.408,
+        "y": -6.088,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 18.408,
+        "y": -6.088,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 18.408,
+        "y": -6.088,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.50649856872925,
+        "y": -6.088,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.377224523007696,
+        "y": -4.958725954278446,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.377224523007696,
+        "y": -5.023775476992304,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.328,
+        "y": -5.073,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 8.328,
+        "y": -5.073,
+        "from_layer": "inner1",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 8.328,
+        "y": -5.073,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.184212789321132,
+        "y": -3.929212789321133,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.5542862357090765,
+        "y": -3.929212789321133,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.2717931620448977,
+        "y": -2.646719715656954,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.2717931620448977,
+        "y": -2.2132579007308877,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.2717931620448977,
+        "y": -2.1832068379551024,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.367,
+        "y": -2.088,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 3.367,
+        "y": -2.088,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 3.367,
+        "y": -2.088,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.367,
+        "y": 0.024399148678509786,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.925,
+        "y": 1.5823991486785096,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.925,
+        "y": 1.7962329999999995,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.725175999999999,
+        "y": 1.996057,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_83"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_83"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_81_0",
+    "connection_name": "source_trace_81",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 29.51,
+        "y": 13,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_110"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.26752918875696,
+        "y": 10.759257575363932,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.7079054607639,
+        "y": 10.760549402029643,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.529529113503735,
+        "y": 10.757529113503738,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.772,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_100"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_81"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_80_0",
+    "connection_name": "source_trace_80",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 28.49,
+        "y": 13,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_109"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.49,
+        "y": 12.74366624480805,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.96420898709089,
+        "y": 12.21787523189894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.94787523189894,
+        "y": 12.21787523189894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.808,
+        "y": 12.078,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 27.808,
+        "y": 12.078,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 27.808,
+        "y": 12.078,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.808,
+        "y": 8.96369195952621,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.535960391112756,
+        "y": 8.691652350638966,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.535960391112756,
+        "y": 8.683960391112755,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.459,
+        "y": 8.607,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 27.459,
+        "y": 8.607,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 27.459,
+        "y": 8.607,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.459,
+        "y": 8.440000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.38010202174998,
+        "y": 7.361102021749981,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.318,
+        "y": 7.299,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 26.318,
+        "y": 7.299,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 26.318,
+        "y": 7.299,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.777041869351805,
+        "y": 4.758041869351805,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.12702643396471,
+        "y": 4.758041869351805,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.122041869351804,
+        "y": 4.758041869351805,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.989,
+        "y": 4.625,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 16.989,
+        "y": 4.625,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 16.989,
+        "y": 4.625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.72407,
+        "y": 4.625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.100069999999999,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_75"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_80"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_79_0",
+    "connection_name": "source_trace_79",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 29.51,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_108"
+      },
+      {
+        "route_type": "wire",
+        "x": 29.28913245435058,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 29.092602636948264,
+        "y": 7.196529817402314,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 29.040175519015836,
+        "y": 7.440256222942021,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.235226090882254,
+        "y": 7.660680824756064,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.443570595962612,
+        "y": 7.5304444540910636,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.241524269541685,
+        "y": 7.5304444540910636,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.50607291506242,
+        "y": 6.794046826403508,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 22.377007150122612,
+        "y": 6.792290915863607,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.772,
+        "y": 8.4,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_101"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_79"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_78_0",
+    "connection_name": "source_trace_78",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 28.49,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_107"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.89,
+        "y": 6.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.238750036697954,
+        "y": 6.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.2,
+        "y": 6.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 18.2,
+        "y": 6.4,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 18.2,
+        "y": 6.4,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.751946859989907,
+        "y": 6.4,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.716102076771058,
+        "y": 6.36415521678115,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.624155216781148,
+        "y": 6.36415521678115,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.603956144815886,
+        "y": 6.343955717895305,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 16.603956144815886,
+        "y": 6.343955717895305,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 16.603956144815886,
+        "y": 6.343955717895305,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.778438651681906,
+        "y": 6.347,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.477676189541869,
+        "y": 3.0462375378599624,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.596775480928002,
+        "y": 3.0462375378599624,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.412939862659385,
+        "y": 2.8624019195913455,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.412939862659385,
+        "y": 2.138939862659385,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.275,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_76"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_78"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_77_0",
+    "connection_name": "source_trace_77",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 17.51,
+        "y": 13,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_106"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.372,
+        "y": 13,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 20.772,
+        "y": 11.6,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_99"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_77"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_76_0",
+    "connection_name": "source_trace_76",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 16.49,
+        "y": 13,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_105"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.49,
+        "y": 10.509617122048537,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.699579962673425,
+        "y": 2.719197084721964,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.699579962673425,
+        "y": 2.0755799626734253,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.625,
+        "y": 2.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_77"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_76"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_55__source_trace_85_mst0_0",
+    "connection_name": "source_trace_55__source_trace_85",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 14.49,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_91"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.131,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.612123628357747,
+        "y": -1.5188763716422538,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.589,
+        "y": -1.542,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 9.589,
+        "y": -1.542,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 9.589,
+        "y": -1.542,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.346,
+        "y": -1.542,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.8124100873833004,
+        "y": -2.0755899126167,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.779,
+        "y": -2.109,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 6.779,
+        "y": -2.109,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 6.779,
+        "y": -2.109,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.025,
+        "y": -2.8629999999999995,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.025,
+        "y": -4.001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_68"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_55__source_trace_85"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_55__source_trace_85_mst1_0",
+    "connection_name": "source_trace_55__source_trace_85",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32,
+        "y": -6.46,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_114"
+      },
+      {
+        "route_type": "wire",
+        "x": 31.5,
+        "y": -6.46,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 31.5,
+        "y": -6.585008,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 31.450008,
+        "y": -6.635,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "through_obstacle",
+        "start": {
+          "x": 31.450008,
+          "y": -6.635
+        },
+        "end": {
+          "x": 31.450008,
+          "y": -6.635
+        },
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "width": 0.15
+      },
+      {
+        "route_type": "wire",
+        "x": 31.450008,
+        "y": -6.635,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 31.450008,
+        "y": -6.044899410254176,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.271840392929214,
+        "y": -1.8667318031833897,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.271840392929214,
+        "y": -1.8658403929292142,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 27.113,
+        "y": -1.707,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 27.113,
+        "y": -1.707,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": 27.113,
+        "y": -1.707,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.406,
+        "y": 0.9999999999999998,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.737502361554505,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.490000000000002,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.49,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_91"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_55__source_trace_85"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_45_0",
+    "connection_name": "source_trace_45",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.51,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_57"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.834620809340347,
+        "y": 4.323705597252367,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.83429533598523,
+        "y": 10.316294418439371,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.95,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_56"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_45"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_42__source_trace_46_mst0_0",
+    "connection_name": "source_trace_42__source_trace_46",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.49,
+        "y": 3,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_58"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.498930128097268,
+        "y": 4.991069871902732,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.498930128097268,
+        "y": 9.14193012809727,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.792919662876784,
+        "y": 10.435919662876787,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.67440278589493,
+        "y": 10.435919662876787,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.67440278589493,
+        "y": 10.87440278589493,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_55"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_42__source_trace_46"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_42__source_trace_46_mst1_0",
+    "connection_name": "source_trace_42__source_trace_46",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.561973,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_59"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.093746717420352,
+        "y": 10,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.07553047902547,
+        "y": 10.981783761605119,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.07553047902547,
+        "y": 11.124469520974529,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 11.2,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_55"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_42__source_trace_46"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst0_0",
+    "connection_name": "source_trace_14__source_trace_15__source_trace_16__source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.678,
+        "y": 0.75,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_38"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.428,
+        "y": 0.75,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": 1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_37"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst1_0",
+    "connection_name": "source_trace_14__source_trace_15__source_trace_16__source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -24.295,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_22"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.295,
+        "y": 5.194999999999997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.99,
+        "y": 4.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_19"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst2_0",
+    "connection_name": "source_trace_14__source_trace_15__source_trace_16__source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_26"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": 7.875545269777625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.578343220819292,
+        "y": 7.3072020489583345,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.608797951041666,
+        "y": 7.3072020489583345,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.613706765706983,
+        "y": 7.295706765706981,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -20.613706765706983,
+        "y": 7.295706765706981,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -20.613706765706983,
+        "y": 7.295706765706981,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.613823879263755,
+        "y": 7.299,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.320284913833436,
+        "y": 8.005461034569683,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.343099652165442,
+        "y": 7.982646296237678,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -22.343099652165442,
+        "y": 7.982646296237678,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -22.343099652165442,
+        "y": 7.982646296237678,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.27764629623768,
+        "y": 7.982646296237678,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.295,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_22"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst3_0",
+    "connection_name": "source_trace_14__source_trace_15__source_trace_16__source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.678,
+        "y": 0.75,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_38"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.483,
+        "y": 0.75,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.327755414336206,
+        "y": 1.5947554143362064,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.42812057122448,
+        "y": 1.6290668694903965,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -13.42812057122448,
+        "y": 1.6290668694903965,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -13.42812057122448,
+        "y": 1.6290668694903965,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.255749551623786,
+        "y": 1.65,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.818274129570693,
+        "y": 6.212524577946905,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.818274129570693,
+        "y": 6.218274129570694,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.967,
+        "y": 6.367,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -20.967,
+        "y": 6.367,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -20.967,
+        "y": 6.367,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.967,
+        "y": 7.043000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": 8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_26"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18_mst0_0",
+    "connection_name": "source_trace_10__source_trace_11__source_trace_12__source_trace_18",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.678,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_41"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.428,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10,
+        "y": -1.178,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_28"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18_mst1_0",
+    "connection_name": "source_trace_10__source_trace_11__source_trace_12__source_trace_18",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -26.705,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_20"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.99,
+        "y": -6.285,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.99,
+        "y": -4.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_17"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18_mst2_0",
+    "connection_name": "source_trace_10__source_trace_11__source_trace_12__source_trace_18",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_24"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.49,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.99,
+        "y": -4.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_17"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18_mst3_0",
+    "connection_name": "source_trace_10__source_trace_11__source_trace_12__source_trace_18",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.678,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_41"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.41134047574976,
+        "y": -0.75,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.306797137941674,
+        "y": 0.1454566621919131,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": -7.557746199866415,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.01,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_24"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_10__source_trace_11__source_trace_12__source_trace_18"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_9_0",
+    "connection_name": "source_trace_9",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -26.01,
+        "y": 4.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_18"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.01,
+        "y": 3.127077057189992,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.099811408742724,
+        "y": 3.0372656484472698,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.109734351552728,
+        "y": 3.0372656484472698,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.237,
+        "y": 2.9099999999999997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -26.237,
+        "y": 2.9099999999999997,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -26.237,
+        "y": 2.9099999999999997,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.74304366549026,
+        "y": 2.9099999999999997,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.682537831968006,
+        "y": 0.9705058335222534,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.66250583352226,
+        "y": 0.9705058335222534,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.654,
+        "y": 0.962,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -36.654,
+        "y": 0.962,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -36.654,
+        "y": 0.962,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.36600000000001,
+        "y": 1.25,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.326,
+        "y": 1.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_5"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_9"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_8_0",
+    "connection_name": "source_trace_8",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -26.01,
+        "y": -4.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_16"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.12265504139787,
+        "y": -4.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.92680932179543,
+        "y": -3.695845719602438,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.97415428039756,
+        "y": -3.695845719602438,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.99,
+        "y": -3.68,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -33.99,
+        "y": -3.68,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -33.99,
+        "y": -3.68,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.17713219813887,
+        "y": -3.4928678018611308,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.91140952754622,
+        "y": -3.4928678018611308,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.018660769430326,
+        "y": -3.494951387166295,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.23106988245259,
+        "y": -3.2811684635191702,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.229669544261775,
+        "y": -1.8887883657249898,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.306115250622355,
+        "y": -1.8123426593644094,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.306115250622355,
+        "y": -1.6131152506223556,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.296,
+        "y": -1.603,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -37.296,
+        "y": -1.603,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.45,
+        "via_hole_diameter": 0.3
+      },
+      {
+        "route_type": "wire",
+        "x": -37.296,
+        "y": -1.603,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.473,
+        "y": -1.603,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -35.326,
+        "y": -1.75,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_11"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_4",
+    "source_trace_id": "source_trace_8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_0",
+    "pcb_trace_id": "source_net_6_mst2_0",
+    "x": 19.556968670857522,
+    "y": -8.349,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_1",
+    "pcb_trace_id": "source_net_6_mst2_0",
+    "x": 4.327,
+    "y": -2.91,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_2",
+    "pcb_trace_id": "source_net_5_mst0_0",
+    "x": -2.3890000000000002,
+    "y": -8.475,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_3",
+    "pcb_trace_id": "source_net_5_mst0_0",
+    "x": -5.199,
+    "y": -5,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "bottom"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_4",
+    "pcb_trace_id": "source_net_5_mst0_0",
+    "x": -5.211,
+    "y": -1.853,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_5",
+    "pcb_trace_id": "source_net_5_mst1_0",
+    "x": 1.416,
+    "y": -6.134,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_6",
+    "pcb_trace_id": "source_net_5_mst1_0",
+    "x": 4.795,
+    "y": -0.364,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_7",
+    "pcb_trace_id": "source_net_4_mst1_0",
+    "x": -0.555,
+    "y": -3.149,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_8",
+    "pcb_trace_id": "source_net_4_mst1_0",
+    "x": -6.83,
+    "y": -0.048,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_9",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": 1.407,
+    "y": 0.853,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_10",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": 8.276,
+    "y": 3.6410000000000005,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_11",
+    "pcb_trace_id": "source_net_2_mst2_0",
+    "x": 23.732151090101958,
+    "y": 10.345080486683996,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_12",
+    "pcb_trace_id": "source_net_2_mst2_0",
+    "x": 25.292,
+    "y": 12.420950099999999,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_13",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "x": -1.503,
+    "y": -0.916,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_14",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "x": -1.501,
+    "y": -2.6959999999999997,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_15",
+    "pcb_trace_id": "source_net_2_mst12_0",
+    "x": -10.772,
+    "y": 7.427,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_16",
+    "pcb_trace_id": "source_net_2_mst12_0",
+    "x": -6.581,
+    "y": 3.903,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_17",
+    "pcb_trace_id": "source_net_2_mst15_0",
+    "x": 28.45399972667971,
+    "y": -11.954196052479555,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_18",
+    "pcb_trace_id": "source_net_2_mst15_0",
+    "x": 27.306,
+    "y": -9.649,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_19",
+    "pcb_trace_id": "source_net_2_mst15_0",
+    "x": 24.6,
+    "y": -8.208,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_20",
+    "pcb_trace_id": "source_net_2_mst15_0",
+    "x": 19.16503132914248,
+    "y": -7.929887770117709,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_21",
+    "pcb_trace_id": "source_net_2_mst16_0",
+    "x": 23.447868279573388,
+    "y": 7.207744801006057,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_22",
+    "pcb_trace_id": "source_net_2_mst16_0",
+    "x": 18.805,
+    "y": -7.199,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_23",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "x": -17.236,
+    "y": 6.195,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_24",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "x": -17.183,
+    "y": 7.757,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_25",
+    "pcb_trace_id": "source_net_1_mst11_0",
+    "x": -33.287,
+    "y": -2.299,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_26",
+    "pcb_trace_id": "source_net_1_mst11_0",
+    "x": -33.21676921968396,
+    "y": 1.9850338138800454,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_27",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "x": 14.295348578680223,
+    "y": 7.648990046275336,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_28",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "x": 11.076,
+    "y": 7.106,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_29",
+    "pcb_trace_id": "source_net_1_mst13_0",
+    "x": 7.347,
+    "y": 3.078897,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_30",
+    "pcb_trace_id": "source_net_1_mst13_0",
+    "x": 6.2762529829672955,
+    "y": -5.079017327296704,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_31",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "x": -2.237,
+    "y": -4.988,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_32",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "x": -6.251,
+    "y": 0.952,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_33",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "x": -19.891,
+    "y": 9.494,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_34",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "x": -21.589,
+    "y": 9.823,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_35",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "x": -6.016953958801986,
+    "y": 10.416138826401884,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_36",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "x": -5.566873719143585,
+    "y": 9.07544674241174,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_37",
+    "pcb_trace_id": "source_net_1_mst22_0",
+    "x": 30.717,
+    "y": -6.198,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_38",
+    "pcb_trace_id": "source_net_1_mst22_0",
+    "x": 30.124,
+    "y": -8.19,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_39",
+    "pcb_trace_id": "source_net_1_mst22_0",
+    "x": 28.876,
+    "y": -9.978,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_40",
+    "pcb_trace_id": "source_net_1_mst22_0",
+    "x": 27.026,
+    "y": -12.35,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_41",
+    "pcb_trace_id": "source_net_1_mst25_0",
+    "x": 22.831687040795956,
+    "y": -11.690311305979039,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_42",
+    "pcb_trace_id": "source_net_1_mst25_0",
+    "x": 23.56,
+    "y": -9.649,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_43",
+    "pcb_trace_id": "source_net_1_mst25_0",
+    "x": 18.6412916815649,
+    "y": -4.475123543021038,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_44",
+    "pcb_trace_id": "source_net_1_mst25_0",
+    "x": 16.870564482087094,
+    "y": 1.427402839514281,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_45",
+    "pcb_trace_id": "source_net_0_mst3_0",
+    "x": -11.203,
+    "y": 5.706,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_46",
+    "pcb_trace_id": "source_net_0_mst3_0",
+    "x": -12.415,
+    "y": 4.756,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_47",
+    "pcb_trace_id": "source_net_0_mst3_0",
+    "x": -12.824879428775517,
+    "y": 1.9089331305096033,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_48",
+    "pcb_trace_id": "source_net_0_mst3_0",
+    "x": -12.345,
+    "y": -0.577,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_49",
+    "pcb_trace_id": "source_net_0_mst4_0",
+    "x": -11.419495030093904,
+    "y": 6.671999984308259,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_50",
+    "pcb_trace_id": "source_net_0_mst4_0",
+    "x": -12.606,
+    "y": 6.611,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_51",
+    "pcb_trace_id": "source_net_0_mst6_0",
+    "x": 4.994,
+    "y": 5.167,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_52",
+    "pcb_trace_id": "source_net_0_mst6_0",
+    "x": -6.392,
+    "y": 9.199,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_53",
+    "pcb_trace_id": "source_net_0_mst6_0",
+    "x": -7.977,
+    "y": 8.751,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_54",
+    "pcb_trace_id": "source_trace_84_0",
+    "x": 11.805,
+    "y": -1.011,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_55",
+    "pcb_trace_id": "source_trace_84_0",
+    "x": 2.0597599277897345,
+    "y": 2.1809817415745587,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_56",
+    "pcb_trace_id": "source_trace_83_0",
+    "x": 18.408,
+    "y": -6.088,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_57",
+    "pcb_trace_id": "source_trace_83_0",
+    "x": 8.328,
+    "y": -5.073,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_58",
+    "pcb_trace_id": "source_trace_83_0",
+    "x": 3.367,
+    "y": -2.088,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_59",
+    "pcb_trace_id": "source_trace_80_0",
+    "x": 27.808,
+    "y": 12.078,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_60",
+    "pcb_trace_id": "source_trace_80_0",
+    "x": 27.459,
+    "y": 8.607,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_61",
+    "pcb_trace_id": "source_trace_80_0",
+    "x": 26.318,
+    "y": 7.299,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_62",
+    "pcb_trace_id": "source_trace_80_0",
+    "x": 16.989,
+    "y": 4.625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_63",
+    "pcb_trace_id": "source_trace_78_0",
+    "x": 18.2,
+    "y": 6.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_64",
+    "pcb_trace_id": "source_trace_78_0",
+    "x": 16.603956144815886,
+    "y": 6.343955717895305,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_65",
+    "pcb_trace_id": "source_trace_55__source_trace_85_mst0_0",
+    "x": 9.589,
+    "y": -1.542,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_66",
+    "pcb_trace_id": "source_trace_55__source_trace_85_mst0_0",
+    "x": 6.779,
+    "y": -2.109,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner2",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_67",
+    "pcb_trace_id": "source_trace_55__source_trace_85_mst1_0",
+    "x": 27.113,
+    "y": -1.707,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_68",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst2_0",
+    "x": -20.613706765706983,
+    "y": 7.295706765706981,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_69",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst2_0",
+    "x": -22.343099652165442,
+    "y": 7.982646296237678,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_70",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst3_0",
+    "x": -13.42812057122448,
+    "y": 1.6290668694903965,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_71",
+    "pcb_trace_id": "source_trace_14__source_trace_15__source_trace_16__source_trace_20_mst3_0",
+    "x": -20.967,
+    "y": 6.367,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_72",
+    "pcb_trace_id": "source_trace_9_0",
+    "x": -26.237,
+    "y": 2.9099999999999997,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_73",
+    "pcb_trace_id": "source_trace_9_0",
+    "x": -36.654,
+    "y": 0.962,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_74",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": -33.99,
+    "y": -3.68,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_75",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": -37.296,
+    "y": -1.603,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.45,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_0",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "L1 has no pin with requires_power=true",
+    "source_component_id": "source_component_14",
+    "source_port_ids": [
+      "source_port_59",
+      "source_port_60"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_0",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "L1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_14",
+    "source_port_ids": [
+      "source_port_59",
+      "source_port_60"
+    ],
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "pcb_copper_pour",
+    "pcb_copper_pour_id": "pcb_copper_pour_0",
+    "shape": "brep",
+    "layer": "inner1",
+    "brep_shape": {
+      "outer_ring": {
+        "vertices": [
+          {
+            "x": 42.75,
+            "y": -17.75
+          },
+          {
+            "x": -42.75,
+            "y": -17.75
+          },
+          {
+            "x": -42.75,
+            "y": 17.75
+          },
+          {
+            "x": 42.75,
+            "y": 17.75
+          }
+        ]
+      },
+      "inner_rings": [
+        {
+          "vertices": [
+            {
+              "x": 23.732151,
+              "y": 9.92008
+            },
+            {
+              "x": 23.815064,
+              "y": 9.928247
+            },
+            {
+              "x": 23.894792,
+              "y": 9.952432
+            },
+            {
+              "x": 23.968268,
+              "y": 9.991706
+            },
+            {
+              "x": 24.032671,
+              "y": 10.04456
+            },
+            {
+              "x": 24.085526,
+              "y": 10.108963
+            },
+            {
+              "x": 24.1248,
+              "y": 10.18244
+            },
+            {
+              "x": 24.148985,
+              "y": 10.262167
+            },
+            {
+              "x": 24.157151,
+              "y": 10.34508
+            },
+            {
+              "x": 24.148985,
+              "y": 10.427994
+            },
+            {
+              "x": 24.1248,
+              "y": 10.507721
+            },
+            {
+              "x": 24.096385,
+              "y": 10.560883
+            },
+            {
+              "x": 25.526915,
+              "y": 11.991414
+            },
+            {
+              "x": 25.561115,
+              "y": 12.033086
+            },
+            {
+              "x": 25.586527,
+              "y": 12.08063
+            },
+            {
+              "x": 25.602165,
+              "y": 12.132183
+            },
+            {
+              "x": 25.645375,
+              "y": 12.184833
+            },
+            {
+              "x": 25.684649,
+              "y": 12.25831
+            },
+            {
+              "x": 25.708834,
+              "y": 12.338037
+            },
+            {
+              "x": 25.717,
+              "y": 12.42095
+            },
+            {
+              "x": 25.708834,
+              "y": 12.503863
+            },
+            {
+              "x": 25.684649,
+              "y": 12.583591
+            },
+            {
+              "x": 25.645375,
+              "y": 12.657067
+            },
+            {
+              "x": 25.59252,
+              "y": 12.72147
+            },
+            {
+              "x": 25.528117,
+              "y": 12.774325
+            },
+            {
+              "x": 25.45464,
+              "y": 12.813599
+            },
+            {
+              "x": 25.374913,
+              "y": 12.837784
+            },
+            {
+              "x": 25.292,
+              "y": 12.84595
+            },
+            {
+              "x": 25.209087,
+              "y": 12.837784
+            },
+            {
+              "x": 25.12936,
+              "y": 12.813599
+            },
+            {
+              "x": 25.055883,
+              "y": 12.774325
+            },
+            {
+              "x": 24.99148,
+              "y": 12.72147
+            },
+            {
+              "x": 24.938625,
+              "y": 12.657067
+            },
+            {
+              "x": 24.899351,
+              "y": 12.583591
+            },
+            {
+              "x": 24.875166,
+              "y": 12.503863
+            },
+            {
+              "x": 24.867,
+              "y": 12.42095
+            },
+            {
+              "x": 24.875166,
+              "y": 12.338037
+            },
+            {
+              "x": 24.899351,
+              "y": 12.25831
+            },
+            {
+              "x": 24.938625,
+              "y": 12.184833
+            },
+            {
+              "x": 24.940379,
+              "y": 12.182695
+            },
+            {
+              "x": 23.537697,
+              "y": 10.780013
+            },
+            {
+              "x": 23.503497,
+              "y": 10.738341
+            },
+            {
+              "x": 23.478084,
+              "y": 10.690797
+            },
+            {
+              "x": 23.475227,
+              "y": 10.681379
+            },
+            {
+              "x": 23.431631,
+              "y": 10.645601
+            },
+            {
+              "x": 23.378777,
+              "y": 10.581198
+            },
+            {
+              "x": 23.339502,
+              "y": 10.507721
+            },
+            {
+              "x": 23.315317,
+              "y": 10.427994
+            },
+            {
+              "x": 23.307151,
+              "y": 10.34508
+            },
+            {
+              "x": 23.315317,
+              "y": 10.262167
+            },
+            {
+              "x": 23.339502,
+              "y": 10.18244
+            },
+            {
+              "x": 23.378777,
+              "y": 10.108963
+            },
+            {
+              "x": 23.431631,
+              "y": 10.04456
+            },
+            {
+              "x": 23.496034,
+              "y": 9.991706
+            },
+            {
+              "x": 23.569511,
+              "y": 9.952432
+            },
+            {
+              "x": 23.649238,
+              "y": 9.928247
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -20.613707,
+              "y": 6.870707
+            },
+            {
+              "x": -20.530793,
+              "y": 6.878873
+            },
+            {
+              "x": -20.451066,
+              "y": 6.903058
+            },
+            {
+              "x": -20.377589,
+              "y": 6.942332
+            },
+            {
+              "x": -20.313186,
+              "y": 6.995186
+            },
+            {
+              "x": -20.260332,
+              "y": 7.059589
+            },
+            {
+              "x": -20.221058,
+              "y": 7.133066
+            },
+            {
+              "x": -20.196873,
+              "y": 7.212793
+            },
+            {
+              "x": -20.188707,
+              "y": 7.295707
+            },
+            {
+              "x": -20.196873,
+              "y": 7.37862
+            },
+            {
+              "x": -20.221058,
+              "y": 7.458347
+            },
+            {
+              "x": -20.260332,
+              "y": 7.531824
+            },
+            {
+              "x": -20.313186,
+              "y": 7.596227
+            },
+            {
+              "x": -20.377589,
+              "y": 7.649081
+            },
+            {
+              "x": -20.451066,
+              "y": 7.688356
+            },
+            {
+              "x": -20.530793,
+              "y": 7.712541
+            },
+            {
+              "x": -20.613707,
+              "y": 7.720707
+            },
+            {
+              "x": -20.69662,
+              "y": 7.712541
+            },
+            {
+              "x": -20.776347,
+              "y": 7.688356
+            },
+            {
+              "x": -20.849824,
+              "y": 7.649081
+            },
+            {
+              "x": -20.914227,
+              "y": 7.596227
+            },
+            {
+              "x": -20.934303,
+              "y": 7.571764
+            },
+            {
+              "x": -21.499542,
+              "y": 7.573626
+            },
+            {
+              "x": -21.919142,
+              "y": 7.993226
+            },
+            {
+              "x": -21.926266,
+              "y": 8.06556
+            },
+            {
+              "x": -21.950451,
+              "y": 8.145287
+            },
+            {
+              "x": -21.989725,
+              "y": 8.218764
+            },
+            {
+              "x": -22.042579,
+              "y": 8.283167
+            },
+            {
+              "x": -22.106982,
+              "y": 8.336021
+            },
+            {
+              "x": -22.180459,
+              "y": 8.375295
+            },
+            {
+              "x": -22.260186,
+              "y": 8.39948
+            },
+            {
+              "x": -22.3431,
+              "y": 8.407646
+            },
+            {
+              "x": -22.426013,
+              "y": 8.39948
+            },
+            {
+              "x": -22.50574,
+              "y": 8.375295
+            },
+            {
+              "x": -22.579217,
+              "y": 8.336021
+            },
+            {
+              "x": -22.64362,
+              "y": 8.283167
+            },
+            {
+              "x": -22.696474,
+              "y": 8.218764
+            },
+            {
+              "x": -22.735748,
+              "y": 8.145287
+            },
+            {
+              "x": -22.759933,
+              "y": 8.06556
+            },
+            {
+              "x": -22.7681,
+              "y": 7.982646
+            },
+            {
+              "x": -22.759933,
+              "y": 7.899733
+            },
+            {
+              "x": -22.735748,
+              "y": 7.820006
+            },
+            {
+              "x": -22.696474,
+              "y": 7.746529
+            },
+            {
+              "x": -22.64362,
+              "y": 7.682126
+            },
+            {
+              "x": -22.579217,
+              "y": 7.629272
+            },
+            {
+              "x": -22.50574,
+              "y": 7.589997
+            },
+            {
+              "x": -22.426013,
+              "y": 7.565813
+            },
+            {
+              "x": -22.3431,
+              "y": 7.557646
+            },
+            {
+              "x": -22.268706,
+              "y": 7.564974
+            },
+            {
+              "x": -21.808278,
+              "y": 7.104546
+            },
+            {
+              "x": -21.766606,
+              "y": 7.070346
+            },
+            {
+              "x": -21.719062,
+              "y": 7.044933
+            },
+            {
+              "x": -21.667474,
+              "y": 7.029284
+            },
+            {
+              "x": -21.614729,
+              "y": 7.024089
+            },
+            {
+              "x": -21.614729,
+              "y": 7.024001
+            },
+            {
+              "x": -20.936041,
+              "y": 7.021766
+            },
+            {
+              "x": -20.914227,
+              "y": 6.995186
+            },
+            {
+              "x": -20.849824,
+              "y": 6.942332
+            },
+            {
+              "x": -20.776347,
+              "y": 6.903058
+            },
+            {
+              "x": -20.69662,
+              "y": 6.878873
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -6.581,
+              "y": 3.478
+            },
+            {
+              "x": -6.498087,
+              "y": 3.486166
+            },
+            {
+              "x": -6.41836,
+              "y": 3.510351
+            },
+            {
+              "x": -6.344883,
+              "y": 3.549625
+            },
+            {
+              "x": -6.28048,
+              "y": 3.60248
+            },
+            {
+              "x": -6.227625,
+              "y": 3.666883
+            },
+            {
+              "x": -6.188351,
+              "y": 3.74036
+            },
+            {
+              "x": -6.164166,
+              "y": 3.820087
+            },
+            {
+              "x": -6.156,
+              "y": 3.903
+            },
+            {
+              "x": -6.164166,
+              "y": 3.985913
+            },
+            {
+              "x": -6.188351,
+              "y": 4.06564
+            },
+            {
+              "x": -6.227625,
+              "y": 4.139117
+            },
+            {
+              "x": -6.28048,
+              "y": 4.20352
+            },
+            {
+              "x": -6.344883,
+              "y": 4.256375
+            },
+            {
+              "x": -6.41836,
+              "y": 4.295649
+            },
+            {
+              "x": -6.498087,
+              "y": 4.319834
+            },
+            {
+              "x": -6.581,
+              "y": 4.328
+            },
+            {
+              "x": -6.663913,
+              "y": 4.319834
+            },
+            {
+              "x": -6.683598,
+              "y": 4.313862
+            },
+            {
+              "x": -9.991191,
+              "y": 7.621454
+            },
+            {
+              "x": -10.032863,
+              "y": 7.655654
+            },
+            {
+              "x": -10.080407,
+              "y": 7.681067
+            },
+            {
+              "x": -10.131995,
+              "y": 7.696716
+            },
+            {
+              "x": -10.185645,
+              "y": 7.702
+            },
+            {
+              "x": -10.450536,
+              "y": 7.702
+            },
+            {
+              "x": -10.47148,
+              "y": 7.72752
+            },
+            {
+              "x": -10.535883,
+              "y": 7.780375
+            },
+            {
+              "x": -10.60936,
+              "y": 7.819649
+            },
+            {
+              "x": -10.689087,
+              "y": 7.843834
+            },
+            {
+              "x": -10.772,
+              "y": 7.852
+            },
+            {
+              "x": -10.854913,
+              "y": 7.843834
+            },
+            {
+              "x": -10.93464,
+              "y": 7.819649
+            },
+            {
+              "x": -11.008117,
+              "y": 7.780375
+            },
+            {
+              "x": -11.07252,
+              "y": 7.72752
+            },
+            {
+              "x": -11.125375,
+              "y": 7.663117
+            },
+            {
+              "x": -11.164649,
+              "y": 7.58964
+            },
+            {
+              "x": -11.188834,
+              "y": 7.509913
+            },
+            {
+              "x": -11.197,
+              "y": 7.427
+            },
+            {
+              "x": -11.188834,
+              "y": 7.344087
+            },
+            {
+              "x": -11.164649,
+              "y": 7.26436
+            },
+            {
+              "x": -11.125375,
+              "y": 7.190883
+            },
+            {
+              "x": -11.07252,
+              "y": 7.12648
+            },
+            {
+              "x": -11.008117,
+              "y": 7.073625
+            },
+            {
+              "x": -10.93464,
+              "y": 7.034351
+            },
+            {
+              "x": -10.854913,
+              "y": 7.010166
+            },
+            {
+              "x": -10.772,
+              "y": 7.002
+            },
+            {
+              "x": -10.689087,
+              "y": 7.010166
+            },
+            {
+              "x": -10.60936,
+              "y": 7.034351
+            },
+            {
+              "x": -10.535883,
+              "y": 7.073625
+            },
+            {
+              "x": -10.47148,
+              "y": 7.12648
+            },
+            {
+              "x": -10.450536,
+              "y": 7.152
+            },
+            {
+              "x": -10.299554,
+              "y": 7.152
+            },
+            {
+              "x": -7.001133,
+              "y": 3.853579
+            },
+            {
+              "x": -6.997834,
+              "y": 3.820087
+            },
+            {
+              "x": -6.973649,
+              "y": 3.74036
+            },
+            {
+              "x": -6.934375,
+              "y": 3.666883
+            },
+            {
+              "x": -6.88152,
+              "y": 3.60248
+            },
+            {
+              "x": -6.817117,
+              "y": 3.549625
+            },
+            {
+              "x": -6.74364,
+              "y": 3.510351
+            },
+            {
+              "x": -6.663913,
+              "y": 3.486166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 16.989,
+              "y": 4.2
+            },
+            {
+              "x": 17.071913,
+              "y": 4.208166
+            },
+            {
+              "x": 17.15164,
+              "y": 4.232351
+            },
+            {
+              "x": 17.225117,
+              "y": 4.271625
+            },
+            {
+              "x": 17.28952,
+              "y": 4.32448
+            },
+            {
+              "x": 17.342375,
+              "y": 4.388883
+            },
+            {
+              "x": 17.381649,
+              "y": 4.46236
+            },
+            {
+              "x": 17.387923,
+              "y": 4.483042
+            },
+            {
+              "x": 23.777042,
+              "y": 4.483042
+            },
+            {
+              "x": 23.830692,
+              "y": 4.488326
+            },
+            {
+              "x": 23.88228,
+              "y": 4.503975
+            },
+            {
+              "x": 23.929824,
+              "y": 4.529388
+            },
+            {
+              "x": 23.971496,
+              "y": 4.563588
+            },
+            {
+              "x": 26.285144,
+              "y": 6.877236
+            },
+            {
+              "x": 26.318,
+              "y": 6.874
+            },
+            {
+              "x": 26.400913,
+              "y": 6.882166
+            },
+            {
+              "x": 26.48064,
+              "y": 6.906351
+            },
+            {
+              "x": 26.554117,
+              "y": 6.945625
+            },
+            {
+              "x": 26.61852,
+              "y": 6.99848
+            },
+            {
+              "x": 26.671375,
+              "y": 7.062883
+            },
+            {
+              "x": 26.710649,
+              "y": 7.13636
+            },
+            {
+              "x": 26.734834,
+              "y": 7.216087
+            },
+            {
+              "x": 26.743,
+              "y": 7.299
+            },
+            {
+              "x": 26.734834,
+              "y": 7.381913
+            },
+            {
+              "x": 26.710649,
+              "y": 7.46164
+            },
+            {
+              "x": 26.671375,
+              "y": 7.535117
+            },
+            {
+              "x": 26.61852,
+              "y": 7.59952
+            },
+            {
+              "x": 26.554117,
+              "y": 7.652375
+            },
+            {
+              "x": 26.48064,
+              "y": 7.691649
+            },
+            {
+              "x": 26.400913,
+              "y": 7.715834
+            },
+            {
+              "x": 26.318,
+              "y": 7.724
+            },
+            {
+              "x": 26.235087,
+              "y": 7.715834
+            },
+            {
+              "x": 26.15536,
+              "y": 7.691649
+            },
+            {
+              "x": 26.081883,
+              "y": 7.652375
+            },
+            {
+              "x": 26.01748,
+              "y": 7.59952
+            },
+            {
+              "x": 25.964625,
+              "y": 7.535117
+            },
+            {
+              "x": 25.925351,
+              "y": 7.46164
+            },
+            {
+              "x": 25.901166,
+              "y": 7.381913
+            },
+            {
+              "x": 25.893,
+              "y": 7.299
+            },
+            {
+              "x": 25.896236,
+              "y": 7.266144
+            },
+            {
+              "x": 23.663134,
+              "y": 5.033042
+            },
+            {
+              "x": 17.127026,
+              "y": 5.033042
+            },
+            {
+              "x": 17.122042,
+              "y": 5.033042
+            },
+            {
+              "x": 17.106079,
+              "y": 5.03147
+            },
+            {
+              "x": 17.071913,
+              "y": 5.041834
+            },
+            {
+              "x": 16.989,
+              "y": 5.05
+            },
+            {
+              "x": 16.906087,
+              "y": 5.041834
+            },
+            {
+              "x": 16.82636,
+              "y": 5.017649
+            },
+            {
+              "x": 16.752883,
+              "y": 4.978375
+            },
+            {
+              "x": 16.68848,
+              "y": 4.92552
+            },
+            {
+              "x": 16.635625,
+              "y": 4.861117
+            },
+            {
+              "x": 16.596351,
+              "y": 4.78764
+            },
+            {
+              "x": 16.572166,
+              "y": 4.707913
+            },
+            {
+              "x": 16.564,
+              "y": 4.625
+            },
+            {
+              "x": 16.572166,
+              "y": 4.542087
+            },
+            {
+              "x": 16.596351,
+              "y": 4.46236
+            },
+            {
+              "x": 16.635625,
+              "y": 4.388883
+            },
+            {
+              "x": 16.68848,
+              "y": 4.32448
+            },
+            {
+              "x": 16.752883,
+              "y": 4.271625
+            },
+            {
+              "x": 16.82636,
+              "y": 4.232351
+            },
+            {
+              "x": 16.906087,
+              "y": 4.208166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -13.428121,
+              "y": 1.204067
+            },
+            {
+              "x": -13.345207,
+              "y": 1.212233
+            },
+            {
+              "x": -13.26548,
+              "y": 1.236418
+            },
+            {
+              "x": -13.192003,
+              "y": 1.275692
+            },
+            {
+              "x": -13.1276,
+              "y": 1.328546
+            },
+            {
+              "x": -13.074746,
+              "y": 1.39295
+            },
+            {
+              "x": -13.035472,
+              "y": 1.466426
+            },
+            {
+              "x": -13.011287,
+              "y": 1.546153
+            },
+            {
+              "x": -13.003121,
+              "y": 1.629067
+            },
+            {
+              "x": -13.011287,
+              "y": 1.71198
+            },
+            {
+              "x": -13.035472,
+              "y": 1.791707
+            },
+            {
+              "x": -13.074746,
+              "y": 1.865184
+            },
+            {
+              "x": -13.1276,
+              "y": 1.929587
+            },
+            {
+              "x": -13.192003,
+              "y": 1.982441
+            },
+            {
+              "x": -13.26548,
+              "y": 2.021716
+            },
+            {
+              "x": -13.345207,
+              "y": 2.045901
+            },
+            {
+              "x": -13.428121,
+              "y": 2.054067
+            },
+            {
+              "x": -13.511034,
+              "y": 2.045901
+            },
+            {
+              "x": -13.590761,
+              "y": 2.021716
+            },
+            {
+              "x": -13.664238,
+              "y": 1.982441
+            },
+            {
+              "x": -13.728641,
+              "y": 1.929587
+            },
+            {
+              "x": -13.747638,
+              "y": 1.906439
+            },
+            {
+              "x": -16.140999,
+              "y": 1.924158
+            },
+            {
+              "x": -20.545751,
+              "y": 6.32891
+            },
+            {
+              "x": -20.542,
+              "y": 6.367
+            },
+            {
+              "x": -20.550166,
+              "y": 6.449913
+            },
+            {
+              "x": -20.574351,
+              "y": 6.52964
+            },
+            {
+              "x": -20.613625,
+              "y": 6.603117
+            },
+            {
+              "x": -20.66648,
+              "y": 6.66752
+            },
+            {
+              "x": -20.730883,
+              "y": 6.720375
+            },
+            {
+              "x": -20.80436,
+              "y": 6.759649
+            },
+            {
+              "x": -20.884087,
+              "y": 6.783834
+            },
+            {
+              "x": -20.967,
+              "y": 6.792
+            },
+            {
+              "x": -21.049913,
+              "y": 6.783834
+            },
+            {
+              "x": -21.12964,
+              "y": 6.759649
+            },
+            {
+              "x": -21.203117,
+              "y": 6.720375
+            },
+            {
+              "x": -21.26752,
+              "y": 6.66752
+            },
+            {
+              "x": -21.320375,
+              "y": 6.603117
+            },
+            {
+              "x": -21.359649,
+              "y": 6.52964
+            },
+            {
+              "x": -21.383834,
+              "y": 6.449913
+            },
+            {
+              "x": -21.392,
+              "y": 6.367
+            },
+            {
+              "x": -21.383834,
+              "y": 6.284087
+            },
+            {
+              "x": -21.359649,
+              "y": 6.20436
+            },
+            {
+              "x": -21.320375,
+              "y": 6.130883
+            },
+            {
+              "x": -21.26752,
+              "y": 6.06648
+            },
+            {
+              "x": -21.203117,
+              "y": 6.013625
+            },
+            {
+              "x": -21.12964,
+              "y": 5.974351
+            },
+            {
+              "x": -21.049913,
+              "y": 5.950166
+            },
+            {
+              "x": -20.967,
+              "y": 5.942
+            },
+            {
+              "x": -20.939378,
+              "y": 5.94472
+            },
+            {
+              "x": -16.450204,
+              "y": 1.455546
+            },
+            {
+              "x": -16.408531,
+              "y": 1.421346
+            },
+            {
+              "x": -16.360987,
+              "y": 1.395933
+            },
+            {
+              "x": -16.309399,
+              "y": 1.380284
+            },
+            {
+              "x": -16.257784,
+              "y": 1.3752
+            },
+            {
+              "x": -16.257785,
+              "y": 1.375008
+            },
+            {
+              "x": -13.751544,
+              "y": 1.356453
+            },
+            {
+              "x": -13.728641,
+              "y": 1.328546
+            },
+            {
+              "x": -13.664238,
+              "y": 1.275692
+            },
+            {
+              "x": -13.590761,
+              "y": 1.236418
+            },
+            {
+              "x": -13.511034,
+              "y": 1.212233
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -12.415,
+              "y": 4.331
+            },
+            {
+              "x": -12.332087,
+              "y": 4.339166
+            },
+            {
+              "x": -12.25236,
+              "y": 4.363351
+            },
+            {
+              "x": -12.178883,
+              "y": 4.402625
+            },
+            {
+              "x": -12.11448,
+              "y": 4.45548
+            },
+            {
+              "x": -12.061625,
+              "y": 4.519883
+            },
+            {
+              "x": -12.022351,
+              "y": 4.59336
+            },
+            {
+              "x": -11.998166,
+              "y": 4.673087
+            },
+            {
+              "x": -11.99,
+              "y": 4.756
+            },
+            {
+              "x": -11.992422,
+              "y": 4.780597
+            },
+            {
+              "x": -11.426916,
+              "y": 5.346103
+            },
+            {
+              "x": -11.36564,
+              "y": 5.313351
+            },
+            {
+              "x": -11.285913,
+              "y": 5.289166
+            },
+            {
+              "x": -11.203,
+              "y": 5.281
+            },
+            {
+              "x": -11.120087,
+              "y": 5.289166
+            },
+            {
+              "x": -11.04036,
+              "y": 5.313351
+            },
+            {
+              "x": -10.966883,
+              "y": 5.352625
+            },
+            {
+              "x": -10.90248,
+              "y": 5.40548
+            },
+            {
+              "x": -10.849625,
+              "y": 5.469883
+            },
+            {
+              "x": -10.810351,
+              "y": 5.54336
+            },
+            {
+              "x": -10.786166,
+              "y": 5.623087
+            },
+            {
+              "x": -10.778,
+              "y": 5.706
+            },
+            {
+              "x": -10.786166,
+              "y": 5.788913
+            },
+            {
+              "x": -10.810351,
+              "y": 5.86864
+            },
+            {
+              "x": -10.849625,
+              "y": 5.942117
+            },
+            {
+              "x": -10.90248,
+              "y": 6.00652
+            },
+            {
+              "x": -10.966883,
+              "y": 6.059375
+            },
+            {
+              "x": -11.04036,
+              "y": 6.098649
+            },
+            {
+              "x": -11.120087,
+              "y": 6.122834
+            },
+            {
+              "x": -11.203,
+              "y": 6.131
+            },
+            {
+              "x": -11.285913,
+              "y": 6.122834
+            },
+            {
+              "x": -11.36564,
+              "y": 6.098649
+            },
+            {
+              "x": -11.439117,
+              "y": 6.059375
+            },
+            {
+              "x": -11.50352,
+              "y": 6.00652
+            },
+            {
+              "x": -11.535172,
+              "y": 5.967952
+            },
+            {
+              "x": -11.561166,
+              "y": 5.960067
+            },
+            {
+              "x": -11.60871,
+              "y": 5.934654
+            },
+            {
+              "x": -11.650382,
+              "y": 5.900454
+            },
+            {
+              "x": -12.373885,
+              "y": 5.176951
+            },
+            {
+              "x": -12.415,
+              "y": 5.181
+            },
+            {
+              "x": -12.497913,
+              "y": 5.172834
+            },
+            {
+              "x": -12.57764,
+              "y": 5.148649
+            },
+            {
+              "x": -12.651117,
+              "y": 5.109375
+            },
+            {
+              "x": -12.71552,
+              "y": 5.05652
+            },
+            {
+              "x": -12.768375,
+              "y": 4.992117
+            },
+            {
+              "x": -12.807649,
+              "y": 4.91864
+            },
+            {
+              "x": -12.831834,
+              "y": 4.838913
+            },
+            {
+              "x": -12.84,
+              "y": 4.756
+            },
+            {
+              "x": -12.831834,
+              "y": 4.673087
+            },
+            {
+              "x": -12.807649,
+              "y": 4.59336
+            },
+            {
+              "x": -12.768375,
+              "y": 4.519883
+            },
+            {
+              "x": -12.71552,
+              "y": 4.45548
+            },
+            {
+              "x": -12.651117,
+              "y": 4.402625
+            },
+            {
+              "x": -12.57764,
+              "y": 4.363351
+            },
+            {
+              "x": -12.497913,
+              "y": 4.339166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.594433,
+              "y": 2.324912
+            },
+            {
+              "x": -36.482255,
+              "y": 2.335961
+            },
+            {
+              "x": -36.374388,
+              "y": 2.368682
+            },
+            {
+              "x": -36.274977,
+              "y": 2.421818
+            },
+            {
+              "x": -36.187842,
+              "y": 2.493328
+            },
+            {
+              "x": -36.116333,
+              "y": 2.580462
+            },
+            {
+              "x": -36.063197,
+              "y": 2.679873
+            },
+            {
+              "x": -36.030476,
+              "y": 2.78774
+            },
+            {
+              "x": -36.019427,
+              "y": 2.899918
+            },
+            {
+              "x": -36.030476,
+              "y": 3.012096
+            },
+            {
+              "x": -36.063197,
+              "y": 3.119963
+            },
+            {
+              "x": -36.116333,
+              "y": 3.219374
+            },
+            {
+              "x": -36.187842,
+              "y": 3.306508
+            },
+            {
+              "x": -36.274977,
+              "y": 3.378018
+            },
+            {
+              "x": -36.374388,
+              "y": 3.431154
+            },
+            {
+              "x": -36.482255,
+              "y": 3.463875
+            },
+            {
+              "x": -36.594433,
+              "y": 3.474924
+            },
+            {
+              "x": -36.706611,
+              "y": 3.463875
+            },
+            {
+              "x": -36.814478,
+              "y": 3.431154
+            },
+            {
+              "x": -36.913889,
+              "y": 3.378018
+            },
+            {
+              "x": -37.001023,
+              "y": 3.306508
+            },
+            {
+              "x": -37.072532,
+              "y": 3.219374
+            },
+            {
+              "x": -37.125669,
+              "y": 3.119963
+            },
+            {
+              "x": -37.15839,
+              "y": 3.012096
+            },
+            {
+              "x": -37.169438,
+              "y": 2.899918
+            },
+            {
+              "x": -37.15839,
+              "y": 2.78774
+            },
+            {
+              "x": -37.125669,
+              "y": 2.679873
+            },
+            {
+              "x": -37.072532,
+              "y": 2.580462
+            },
+            {
+              "x": -37.001023,
+              "y": 2.493328
+            },
+            {
+              "x": -36.913889,
+              "y": 2.421818
+            },
+            {
+              "x": -36.814478,
+              "y": 2.368682
+            },
+            {
+              "x": -36.706611,
+              "y": 2.335961
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.654,
+              "y": 0.537
+            },
+            {
+              "x": -36.571087,
+              "y": 0.545166
+            },
+            {
+              "x": -36.49136,
+              "y": 0.569351
+            },
+            {
+              "x": -36.417883,
+              "y": 0.608625
+            },
+            {
+              "x": -36.35348,
+              "y": 0.66148
+            },
+            {
+              "x": -36.300625,
+              "y": 0.725883
+            },
+            {
+              "x": -36.261351,
+              "y": 0.79936
+            },
+            {
+              "x": -36.237166,
+              "y": 0.879087
+            },
+            {
+              "x": -36.229,
+              "y": 0.962
+            },
+            {
+              "x": -36.235557,
+              "y": 1.028577
+            },
+            {
+              "x": -34.629135,
+              "y": 2.635
+            },
+            {
+              "x": -26.558464,
+              "y": 2.635
+            },
+            {
+              "x": -26.53752,
+              "y": 2.60948
+            },
+            {
+              "x": -26.473117,
+              "y": 2.556625
+            },
+            {
+              "x": -26.39964,
+              "y": 2.517351
+            },
+            {
+              "x": -26.319913,
+              "y": 2.493166
+            },
+            {
+              "x": -26.237,
+              "y": 2.485
+            },
+            {
+              "x": -26.154087,
+              "y": 2.493166
+            },
+            {
+              "x": -26.07436,
+              "y": 2.517351
+            },
+            {
+              "x": -26.000883,
+              "y": 2.556625
+            },
+            {
+              "x": -25.93648,
+              "y": 2.60948
+            },
+            {
+              "x": -25.883625,
+              "y": 2.673883
+            },
+            {
+              "x": -25.844351,
+              "y": 2.74736
+            },
+            {
+              "x": -25.820166,
+              "y": 2.827087
+            },
+            {
+              "x": -25.812,
+              "y": 2.91
+            },
+            {
+              "x": -25.820166,
+              "y": 2.992913
+            },
+            {
+              "x": -25.844351,
+              "y": 3.07264
+            },
+            {
+              "x": -25.883625,
+              "y": 3.146117
+            },
+            {
+              "x": -25.93648,
+              "y": 3.21052
+            },
+            {
+              "x": -26.000883,
+              "y": 3.263375
+            },
+            {
+              "x": -26.07436,
+              "y": 3.302649
+            },
+            {
+              "x": -26.154087,
+              "y": 3.326834
+            },
+            {
+              "x": -26.237,
+              "y": 3.335
+            },
+            {
+              "x": -26.319913,
+              "y": 3.326834
+            },
+            {
+              "x": -26.39964,
+              "y": 3.302649
+            },
+            {
+              "x": -26.473117,
+              "y": 3.263375
+            },
+            {
+              "x": -26.53752,
+              "y": 3.21052
+            },
+            {
+              "x": -26.558464,
+              "y": 3.185
+            },
+            {
+              "x": -34.743044,
+              "y": 3.185
+            },
+            {
+              "x": -34.796694,
+              "y": 3.179716
+            },
+            {
+              "x": -34.848282,
+              "y": 3.164067
+            },
+            {
+              "x": -34.895825,
+              "y": 3.138654
+            },
+            {
+              "x": -34.937498,
+              "y": 3.104454
+            },
+            {
+              "x": -36.655056,
+              "y": 1.386896
+            },
+            {
+              "x": -36.736913,
+              "y": 1.378834
+            },
+            {
+              "x": -36.81664,
+              "y": 1.354649
+            },
+            {
+              "x": -36.890117,
+              "y": 1.315375
+            },
+            {
+              "x": -36.95452,
+              "y": 1.26252
+            },
+            {
+              "x": -37.007375,
+              "y": 1.198117
+            },
+            {
+              "x": -37.046649,
+              "y": 1.12464
+            },
+            {
+              "x": -37.070834,
+              "y": 1.044913
+            },
+            {
+              "x": -37.079,
+              "y": 0.962
+            },
+            {
+              "x": -37.070834,
+              "y": 0.879087
+            },
+            {
+              "x": -37.046649,
+              "y": 0.79936
+            },
+            {
+              "x": -37.007375,
+              "y": 0.725883
+            },
+            {
+              "x": -36.95452,
+              "y": 0.66148
+            },
+            {
+              "x": -36.890117,
+              "y": 0.608625
+            },
+            {
+              "x": -36.81664,
+              "y": 0.569351
+            },
+            {
+              "x": -36.736913,
+              "y": 0.545166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 1.416,
+              "y": -6.559
+            },
+            {
+              "x": 1.498913,
+              "y": -6.550834
+            },
+            {
+              "x": 1.57864,
+              "y": -6.526649
+            },
+            {
+              "x": 1.652117,
+              "y": -6.487375
+            },
+            {
+              "x": 1.71652,
+              "y": -6.43452
+            },
+            {
+              "x": 1.737464,
+              "y": -6.409
+            },
+            {
+              "x": 1.889242,
+              "y": -6.409
+            },
+            {
+              "x": 1.942892,
+              "y": -6.403716
+            },
+            {
+              "x": 1.99448,
+              "y": -6.388067
+            },
+            {
+              "x": 2.042024,
+              "y": -6.362654
+            },
+            {
+              "x": 2.083697,
+              "y": -6.328454
+            },
+            {
+              "x": 5.262639,
+              "y": -3.149512
+            },
+            {
+              "x": 5.296839,
+              "y": -3.107839
+            },
+            {
+              "x": 5.322251,
+              "y": -3.060296
+            },
+            {
+              "x": 5.337901,
+              "y": -3.008707
+            },
+            {
+              "x": 5.343185,
+              "y": -2.955058
+            },
+            {
+              "x": 5.343185,
+              "y": -0.657786
+            },
+            {
+              "x": 5.337901,
+              "y": -0.604136
+            },
+            {
+              "x": 5.322251,
+              "y": -0.552548
+            },
+            {
+              "x": 5.296839,
+              "y": -0.505004
+            },
+            {
+              "x": 5.262639,
+              "y": -0.463331
+            },
+            {
+              "x": 5.214917,
+              "y": -0.415609
+            },
+            {
+              "x": 5.22,
+              "y": -0.364
+            },
+            {
+              "x": 5.211834,
+              "y": -0.281087
+            },
+            {
+              "x": 5.187649,
+              "y": -0.20136
+            },
+            {
+              "x": 5.148375,
+              "y": -0.127883
+            },
+            {
+              "x": 5.09552,
+              "y": -0.06348
+            },
+            {
+              "x": 5.031117,
+              "y": -0.010625
+            },
+            {
+              "x": 4.95764,
+              "y": 0.028649
+            },
+            {
+              "x": 4.877913,
+              "y": 0.052834
+            },
+            {
+              "x": 4.795,
+              "y": 0.061
+            },
+            {
+              "x": 4.712087,
+              "y": 0.052834
+            },
+            {
+              "x": 4.63236,
+              "y": 0.028649
+            },
+            {
+              "x": 4.558883,
+              "y": -0.010625
+            },
+            {
+              "x": 4.49448,
+              "y": -0.06348
+            },
+            {
+              "x": 4.441625,
+              "y": -0.127883
+            },
+            {
+              "x": 4.402351,
+              "y": -0.20136
+            },
+            {
+              "x": 4.378166,
+              "y": -0.281087
+            },
+            {
+              "x": 4.37,
+              "y": -0.364
+            },
+            {
+              "x": 4.378166,
+              "y": -0.446913
+            },
+            {
+              "x": 4.402351,
+              "y": -0.52664
+            },
+            {
+              "x": 4.441625,
+              "y": -0.600117
+            },
+            {
+              "x": 4.49448,
+              "y": -0.66452
+            },
+            {
+              "x": 4.558883,
+              "y": -0.717375
+            },
+            {
+              "x": 4.63236,
+              "y": -0.756649
+            },
+            {
+              "x": 4.712087,
+              "y": -0.780834
+            },
+            {
+              "x": 4.793185,
+              "y": -0.788821
+            },
+            {
+              "x": 4.793185,
+              "y": -2.841148
+            },
+            {
+              "x": 1.775334,
+              "y": -5.859
+            },
+            {
+              "x": 1.737464,
+              "y": -5.859
+            },
+            {
+              "x": 1.71652,
+              "y": -5.83348
+            },
+            {
+              "x": 1.652117,
+              "y": -5.780625
+            },
+            {
+              "x": 1.57864,
+              "y": -5.741351
+            },
+            {
+              "x": 1.498913,
+              "y": -5.717166
+            },
+            {
+              "x": 1.416,
+              "y": -5.709
+            },
+            {
+              "x": 1.333087,
+              "y": -5.717166
+            },
+            {
+              "x": 1.25336,
+              "y": -5.741351
+            },
+            {
+              "x": 1.179883,
+              "y": -5.780625
+            },
+            {
+              "x": 1.11548,
+              "y": -5.83348
+            },
+            {
+              "x": 1.062625,
+              "y": -5.897883
+            },
+            {
+              "x": 1.023351,
+              "y": -5.97136
+            },
+            {
+              "x": 0.999166,
+              "y": -6.051087
+            },
+            {
+              "x": 0.991,
+              "y": -6.134
+            },
+            {
+              "x": 0.999166,
+              "y": -6.216913
+            },
+            {
+              "x": 1.023351,
+              "y": -6.29664
+            },
+            {
+              "x": 1.062625,
+              "y": -6.370117
+            },
+            {
+              "x": 1.11548,
+              "y": -6.43452
+            },
+            {
+              "x": 1.179883,
+              "y": -6.487375
+            },
+            {
+              "x": 1.25336,
+              "y": -6.526649
+            },
+            {
+              "x": 1.333087,
+              "y": -6.550834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -1.501,
+              "y": -3.121
+            },
+            {
+              "x": -1.418087,
+              "y": -3.112834
+            },
+            {
+              "x": -1.33836,
+              "y": -3.088649
+            },
+            {
+              "x": -1.264883,
+              "y": -3.049375
+            },
+            {
+              "x": -1.20048,
+              "y": -2.99652
+            },
+            {
+              "x": -1.147625,
+              "y": -2.932117
+            },
+            {
+              "x": -1.108351,
+              "y": -2.85864
+            },
+            {
+              "x": -1.084166,
+              "y": -2.778913
+            },
+            {
+              "x": -1.076,
+              "y": -2.696
+            },
+            {
+              "x": -1.084166,
+              "y": -2.613087
+            },
+            {
+              "x": -1.108351,
+              "y": -2.53336
+            },
+            {
+              "x": -1.147625,
+              "y": -2.459883
+            },
+            {
+              "x": -1.20048,
+              "y": -2.39548
+            },
+            {
+              "x": -1.228,
+              "y": -2.372895
+            },
+            {
+              "x": -1.228,
+              "y": -1.237464
+            },
+            {
+              "x": -1.20248,
+              "y": -1.21652
+            },
+            {
+              "x": -1.149625,
+              "y": -1.152117
+            },
+            {
+              "x": -1.110351,
+              "y": -1.07864
+            },
+            {
+              "x": -1.086166,
+              "y": -0.998913
+            },
+            {
+              "x": -1.078,
+              "y": -0.916
+            },
+            {
+              "x": -1.086166,
+              "y": -0.833087
+            },
+            {
+              "x": -1.110351,
+              "y": -0.75336
+            },
+            {
+              "x": -1.149625,
+              "y": -0.679883
+            },
+            {
+              "x": -1.20248,
+              "y": -0.61548
+            },
+            {
+              "x": -1.266883,
+              "y": -0.562625
+            },
+            {
+              "x": -1.34036,
+              "y": -0.523351
+            },
+            {
+              "x": -1.420087,
+              "y": -0.499166
+            },
+            {
+              "x": -1.503,
+              "y": -0.491
+            },
+            {
+              "x": -1.585913,
+              "y": -0.499166
+            },
+            {
+              "x": -1.66564,
+              "y": -0.523351
+            },
+            {
+              "x": -1.739117,
+              "y": -0.562625
+            },
+            {
+              "x": -1.80352,
+              "y": -0.61548
+            },
+            {
+              "x": -1.856375,
+              "y": -0.679883
+            },
+            {
+              "x": -1.895649,
+              "y": -0.75336
+            },
+            {
+              "x": -1.919834,
+              "y": -0.833087
+            },
+            {
+              "x": -1.928,
+              "y": -0.916
+            },
+            {
+              "x": -1.919834,
+              "y": -0.998913
+            },
+            {
+              "x": -1.895649,
+              "y": -1.07864
+            },
+            {
+              "x": -1.856375,
+              "y": -1.152117
+            },
+            {
+              "x": -1.80352,
+              "y": -1.21652
+            },
+            {
+              "x": -1.778,
+              "y": -1.237464
+            },
+            {
+              "x": -1.778,
+              "y": -2.376177
+            },
+            {
+              "x": -1.80152,
+              "y": -2.39548
+            },
+            {
+              "x": -1.854375,
+              "y": -2.459883
+            },
+            {
+              "x": -1.893649,
+              "y": -2.53336
+            },
+            {
+              "x": -1.917834,
+              "y": -2.613087
+            },
+            {
+              "x": -1.926,
+              "y": -2.696
+            },
+            {
+              "x": -1.917834,
+              "y": -2.778913
+            },
+            {
+              "x": -1.893649,
+              "y": -2.85864
+            },
+            {
+              "x": -1.854375,
+              "y": -2.932117
+            },
+            {
+              "x": -1.80152,
+              "y": -2.99652
+            },
+            {
+              "x": -1.737117,
+              "y": -3.049375
+            },
+            {
+              "x": -1.66364,
+              "y": -3.088649
+            },
+            {
+              "x": -1.583913,
+              "y": -3.112834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -33.99,
+              "y": -4.105
+            },
+            {
+              "x": -33.907087,
+              "y": -4.096834
+            },
+            {
+              "x": -33.82736,
+              "y": -4.072649
+            },
+            {
+              "x": -33.753883,
+              "y": -4.033375
+            },
+            {
+              "x": -33.68948,
+              "y": -3.98052
+            },
+            {
+              "x": -33.636625,
+              "y": -3.916117
+            },
+            {
+              "x": -33.597351,
+              "y": -3.84264
+            },
+            {
+              "x": -33.573166,
+              "y": -3.762913
+            },
+            {
+              "x": -33.565,
+              "y": -3.68
+            },
+            {
+              "x": -33.573166,
+              "y": -3.597087
+            },
+            {
+              "x": -33.597351,
+              "y": -3.51736
+            },
+            {
+              "x": -33.636625,
+              "y": -3.443883
+            },
+            {
+              "x": -33.68948,
+              "y": -3.37948
+            },
+            {
+              "x": -33.753883,
+              "y": -3.326625
+            },
+            {
+              "x": -33.82736,
+              "y": -3.287351
+            },
+            {
+              "x": -33.907087,
+              "y": -3.263166
+            },
+            {
+              "x": -33.99,
+              "y": -3.255
+            },
+            {
+              "x": -34.033561,
+              "y": -3.25929
+            },
+            {
+              "x": -34.071894,
+              "y": -3.238801
+            },
+            {
+              "x": -34.123482,
+              "y": -3.223152
+            },
+            {
+              "x": -34.177132,
+              "y": -3.217868
+            },
+            {
+              "x": -36.115528,
+              "y": -3.217868
+            },
+            {
+              "x": -36.063197,
+              "y": -3.119963
+            },
+            {
+              "x": -36.030476,
+              "y": -3.012096
+            },
+            {
+              "x": -36.019427,
+              "y": -2.899918
+            },
+            {
+              "x": -36.030476,
+              "y": -2.78774
+            },
+            {
+              "x": -36.063197,
+              "y": -2.679873
+            },
+            {
+              "x": -36.116333,
+              "y": -2.580462
+            },
+            {
+              "x": -36.187842,
+              "y": -2.493328
+            },
+            {
+              "x": -36.274977,
+              "y": -2.421818
+            },
+            {
+              "x": -36.374388,
+              "y": -2.368682
+            },
+            {
+              "x": -36.482255,
+              "y": -2.335961
+            },
+            {
+              "x": -36.594433,
+              "y": -2.324912
+            },
+            {
+              "x": -36.706611,
+              "y": -2.335961
+            },
+            {
+              "x": -36.814478,
+              "y": -2.368682
+            },
+            {
+              "x": -36.913889,
+              "y": -2.421818
+            },
+            {
+              "x": -36.95524,
+              "y": -2.455754
+            },
+            {
+              "x": -36.95467,
+              "y": -1.889065
+            },
+            {
+              "x": -36.954697,
+              "y": -1.889065
+            },
+            {
+              "x": -36.95467,
+              "y": -1.888788
+            },
+            {
+              "x": -36.957747,
+              "y": -1.857543
+            },
+            {
+              "x": -36.942625,
+              "y": -1.839117
+            },
+            {
+              "x": -36.903351,
+              "y": -1.76564
+            },
+            {
+              "x": -36.879166,
+              "y": -1.685913
+            },
+            {
+              "x": -36.871,
+              "y": -1.603
+            },
+            {
+              "x": -36.879166,
+              "y": -1.520087
+            },
+            {
+              "x": -36.903351,
+              "y": -1.44036
+            },
+            {
+              "x": -36.942625,
+              "y": -1.366883
+            },
+            {
+              "x": -36.99548,
+              "y": -1.30248
+            },
+            {
+              "x": -37.059883,
+              "y": -1.249625
+            },
+            {
+              "x": -37.13336,
+              "y": -1.210351
+            },
+            {
+              "x": -37.213087,
+              "y": -1.186166
+            },
+            {
+              "x": -37.296,
+              "y": -1.178
+            },
+            {
+              "x": -37.378913,
+              "y": -1.186166
+            },
+            {
+              "x": -37.45864,
+              "y": -1.210351
+            },
+            {
+              "x": -37.532117,
+              "y": -1.249625
+            },
+            {
+              "x": -37.59652,
+              "y": -1.30248
+            },
+            {
+              "x": -37.649375,
+              "y": -1.366883
+            },
+            {
+              "x": -37.688649,
+              "y": -1.44036
+            },
+            {
+              "x": -37.712834,
+              "y": -1.520087
+            },
+            {
+              "x": -37.721,
+              "y": -1.603
+            },
+            {
+              "x": -37.712834,
+              "y": -1.685913
+            },
+            {
+              "x": -37.688649,
+              "y": -1.76564
+            },
+            {
+              "x": -37.649375,
+              "y": -1.839117
+            },
+            {
+              "x": -37.59652,
+              "y": -1.90352
+            },
+            {
+              "x": -37.545173,
+              "y": -1.94566
+            },
+            {
+              "x": -37.534769,
+              "y": -1.965124
+            },
+            {
+              "x": -37.504783,
+              "y": -2.001663
+            },
+            {
+              "x": -37.50607,
+              "y": -3.280892
+            },
+            {
+              "x": -37.506043,
+              "y": -3.280892
+            },
+            {
+              "x": -37.50607,
+              "y": -3.281168
+            },
+            {
+              "x": -37.500786,
+              "y": -3.334818
+            },
+            {
+              "x": -37.485137,
+              "y": -3.386406
+            },
+            {
+              "x": -37.459724,
+              "y": -3.43395
+            },
+            {
+              "x": -37.426089,
+              "y": -3.474934
+            },
+            {
+              "x": -37.42615,
+              "y": -3.474995
+            },
+            {
+              "x": -37.213741,
+              "y": -3.688778
+            },
+            {
+              "x": -37.21368,
+              "y": -3.688717
+            },
+            {
+              "x": -37.213115,
+              "y": -3.689406
+            },
+            {
+              "x": -37.171443,
+              "y": -3.723606
+            },
+            {
+              "x": -37.123899,
+              "y": -3.749018
+            },
+            {
+              "x": -37.072311,
+              "y": -3.764667
+            },
+            {
+              "x": -37.018661,
+              "y": -3.769951
+            },
+            {
+              "x": -37.013328,
+              "y": -3.769426
+            },
+            {
+              "x": -37.013319,
+              "y": -3.7699
+            },
+            {
+              "x": -36.908744,
+              "y": -3.767868
+            },
+            {
+              "x": -34.405331,
+              "y": -3.767868
+            },
+            {
+              "x": -34.382649,
+              "y": -3.84264
+            },
+            {
+              "x": -34.343375,
+              "y": -3.916117
+            },
+            {
+              "x": -34.29052,
+              "y": -3.98052
+            },
+            {
+              "x": -34.226117,
+              "y": -4.033375
+            },
+            {
+              "x": -34.15264,
+              "y": -4.072649
+            },
+            {
+              "x": -34.072913,
+              "y": -4.096834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 31.450008,
+              "y": -6.91
+            },
+            {
+              "x": 31.503658,
+              "y": -6.904716
+            },
+            {
+              "x": 31.555246,
+              "y": -6.889067
+            },
+            {
+              "x": 31.60279,
+              "y": -6.863654
+            },
+            {
+              "x": 31.644462,
+              "y": -6.829454
+            },
+            {
+              "x": 31.678662,
+              "y": -6.787782
+            },
+            {
+              "x": 31.704075,
+              "y": -6.740238
+            },
+            {
+              "x": 31.719724,
+              "y": -6.68865
+            },
+            {
+              "x": 31.725008,
+              "y": -6.635
+            },
+            {
+              "x": 31.725008,
+              "y": -6.044899
+            },
+            {
+              "x": 31.719724,
+              "y": -5.99125
+            },
+            {
+              "x": 31.704075,
+              "y": -5.939661
+            },
+            {
+              "x": 31.678662,
+              "y": -5.892118
+            },
+            {
+              "x": 31.644462,
+              "y": -5.850445
+            },
+            {
+              "x": 27.534684,
+              "y": -1.740666
+            },
+            {
+              "x": 27.538,
+              "y": -1.707
+            },
+            {
+              "x": 27.529834,
+              "y": -1.624087
+            },
+            {
+              "x": 27.505649,
+              "y": -1.54436
+            },
+            {
+              "x": 27.466375,
+              "y": -1.470883
+            },
+            {
+              "x": 27.41352,
+              "y": -1.40648
+            },
+            {
+              "x": 27.349117,
+              "y": -1.353625
+            },
+            {
+              "x": 27.27564,
+              "y": -1.314351
+            },
+            {
+              "x": 27.195913,
+              "y": -1.290166
+            },
+            {
+              "x": 27.113,
+              "y": -1.282
+            },
+            {
+              "x": 27.030087,
+              "y": -1.290166
+            },
+            {
+              "x": 26.95036,
+              "y": -1.314351
+            },
+            {
+              "x": 26.876883,
+              "y": -1.353625
+            },
+            {
+              "x": 26.81248,
+              "y": -1.40648
+            },
+            {
+              "x": 26.759625,
+              "y": -1.470883
+            },
+            {
+              "x": 26.720351,
+              "y": -1.54436
+            },
+            {
+              "x": 26.696166,
+              "y": -1.624087
+            },
+            {
+              "x": 26.688,
+              "y": -1.707
+            },
+            {
+              "x": 26.696166,
+              "y": -1.789913
+            },
+            {
+              "x": 26.720351,
+              "y": -1.86964
+            },
+            {
+              "x": 26.759625,
+              "y": -1.943117
+            },
+            {
+              "x": 26.81248,
+              "y": -2.00752
+            },
+            {
+              "x": 26.876883,
+              "y": -2.060375
+            },
+            {
+              "x": 26.95036,
+              "y": -2.099649
+            },
+            {
+              "x": 27.030087,
+              "y": -2.123834
+            },
+            {
+              "x": 27.113,
+              "y": -2.132
+            },
+            {
+              "x": 27.145044,
+              "y": -2.128844
+            },
+            {
+              "x": 31.175008,
+              "y": -6.158808
+            },
+            {
+              "x": 31.175008,
+              "y": -6.635
+            },
+            {
+              "x": 31.180292,
+              "y": -6.68865
+            },
+            {
+              "x": 31.195941,
+              "y": -6.740238
+            },
+            {
+              "x": 31.221354,
+              "y": -6.787782
+            },
+            {
+              "x": 31.255554,
+              "y": -6.829454
+            },
+            {
+              "x": 31.297226,
+              "y": -6.863654
+            },
+            {
+              "x": 31.34477,
+              "y": -6.889067
+            },
+            {
+              "x": 31.396358,
+              "y": -6.904716
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -2.389,
+              "y": -8.9
+            },
+            {
+              "x": -2.306087,
+              "y": -8.891834
+            },
+            {
+              "x": -2.22636,
+              "y": -8.867649
+            },
+            {
+              "x": -2.152883,
+              "y": -8.828375
+            },
+            {
+              "x": -2.08848,
+              "y": -8.77552
+            },
+            {
+              "x": -2.035625,
+              "y": -8.711117
+            },
+            {
+              "x": -1.996351,
+              "y": -8.63764
+            },
+            {
+              "x": -1.972166,
+              "y": -8.557913
+            },
+            {
+              "x": -1.964,
+              "y": -8.475
+            },
+            {
+              "x": -1.972166,
+              "y": -8.392087
+            },
+            {
+              "x": -1.996351,
+              "y": -8.31236
+            },
+            {
+              "x": -2.035625,
+              "y": -8.238883
+            },
+            {
+              "x": -2.08848,
+              "y": -8.17448
+            },
+            {
+              "x": -2.152883,
+              "y": -8.121625
+            },
+            {
+              "x": -2.165134,
+              "y": -8.115077
+            },
+            {
+              "x": -2.22207,
+              "y": -7.737264
+            },
+            {
+              "x": -2.223022,
+              "y": -7.737407
+            },
+            {
+              "x": -2.224284,
+              "y": -7.724594
+            },
+            {
+              "x": -2.239933,
+              "y": -7.673006
+            },
+            {
+              "x": -2.265346,
+              "y": -7.625462
+            },
+            {
+              "x": -2.299546,
+              "y": -7.583789
+            },
+            {
+              "x": -4.786415,
+              "y": -5.09692
+            },
+            {
+              "x": -4.782166,
+              "y": -5.082913
+            },
+            {
+              "x": -4.774,
+              "y": -5
+            },
+            {
+              "x": -4.782166,
+              "y": -4.917087
+            },
+            {
+              "x": -4.806351,
+              "y": -4.83736
+            },
+            {
+              "x": -4.845625,
+              "y": -4.763883
+            },
+            {
+              "x": -4.89848,
+              "y": -4.69948
+            },
+            {
+              "x": -4.962883,
+              "y": -4.646625
+            },
+            {
+              "x": -5.03636,
+              "y": -4.607351
+            },
+            {
+              "x": -5.116087,
+              "y": -4.583166
+            },
+            {
+              "x": -5.199,
+              "y": -4.575
+            },
+            {
+              "x": -5.281913,
+              "y": -4.583166
+            },
+            {
+              "x": -5.36164,
+              "y": -4.607351
+            },
+            {
+              "x": -5.435117,
+              "y": -4.646625
+            },
+            {
+              "x": -5.49952,
+              "y": -4.69948
+            },
+            {
+              "x": -5.552375,
+              "y": -4.763883
+            },
+            {
+              "x": -5.591649,
+              "y": -4.83736
+            },
+            {
+              "x": -5.615834,
+              "y": -4.917087
+            },
+            {
+              "x": -5.624,
+              "y": -5
+            },
+            {
+              "x": -5.615834,
+              "y": -5.082913
+            },
+            {
+              "x": -5.591649,
+              "y": -5.16264
+            },
+            {
+              "x": -5.552375,
+              "y": -5.236117
+            },
+            {
+              "x": -5.49952,
+              "y": -5.30052
+            },
+            {
+              "x": -5.435117,
+              "y": -5.353375
+            },
+            {
+              "x": -5.36164,
+              "y": -5.392649
+            },
+            {
+              "x": -5.281913,
+              "y": -5.416834
+            },
+            {
+              "x": -5.240212,
+              "y": -5.420941
+            },
+            {
+              "x": -2.752445,
+              "y": -7.908707
+            },
+            {
+              "x": -2.708845,
+              "y": -8.198027
+            },
+            {
+              "x": -2.742375,
+              "y": -8.238883
+            },
+            {
+              "x": -2.781649,
+              "y": -8.31236
+            },
+            {
+              "x": -2.805834,
+              "y": -8.392087
+            },
+            {
+              "x": -2.814,
+              "y": -8.475
+            },
+            {
+              "x": -2.805834,
+              "y": -8.557913
+            },
+            {
+              "x": -2.781649,
+              "y": -8.63764
+            },
+            {
+              "x": -2.742375,
+              "y": -8.711117
+            },
+            {
+              "x": -2.68952,
+              "y": -8.77552
+            },
+            {
+              "x": -2.625117,
+              "y": -8.828375
+            },
+            {
+              "x": -2.55164,
+              "y": -8.867649
+            },
+            {
+              "x": -2.471913,
+              "y": -8.891834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 18.408,
+              "y": -6.513
+            },
+            {
+              "x": 18.490913,
+              "y": -6.504834
+            },
+            {
+              "x": 18.57064,
+              "y": -6.480649
+            },
+            {
+              "x": 18.644117,
+              "y": -6.441375
+            },
+            {
+              "x": 18.70852,
+              "y": -6.38852
+            },
+            {
+              "x": 18.761375,
+              "y": -6.324117
+            },
+            {
+              "x": 18.800649,
+              "y": -6.25064
+            },
+            {
+              "x": 18.824834,
+              "y": -6.170913
+            },
+            {
+              "x": 18.833,
+              "y": -6.088
+            },
+            {
+              "x": 18.824834,
+              "y": -6.005087
+            },
+            {
+              "x": 18.800649,
+              "y": -5.92536
+            },
+            {
+              "x": 18.761375,
+              "y": -5.851883
+            },
+            {
+              "x": 18.70852,
+              "y": -5.78748
+            },
+            {
+              "x": 18.644117,
+              "y": -5.734625
+            },
+            {
+              "x": 18.57064,
+              "y": -5.695351
+            },
+            {
+              "x": 18.490913,
+              "y": -5.671166
+            },
+            {
+              "x": 18.408,
+              "y": -5.663
+            },
+            {
+              "x": 18.325087,
+              "y": -5.671166
+            },
+            {
+              "x": 18.24536,
+              "y": -5.695351
+            },
+            {
+              "x": 18.171883,
+              "y": -5.734625
+            },
+            {
+              "x": 18.10748,
+              "y": -5.78748
+            },
+            {
+              "x": 18.086536,
+              "y": -5.813
+            },
+            {
+              "x": 9.620407,
+              "y": -5.813
+            },
+            {
+              "x": 8.721904,
+              "y": -4.914497
+            },
+            {
+              "x": 8.720649,
+              "y": -4.91036
+            },
+            {
+              "x": 8.681375,
+              "y": -4.836883
+            },
+            {
+              "x": 8.62852,
+              "y": -4.77248
+            },
+            {
+              "x": 8.564117,
+              "y": -4.719625
+            },
+            {
+              "x": 8.49064,
+              "y": -4.680351
+            },
+            {
+              "x": 8.410913,
+              "y": -4.656166
+            },
+            {
+              "x": 8.328,
+              "y": -4.648
+            },
+            {
+              "x": 8.245087,
+              "y": -4.656166
+            },
+            {
+              "x": 8.16536,
+              "y": -4.680351
+            },
+            {
+              "x": 8.091883,
+              "y": -4.719625
+            },
+            {
+              "x": 8.02748,
+              "y": -4.77248
+            },
+            {
+              "x": 7.974625,
+              "y": -4.836883
+            },
+            {
+              "x": 7.935351,
+              "y": -4.91036
+            },
+            {
+              "x": 7.911166,
+              "y": -4.990087
+            },
+            {
+              "x": 7.903,
+              "y": -5.073
+            },
+            {
+              "x": 7.911166,
+              "y": -5.155913
+            },
+            {
+              "x": 7.935351,
+              "y": -5.23564
+            },
+            {
+              "x": 7.974625,
+              "y": -5.309117
+            },
+            {
+              "x": 8.02748,
+              "y": -5.37352
+            },
+            {
+              "x": 8.091883,
+              "y": -5.426375
+            },
+            {
+              "x": 8.16536,
+              "y": -5.465649
+            },
+            {
+              "x": 8.245087,
+              "y": -5.489834
+            },
+            {
+              "x": 8.328,
+              "y": -5.498
+            },
+            {
+              "x": 8.410913,
+              "y": -5.489834
+            },
+            {
+              "x": 8.49064,
+              "y": -5.465649
+            },
+            {
+              "x": 8.493637,
+              "y": -5.464047
+            },
+            {
+              "x": 9.312044,
+              "y": -6.282454
+            },
+            {
+              "x": 9.353717,
+              "y": -6.316654
+            },
+            {
+              "x": 9.401261,
+              "y": -6.342067
+            },
+            {
+              "x": 9.452849,
+              "y": -6.357716
+            },
+            {
+              "x": 9.506499,
+              "y": -6.363
+            },
+            {
+              "x": 18.086536,
+              "y": -6.363
+            },
+            {
+              "x": 18.10748,
+              "y": -6.38852
+            },
+            {
+              "x": 18.171883,
+              "y": -6.441375
+            },
+            {
+              "x": 18.24536,
+              "y": -6.480649
+            },
+            {
+              "x": 18.325087,
+              "y": -6.504834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 24.6,
+              "y": -8.633
+            },
+            {
+              "x": 24.682913,
+              "y": -8.624834
+            },
+            {
+              "x": 24.76264,
+              "y": -8.600649
+            },
+            {
+              "x": 24.836117,
+              "y": -8.561375
+            },
+            {
+              "x": 24.90052,
+              "y": -8.50852
+            },
+            {
+              "x": 24.953375,
+              "y": -8.444117
+            },
+            {
+              "x": 24.992649,
+              "y": -8.37064
+            },
+            {
+              "x": 25.016834,
+              "y": -8.290913
+            },
+            {
+              "x": 25.025,
+              "y": -8.208
+            },
+            {
+              "x": 25.016834,
+              "y": -8.125087
+            },
+            {
+              "x": 24.992649,
+              "y": -8.04536
+            },
+            {
+              "x": 24.953375,
+              "y": -7.971883
+            },
+            {
+              "x": 24.90052,
+              "y": -7.90748
+            },
+            {
+              "x": 24.836117,
+              "y": -7.854625
+            },
+            {
+              "x": 24.76264,
+              "y": -7.815351
+            },
+            {
+              "x": 24.682913,
+              "y": -7.791166
+            },
+            {
+              "x": 24.6,
+              "y": -7.783
+            },
+            {
+              "x": 24.567144,
+              "y": -7.786236
+            },
+            {
+              "x": 24.430548,
+              "y": -7.64964
+            },
+            {
+              "x": 24.388876,
+              "y": -7.61544
+            },
+            {
+              "x": 24.341332,
+              "y": -7.590027
+            },
+            {
+              "x": 24.289744,
+              "y": -7.574378
+            },
+            {
+              "x": 24.236094,
+              "y": -7.569094
+            },
+            {
+              "x": 19.387269,
+              "y": -7.569094
+            },
+            {
+              "x": 19.327672,
+              "y": -7.537239
+            },
+            {
+              "x": 19.247945,
+              "y": -7.513054
+            },
+            {
+              "x": 19.165031,
+              "y": -7.504888
+            },
+            {
+              "x": 19.082118,
+              "y": -7.513054
+            },
+            {
+              "x": 19.002391,
+              "y": -7.537239
+            },
+            {
+              "x": 18.928914,
+              "y": -7.576513
+            },
+            {
+              "x": 18.864511,
+              "y": -7.629367
+            },
+            {
+              "x": 18.811657,
+              "y": -7.69377
+            },
+            {
+              "x": 18.772383,
+              "y": -7.767247
+            },
+            {
+              "x": 18.748198,
+              "y": -7.846974
+            },
+            {
+              "x": 18.740031,
+              "y": -7.929888
+            },
+            {
+              "x": 18.748198,
+              "y": -8.012801
+            },
+            {
+              "x": 18.772383,
+              "y": -8.092528
+            },
+            {
+              "x": 18.811657,
+              "y": -8.166005
+            },
+            {
+              "x": 18.864511,
+              "y": -8.230408
+            },
+            {
+              "x": 18.928914,
+              "y": -8.283262
+            },
+            {
+              "x": 19.002391,
+              "y": -8.322537
+            },
+            {
+              "x": 19.082118,
+              "y": -8.346722
+            },
+            {
+              "x": 19.165031,
+              "y": -8.354888
+            },
+            {
+              "x": 19.247945,
+              "y": -8.346722
+            },
+            {
+              "x": 19.327672,
+              "y": -8.322537
+            },
+            {
+              "x": 19.401149,
+              "y": -8.283262
+            },
+            {
+              "x": 19.465552,
+              "y": -8.230408
+            },
+            {
+              "x": 19.518406,
+              "y": -8.166005
+            },
+            {
+              "x": 19.54348,
+              "y": -8.119094
+            },
+            {
+              "x": 24.122186,
+              "y": -8.119094
+            },
+            {
+              "x": 24.178236,
+              "y": -8.175144
+            },
+            {
+              "x": 24.175,
+              "y": -8.208
+            },
+            {
+              "x": 24.183166,
+              "y": -8.290913
+            },
+            {
+              "x": 24.207351,
+              "y": -8.37064
+            },
+            {
+              "x": 24.246625,
+              "y": -8.444117
+            },
+            {
+              "x": 24.29948,
+              "y": -8.50852
+            },
+            {
+              "x": 24.363883,
+              "y": -8.561375
+            },
+            {
+              "x": 24.43736,
+              "y": -8.600649
+            },
+            {
+              "x": 24.517087,
+              "y": -8.624834
+            }
+          ]
+        }
+      ]
+    },
+    "source_net_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "covered_with_solder_mask": true
+  },
+  {
+    "type": "pcb_copper_pour",
+    "pcb_copper_pour_id": "pcb_copper_pour_1",
+    "shape": "brep",
+    "layer": "inner2",
+    "brep_shape": {
+      "outer_ring": {
+        "vertices": [
+          {
+            "x": 9.174123,
+            "y": -5.75
+          },
+          {
+            "x": -41.75,
+            "y": -5.75
+          },
+          {
+            "x": -41.75,
+            "y": 15.75
+          },
+          {
+            "x": -6.25,
+            "y": 15.75
+          },
+          {
+            "x": -6.25,
+            "y": 4.25
+          },
+          {
+            "x": -6.25,
+            "y": 3.75
+          },
+          {
+            "x": -5.75,
+            "y": 3.75
+          },
+          {
+            "x": 22,
+            "y": 3.75
+          },
+          {
+            "x": 22.25,
+            "y": 3.75
+          },
+          {
+            "x": 22.25,
+            "y": 4
+          },
+          {
+            "x": 22.25,
+            "y": 15.75
+          },
+          {
+            "x": 41.75,
+            "y": 15.75
+          },
+          {
+            "x": 41.75,
+            "y": -5.75
+          },
+          {
+            "x": 30.868588,
+            "y": -5.75
+          },
+          {
+            "x": 30.809668,
+            "y": -5.732127
+          },
+          {
+            "x": 30.717,
+            "y": -5.723
+          },
+          {
+            "x": 30.624332,
+            "y": -5.732127
+          },
+          {
+            "x": 30.565412,
+            "y": -5.75
+          },
+          {
+            "x": 10.093363,
+            "y": -5.75
+          },
+          {
+            "x": 7.753148,
+            "y": -3.409785
+          },
+          {
+            "x": 7.703899,
+            "y": -3.369367
+          },
+          {
+            "x": 7.64771,
+            "y": -3.339334
+          },
+          {
+            "x": 7.586743,
+            "y": -3.32084
+          },
+          {
+            "x": 7.523338,
+            "y": -3.314595
+          },
+          {
+            "x": 5.191215,
+            "y": -3.314595
+          },
+          {
+            "x": 4.800621,
+            "y": -2.924002
+          },
+          {
+            "x": 4.802,
+            "y": -2.91
+          },
+          {
+            "x": 4.792873,
+            "y": -2.817332
+          },
+          {
+            "x": 4.765843,
+            "y": -2.728225
+          },
+          {
+            "x": 4.721948,
+            "y": -2.646104
+          },
+          {
+            "x": 4.662876,
+            "y": -2.574124
+          },
+          {
+            "x": 4.590896,
+            "y": -2.515052
+          },
+          {
+            "x": 4.508775,
+            "y": -2.471157
+          },
+          {
+            "x": 4.419668,
+            "y": -2.444127
+          },
+          {
+            "x": 4.327,
+            "y": -2.435
+          },
+          {
+            "x": 4.234332,
+            "y": -2.444127
+          },
+          {
+            "x": 4.145225,
+            "y": -2.471157
+          },
+          {
+            "x": 4.063104,
+            "y": -2.515052
+          },
+          {
+            "x": 3.991124,
+            "y": -2.574124
+          },
+          {
+            "x": 3.932052,
+            "y": -2.646104
+          },
+          {
+            "x": 3.888157,
+            "y": -2.728225
+          },
+          {
+            "x": 3.870646,
+            "y": -2.785953
+          },
+          {
+            "x": 3.596793,
+            "y": -2.5121
+          },
+          {
+            "x": 3.596793,
+            "y": -2.501177
+          },
+          {
+            "x": 3.630896,
+            "y": -2.482948
+          },
+          {
+            "x": 3.702876,
+            "y": -2.423876
+          },
+          {
+            "x": 3.761948,
+            "y": -2.351896
+          },
+          {
+            "x": 3.805843,
+            "y": -2.269775
+          },
+          {
+            "x": 3.832873,
+            "y": -2.180668
+          },
+          {
+            "x": 3.842,
+            "y": -2.088
+          },
+          {
+            "x": 3.832873,
+            "y": -1.995332
+          },
+          {
+            "x": 3.805843,
+            "y": -1.906225
+          },
+          {
+            "x": 3.761948,
+            "y": -1.824104
+          },
+          {
+            "x": 3.702876,
+            "y": -1.752124
+          },
+          {
+            "x": 3.630896,
+            "y": -1.693052
+          },
+          {
+            "x": 3.548775,
+            "y": -1.649157
+          },
+          {
+            "x": 3.459668,
+            "y": -1.622127
+          },
+          {
+            "x": 3.367,
+            "y": -1.613
+          },
+          {
+            "x": 3.274332,
+            "y": -1.622127
+          },
+          {
+            "x": 3.185225,
+            "y": -1.649157
+          },
+          {
+            "x": 3.103104,
+            "y": -1.693052
+          },
+          {
+            "x": 3.031124,
+            "y": -1.752124
+          },
+          {
+            "x": 2.972052,
+            "y": -1.824104
+          },
+          {
+            "x": 2.928157,
+            "y": -1.906225
+          },
+          {
+            "x": 2.901127,
+            "y": -1.995332
+          },
+          {
+            "x": 2.892,
+            "y": -2.088
+          },
+          {
+            "x": 2.901127,
+            "y": -2.180668
+          },
+          {
+            "x": 2.928157,
+            "y": -2.269775
+          },
+          {
+            "x": 2.946793,
+            "y": -2.30464
+          },
+          {
+            "x": 2.946793,
+            "y": -2.64672
+          },
+          {
+            "x": 2.953038,
+            "y": -2.710124
+          },
+          {
+            "x": 2.971532,
+            "y": -2.771092
+          },
+          {
+            "x": 3.001566,
+            "y": -2.82728
+          },
+          {
+            "x": 3.041983,
+            "y": -2.876529
+          },
+          {
+            "x": 4.324477,
+            "y": -4.159022
+          },
+          {
+            "x": 4.373726,
+            "y": -4.19944
+          },
+          {
+            "x": 4.429914,
+            "y": -4.229474
+          },
+          {
+            "x": 4.490882,
+            "y": -4.247968
+          },
+          {
+            "x": 4.554286,
+            "y": -4.254213
+          },
+          {
+            "x": 7.049594,
+            "y": -4.254213
+          },
+          {
+            "x": 7.854379,
+            "y": -5.058999
+          },
+          {
+            "x": 7.853,
+            "y": -5.073
+          },
+          {
+            "x": 7.862127,
+            "y": -5.165668
+          },
+          {
+            "x": 7.889157,
+            "y": -5.254775
+          },
+          {
+            "x": 7.933052,
+            "y": -5.336896
+          },
+          {
+            "x": 7.992124,
+            "y": -5.408876
+          },
+          {
+            "x": 8.064104,
+            "y": -5.467948
+          },
+          {
+            "x": 8.146225,
+            "y": -5.511843
+          },
+          {
+            "x": 8.235332,
+            "y": -5.538873
+          },
+          {
+            "x": 8.328,
+            "y": -5.548
+          },
+          {
+            "x": 8.420668,
+            "y": -5.538873
+          },
+          {
+            "x": 8.509775,
+            "y": -5.511843
+          },
+          {
+            "x": 8.591896,
+            "y": -5.467948
+          },
+          {
+            "x": 8.663876,
+            "y": -5.408876
+          },
+          {
+            "x": 8.722948,
+            "y": -5.336896
+          },
+          {
+            "x": 8.736209,
+            "y": -5.312086
+          }
+        ]
+      },
+      "inner_rings": [
+        {
+          "vertices": [
+            {
+              "x": -19.891,
+              "y": 9.019
+            },
+            {
+              "x": -19.798332,
+              "y": 9.028127
+            },
+            {
+              "x": -19.709225,
+              "y": 9.055157
+            },
+            {
+              "x": -19.627104,
+              "y": 9.099052
+            },
+            {
+              "x": -19.555124,
+              "y": 9.158124
+            },
+            {
+              "x": -19.496052,
+              "y": 9.230104
+            },
+            {
+              "x": -19.452157,
+              "y": 9.312225
+            },
+            {
+              "x": -19.425127,
+              "y": 9.401332
+            },
+            {
+              "x": -19.416,
+              "y": 9.494
+            },
+            {
+              "x": -19.425127,
+              "y": 9.586668
+            },
+            {
+              "x": -19.452157,
+              "y": 9.675775
+            },
+            {
+              "x": -19.496052,
+              "y": 9.757896
+            },
+            {
+              "x": -19.555124,
+              "y": 9.829876
+            },
+            {
+              "x": -19.627104,
+              "y": 9.888948
+            },
+            {
+              "x": -19.709225,
+              "y": 9.932843
+            },
+            {
+              "x": -19.798332,
+              "y": 9.959873
+            },
+            {
+              "x": -19.891,
+              "y": 9.969
+            },
+            {
+              "x": -19.983668,
+              "y": 9.959873
+            },
+            {
+              "x": -20.072775,
+              "y": 9.932843
+            },
+            {
+              "x": -20.154896,
+              "y": 9.888948
+            },
+            {
+              "x": -20.226876,
+              "y": 9.829876
+            },
+            {
+              "x": -20.235802,
+              "y": 9.819
+            },
+            {
+              "x": -21.114394,
+              "y": 9.819
+            },
+            {
+              "x": -21.114,
+              "y": 9.823
+            },
+            {
+              "x": -21.123127,
+              "y": 9.915668
+            },
+            {
+              "x": -21.150157,
+              "y": 10.004775
+            },
+            {
+              "x": -21.194052,
+              "y": 10.086896
+            },
+            {
+              "x": -21.253124,
+              "y": 10.158876
+            },
+            {
+              "x": -21.325104,
+              "y": 10.217948
+            },
+            {
+              "x": -21.407225,
+              "y": 10.261843
+            },
+            {
+              "x": -21.496332,
+              "y": 10.288873
+            },
+            {
+              "x": -21.589,
+              "y": 10.298
+            },
+            {
+              "x": -21.681668,
+              "y": 10.288873
+            },
+            {
+              "x": -21.770775,
+              "y": 10.261843
+            },
+            {
+              "x": -21.852896,
+              "y": 10.217948
+            },
+            {
+              "x": -21.924876,
+              "y": 10.158876
+            },
+            {
+              "x": -21.983948,
+              "y": 10.086896
+            },
+            {
+              "x": -22.027843,
+              "y": 10.004775
+            },
+            {
+              "x": -22.054873,
+              "y": 9.915668
+            },
+            {
+              "x": -22.064,
+              "y": 9.823
+            },
+            {
+              "x": -22.054873,
+              "y": 9.730332
+            },
+            {
+              "x": -22.027843,
+              "y": 9.641225
+            },
+            {
+              "x": -21.983948,
+              "y": 9.559104
+            },
+            {
+              "x": -21.924876,
+              "y": 9.487124
+            },
+            {
+              "x": -21.852896,
+              "y": 9.428052
+            },
+            {
+              "x": -21.770775,
+              "y": 9.384157
+            },
+            {
+              "x": -21.681668,
+              "y": 9.357127
+            },
+            {
+              "x": -21.589,
+              "y": 9.348
+            },
+            {
+              "x": -21.567744,
+              "y": 9.350094
+            },
+            {
+              "x": -21.481841,
+              "y": 9.26419
+            },
+            {
+              "x": -21.432591,
+              "y": 9.223772
+            },
+            {
+              "x": -21.376403,
+              "y": 9.193739
+            },
+            {
+              "x": -21.315435,
+              "y": 9.175245
+            },
+            {
+              "x": -21.252031,
+              "y": 9.169
+            },
+            {
+              "x": -20.235802,
+              "y": 9.169
+            },
+            {
+              "x": -20.226876,
+              "y": 9.158124
+            },
+            {
+              "x": -20.154896,
+              "y": 9.099052
+            },
+            {
+              "x": -20.072775,
+              "y": 9.055157
+            },
+            {
+              "x": -19.983668,
+              "y": 9.028127
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.594433,
+              "y": 2.274912
+            },
+            {
+              "x": -36.4725,
+              "y": 2.286922
+            },
+            {
+              "x": -36.355254,
+              "y": 2.322488
+            },
+            {
+              "x": -36.247198,
+              "y": 2.380245
+            },
+            {
+              "x": -36.152487,
+              "y": 2.457972
+            },
+            {
+              "x": -36.07476,
+              "y": 2.552683
+            },
+            {
+              "x": -36.017003,
+              "y": 2.660739
+            },
+            {
+              "x": -35.981437,
+              "y": 2.777985
+            },
+            {
+              "x": -35.969427,
+              "y": 2.899918
+            },
+            {
+              "x": -35.981437,
+              "y": 3.021851
+            },
+            {
+              "x": -36.017003,
+              "y": 3.139097
+            },
+            {
+              "x": -36.07476,
+              "y": 3.247153
+            },
+            {
+              "x": -36.152487,
+              "y": 3.341864
+            },
+            {
+              "x": -36.247198,
+              "y": 3.419591
+            },
+            {
+              "x": -36.355254,
+              "y": 3.477348
+            },
+            {
+              "x": -36.4725,
+              "y": 3.512914
+            },
+            {
+              "x": -36.594433,
+              "y": 3.524924
+            },
+            {
+              "x": -36.716365,
+              "y": 3.512914
+            },
+            {
+              "x": -36.833612,
+              "y": 3.477348
+            },
+            {
+              "x": -36.941667,
+              "y": 3.419591
+            },
+            {
+              "x": -37.036378,
+              "y": 3.341864
+            },
+            {
+              "x": -37.114106,
+              "y": 3.247153
+            },
+            {
+              "x": -37.171863,
+              "y": 3.139097
+            },
+            {
+              "x": -37.207429,
+              "y": 3.021851
+            },
+            {
+              "x": -37.219438,
+              "y": 2.899918
+            },
+            {
+              "x": -37.207429,
+              "y": 2.777985
+            },
+            {
+              "x": -37.171863,
+              "y": 2.660739
+            },
+            {
+              "x": -37.114106,
+              "y": 2.552683
+            },
+            {
+              "x": -37.036378,
+              "y": 2.457972
+            },
+            {
+              "x": -36.941667,
+              "y": 2.380245
+            },
+            {
+              "x": -36.833612,
+              "y": 2.322488
+            },
+            {
+              "x": -36.716365,
+              "y": 2.286922
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 11.805,
+              "y": -1.486
+            },
+            {
+              "x": 11.897668,
+              "y": -1.476873
+            },
+            {
+              "x": 11.986775,
+              "y": -1.449843
+            },
+            {
+              "x": 12.068896,
+              "y": -1.405948
+            },
+            {
+              "x": 12.140876,
+              "y": -1.346876
+            },
+            {
+              "x": 12.199948,
+              "y": -1.274896
+            },
+            {
+              "x": 12.243843,
+              "y": -1.192775
+            },
+            {
+              "x": 12.270873,
+              "y": -1.103668
+            },
+            {
+              "x": 12.28,
+              "y": -1.011
+            },
+            {
+              "x": 12.270873,
+              "y": -0.918332
+            },
+            {
+              "x": 12.243843,
+              "y": -0.829225
+            },
+            {
+              "x": 12.199948,
+              "y": -0.747104
+            },
+            {
+              "x": 12.140876,
+              "y": -0.675124
+            },
+            {
+              "x": 12.068896,
+              "y": -0.616052
+            },
+            {
+              "x": 11.986775,
+              "y": -0.572157
+            },
+            {
+              "x": 11.897668,
+              "y": -0.545127
+            },
+            {
+              "x": 11.805,
+              "y": -0.536
+            },
+            {
+              "x": 11.790999,
+              "y": -0.537379
+            },
+            {
+              "x": 8.847139,
+              "y": 2.406481
+            },
+            {
+              "x": 8.797889,
+              "y": 2.446899
+            },
+            {
+              "x": 8.741701,
+              "y": 2.476932
+            },
+            {
+              "x": 8.680733,
+              "y": 2.495426
+            },
+            {
+              "x": 8.617329,
+              "y": 2.501671
+            },
+            {
+              "x": 2.408099,
+              "y": 2.501671
+            },
+            {
+              "x": 2.395636,
+              "y": 2.516857
+            },
+            {
+              "x": 2.323656,
+              "y": 2.57593
+            },
+            {
+              "x": 2.241535,
+              "y": 2.619825
+            },
+            {
+              "x": 2.152428,
+              "y": 2.646855
+            },
+            {
+              "x": 2.05976,
+              "y": 2.655982
+            },
+            {
+              "x": 1.967092,
+              "y": 2.646855
+            },
+            {
+              "x": 1.877985,
+              "y": 2.619825
+            },
+            {
+              "x": 1.795864,
+              "y": 2.57593
+            },
+            {
+              "x": 1.723884,
+              "y": 2.516857
+            },
+            {
+              "x": 1.664812,
+              "y": 2.444878
+            },
+            {
+              "x": 1.620917,
+              "y": 2.362756
+            },
+            {
+              "x": 1.593887,
+              "y": 2.27365
+            },
+            {
+              "x": 1.58476,
+              "y": 2.180982
+            },
+            {
+              "x": 1.593887,
+              "y": 2.088314
+            },
+            {
+              "x": 1.620917,
+              "y": 1.999207
+            },
+            {
+              "x": 1.664812,
+              "y": 1.917086
+            },
+            {
+              "x": 1.723884,
+              "y": 1.845106
+            },
+            {
+              "x": 1.795864,
+              "y": 1.786034
+            },
+            {
+              "x": 1.877985,
+              "y": 1.742139
+            },
+            {
+              "x": 1.967092,
+              "y": 1.715109
+            },
+            {
+              "x": 2.05976,
+              "y": 1.705982
+            },
+            {
+              "x": 2.152428,
+              "y": 1.715109
+            },
+            {
+              "x": 2.241535,
+              "y": 1.742139
+            },
+            {
+              "x": 2.323656,
+              "y": 1.786034
+            },
+            {
+              "x": 2.395636,
+              "y": 1.845106
+            },
+            {
+              "x": 2.401024,
+              "y": 1.851671
+            },
+            {
+              "x": 8.482709,
+              "y": 1.851671
+            },
+            {
+              "x": 11.331379,
+              "y": -0.996999
+            },
+            {
+              "x": 11.33,
+              "y": -1.011
+            },
+            {
+              "x": 11.339127,
+              "y": -1.103668
+            },
+            {
+              "x": 11.366157,
+              "y": -1.192775
+            },
+            {
+              "x": 11.410052,
+              "y": -1.274896
+            },
+            {
+              "x": 11.469124,
+              "y": -1.346876
+            },
+            {
+              "x": 11.541104,
+              "y": -1.405948
+            },
+            {
+              "x": 11.623225,
+              "y": -1.449843
+            },
+            {
+              "x": 11.712332,
+              "y": -1.476873
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -0.555,
+              "y": -3.624
+            },
+            {
+              "x": -0.462332,
+              "y": -3.614873
+            },
+            {
+              "x": -0.373225,
+              "y": -3.587843
+            },
+            {
+              "x": -0.291104,
+              "y": -3.543948
+            },
+            {
+              "x": -0.219124,
+              "y": -3.484876
+            },
+            {
+              "x": -0.160052,
+              "y": -3.412896
+            },
+            {
+              "x": -0.116157,
+              "y": -3.330775
+            },
+            {
+              "x": -0.089127,
+              "y": -3.241668
+            },
+            {
+              "x": -0.08,
+              "y": -3.149
+            },
+            {
+              "x": -0.089127,
+              "y": -3.056332
+            },
+            {
+              "x": -0.116157,
+              "y": -2.967225
+            },
+            {
+              "x": -0.160052,
+              "y": -2.885104
+            },
+            {
+              "x": -0.219124,
+              "y": -2.813124
+            },
+            {
+              "x": -0.291104,
+              "y": -2.754052
+            },
+            {
+              "x": -0.373225,
+              "y": -2.710157
+            },
+            {
+              "x": -0.462332,
+              "y": -2.683127
+            },
+            {
+              "x": -0.555,
+              "y": -2.674
+            },
+            {
+              "x": -0.647668,
+              "y": -2.683127
+            },
+            {
+              "x": -0.736775,
+              "y": -2.710157
+            },
+            {
+              "x": -0.818896,
+              "y": -2.754052
+            },
+            {
+              "x": -0.890876,
+              "y": -2.813124
+            },
+            {
+              "x": -0.905897,
+              "y": -2.831427
+            },
+            {
+              "x": -4.305646,
+              "y": -2.904109
+            },
+            {
+              "x": -5.785776,
+              "y": -1.42398
+            },
+            {
+              "x": -5.785776,
+              "y": -0.767224
+            },
+            {
+              "x": -5.792021,
+              "y": -0.703819
+            },
+            {
+              "x": -5.810516,
+              "y": -0.642851
+            },
+            {
+              "x": -5.840549,
+              "y": -0.586663
+            },
+            {
+              "x": -5.880967,
+              "y": -0.537414
+            },
+            {
+              "x": -6.356379,
+              "y": -0.062002
+            },
+            {
+              "x": -6.355,
+              "y": -0.048
+            },
+            {
+              "x": -6.364127,
+              "y": 0.044668
+            },
+            {
+              "x": -6.391157,
+              "y": 0.133775
+            },
+            {
+              "x": -6.435052,
+              "y": 0.215896
+            },
+            {
+              "x": -6.494124,
+              "y": 0.287876
+            },
+            {
+              "x": -6.566104,
+              "y": 0.346948
+            },
+            {
+              "x": -6.648225,
+              "y": 0.390843
+            },
+            {
+              "x": -6.737332,
+              "y": 0.417873
+            },
+            {
+              "x": -6.83,
+              "y": 0.427
+            },
+            {
+              "x": -6.922668,
+              "y": 0.417873
+            },
+            {
+              "x": -7.011775,
+              "y": 0.390843
+            },
+            {
+              "x": -7.093896,
+              "y": 0.346948
+            },
+            {
+              "x": -7.165876,
+              "y": 0.287876
+            },
+            {
+              "x": -7.224948,
+              "y": 0.215896
+            },
+            {
+              "x": -7.268843,
+              "y": 0.133775
+            },
+            {
+              "x": -7.295873,
+              "y": 0.044668
+            },
+            {
+              "x": -7.305,
+              "y": -0.048
+            },
+            {
+              "x": -7.295873,
+              "y": -0.140668
+            },
+            {
+              "x": -7.268843,
+              "y": -0.229775
+            },
+            {
+              "x": -7.224948,
+              "y": -0.311896
+            },
+            {
+              "x": -7.165876,
+              "y": -0.383876
+            },
+            {
+              "x": -7.093896,
+              "y": -0.442948
+            },
+            {
+              "x": -7.011775,
+              "y": -0.486843
+            },
+            {
+              "x": -6.922668,
+              "y": -0.513873
+            },
+            {
+              "x": -6.83,
+              "y": -0.523
+            },
+            {
+              "x": -6.815998,
+              "y": -0.521621
+            },
+            {
+              "x": -6.435776,
+              "y": -0.901843
+            },
+            {
+              "x": -6.435776,
+              "y": -1.558598
+            },
+            {
+              "x": -6.429532,
+              "y": -1.622003
+            },
+            {
+              "x": -6.411037,
+              "y": -1.68297
+            },
+            {
+              "x": -6.381004,
+              "y": -1.739159
+            },
+            {
+              "x": -6.340586,
+              "y": -1.788408
+            },
+            {
+              "x": -4.667184,
+              "y": -3.46181
+            },
+            {
+              "x": -4.617935,
+              "y": -3.502228
+            },
+            {
+              "x": -4.561747,
+              "y": -3.532261
+            },
+            {
+              "x": -4.500779,
+              "y": -3.550755
+            },
+            {
+              "x": -4.437375,
+              "y": -3.557
+            },
+            {
+              "x": -4.430441,
+              "y": -3.556317
+            },
+            {
+              "x": -4.430428,
+              "y": -3.556926
+            },
+            {
+              "x": -0.893796,
+              "y": -3.481318
+            },
+            {
+              "x": -0.890876,
+              "y": -3.484876
+            },
+            {
+              "x": -0.818896,
+              "y": -3.543948
+            },
+            {
+              "x": -0.736775,
+              "y": -3.587843
+            },
+            {
+              "x": -0.647668,
+              "y": -3.614873
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 6.779,
+              "y": -2.584
+            },
+            {
+              "x": 6.871668,
+              "y": -2.574873
+            },
+            {
+              "x": 6.960775,
+              "y": -2.547843
+            },
+            {
+              "x": 7.042896,
+              "y": -2.503948
+            },
+            {
+              "x": 7.114876,
+              "y": -2.444876
+            },
+            {
+              "x": 7.173948,
+              "y": -2.372896
+            },
+            {
+              "x": 7.217843,
+              "y": -2.290775
+            },
+            {
+              "x": 7.244873,
+              "y": -2.201668
+            },
+            {
+              "x": 7.254,
+              "y": -2.109
+            },
+            {
+              "x": 7.252621,
+              "y": -2.094999
+            },
+            {
+              "x": 7.48062,
+              "y": -1.867
+            },
+            {
+              "x": 9.244198,
+              "y": -1.867
+            },
+            {
+              "x": 9.253124,
+              "y": -1.877876
+            },
+            {
+              "x": 9.325104,
+              "y": -1.936948
+            },
+            {
+              "x": 9.407225,
+              "y": -1.980843
+            },
+            {
+              "x": 9.496332,
+              "y": -2.007873
+            },
+            {
+              "x": 9.589,
+              "y": -2.017
+            },
+            {
+              "x": 9.681668,
+              "y": -2.007873
+            },
+            {
+              "x": 9.770775,
+              "y": -1.980843
+            },
+            {
+              "x": 9.852896,
+              "y": -1.936948
+            },
+            {
+              "x": 9.924876,
+              "y": -1.877876
+            },
+            {
+              "x": 9.983948,
+              "y": -1.805896
+            },
+            {
+              "x": 10.027843,
+              "y": -1.723775
+            },
+            {
+              "x": 10.054873,
+              "y": -1.634668
+            },
+            {
+              "x": 10.064,
+              "y": -1.542
+            },
+            {
+              "x": 10.054873,
+              "y": -1.449332
+            },
+            {
+              "x": 10.027843,
+              "y": -1.360225
+            },
+            {
+              "x": 9.983948,
+              "y": -1.278104
+            },
+            {
+              "x": 9.924876,
+              "y": -1.206124
+            },
+            {
+              "x": 9.852896,
+              "y": -1.147052
+            },
+            {
+              "x": 9.770775,
+              "y": -1.103157
+            },
+            {
+              "x": 9.681668,
+              "y": -1.076127
+            },
+            {
+              "x": 9.589,
+              "y": -1.067
+            },
+            {
+              "x": 9.496332,
+              "y": -1.076127
+            },
+            {
+              "x": 9.407225,
+              "y": -1.103157
+            },
+            {
+              "x": 9.325104,
+              "y": -1.147052
+            },
+            {
+              "x": 9.253124,
+              "y": -1.206124
+            },
+            {
+              "x": 9.244198,
+              "y": -1.217
+            },
+            {
+              "x": 7.346,
+              "y": -1.217
+            },
+            {
+              "x": 7.282596,
+              "y": -1.223245
+            },
+            {
+              "x": 7.221628,
+              "y": -1.241739
+            },
+            {
+              "x": 7.16544,
+              "y": -1.271772
+            },
+            {
+              "x": 7.11619,
+              "y": -1.31219
+            },
+            {
+              "x": 6.793001,
+              "y": -1.635379
+            },
+            {
+              "x": 6.779,
+              "y": -1.634
+            },
+            {
+              "x": 6.686332,
+              "y": -1.643127
+            },
+            {
+              "x": 6.597225,
+              "y": -1.670157
+            },
+            {
+              "x": 6.515104,
+              "y": -1.714052
+            },
+            {
+              "x": 6.443124,
+              "y": -1.773124
+            },
+            {
+              "x": 6.384052,
+              "y": -1.845104
+            },
+            {
+              "x": 6.340157,
+              "y": -1.927225
+            },
+            {
+              "x": 6.313127,
+              "y": -2.016332
+            },
+            {
+              "x": 6.304,
+              "y": -2.109
+            },
+            {
+              "x": 6.313127,
+              "y": -2.201668
+            },
+            {
+              "x": 6.340157,
+              "y": -2.290775
+            },
+            {
+              "x": 6.384052,
+              "y": -2.372896
+            },
+            {
+              "x": 6.443124,
+              "y": -2.444876
+            },
+            {
+              "x": 6.515104,
+              "y": -2.503948
+            },
+            {
+              "x": 6.597225,
+              "y": -2.547843
+            },
+            {
+              "x": 6.686332,
+              "y": -2.574873
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.594433,
+              "y": -3.524924
+            },
+            {
+              "x": -36.4725,
+              "y": -3.512914
+            },
+            {
+              "x": -36.355254,
+              "y": -3.477348
+            },
+            {
+              "x": -36.247198,
+              "y": -3.419591
+            },
+            {
+              "x": -36.152487,
+              "y": -3.341864
+            },
+            {
+              "x": -36.07476,
+              "y": -3.247153
+            },
+            {
+              "x": -36.017003,
+              "y": -3.139097
+            },
+            {
+              "x": -35.981437,
+              "y": -3.021851
+            },
+            {
+              "x": -35.969427,
+              "y": -2.899918
+            },
+            {
+              "x": -35.981437,
+              "y": -2.777985
+            },
+            {
+              "x": -36.017003,
+              "y": -2.660739
+            },
+            {
+              "x": -36.07476,
+              "y": -2.552683
+            },
+            {
+              "x": -36.152487,
+              "y": -2.457972
+            },
+            {
+              "x": -36.247198,
+              "y": -2.380245
+            },
+            {
+              "x": -36.355254,
+              "y": -2.322488
+            },
+            {
+              "x": -36.4725,
+              "y": -2.286922
+            },
+            {
+              "x": -36.594433,
+              "y": -2.274912
+            },
+            {
+              "x": -36.716365,
+              "y": -2.286922
+            },
+            {
+              "x": -36.833612,
+              "y": -2.322488
+            },
+            {
+              "x": -36.941667,
+              "y": -2.380245
+            },
+            {
+              "x": -37.036378,
+              "y": -2.457972
+            },
+            {
+              "x": -37.114106,
+              "y": -2.552683
+            },
+            {
+              "x": -37.171863,
+              "y": -2.660739
+            },
+            {
+              "x": -37.207429,
+              "y": -2.777985
+            },
+            {
+              "x": -37.219438,
+              "y": -2.899918
+            },
+            {
+              "x": -37.207429,
+              "y": -3.021851
+            },
+            {
+              "x": -37.171863,
+              "y": -3.139097
+            },
+            {
+              "x": -37.114106,
+              "y": -3.247153
+            },
+            {
+              "x": -37.036378,
+              "y": -3.341864
+            },
+            {
+              "x": -36.941667,
+              "y": -3.419591
+            },
+            {
+              "x": -36.833612,
+              "y": -3.477348
+            },
+            {
+              "x": -36.716365,
+              "y": -3.512914
+            }
+          ]
+        }
+      ]
+    },
+    "source_net_id": "source_net_0",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "covered_with_solder_mask": true
+  },
+  {
+    "type": "pcb_copper_pour",
+    "pcb_copper_pour_id": "pcb_copper_pour_2",
+    "shape": "brep",
+    "layer": "bottom",
+    "brep_shape": {
+      "outer_ring": {
+        "vertices": [
+          {
+            "x": 42.75,
+            "y": -17.75
+          },
+          {
+            "x": -42.75,
+            "y": -17.75
+          },
+          {
+            "x": -42.75,
+            "y": 17.75
+          },
+          {
+            "x": 42.75,
+            "y": 17.75
+          }
+        ]
+      },
+      "inner_rings": [
+        {
+          "vertices": [
+            {
+              "x": 27.459,
+              "y": 8.182
+            },
+            {
+              "x": 27.541913,
+              "y": 8.190166
+            },
+            {
+              "x": 27.62164,
+              "y": 8.214351
+            },
+            {
+              "x": 27.695117,
+              "y": 8.253625
+            },
+            {
+              "x": 27.75952,
+              "y": 8.30648
+            },
+            {
+              "x": 27.812375,
+              "y": 8.370883
+            },
+            {
+              "x": 27.851649,
+              "y": 8.44436
+            },
+            {
+              "x": 27.875834,
+              "y": 8.524087
+            },
+            {
+              "x": 27.884,
+              "y": 8.607
+            },
+            {
+              "x": 27.880074,
+              "y": 8.646858
+            },
+            {
+              "x": 28.002454,
+              "y": 8.769238
+            },
+            {
+              "x": 28.036654,
+              "y": 8.81091
+            },
+            {
+              "x": 28.062067,
+              "y": 8.858454
+            },
+            {
+              "x": 28.077716,
+              "y": 8.910042
+            },
+            {
+              "x": 28.083,
+              "y": 8.963692
+            },
+            {
+              "x": 28.083,
+              "y": 11.756536
+            },
+            {
+              "x": 28.10852,
+              "y": 11.77748
+            },
+            {
+              "x": 28.161375,
+              "y": 11.841883
+            },
+            {
+              "x": 28.200649,
+              "y": 11.91536
+            },
+            {
+              "x": 28.224834,
+              "y": 11.995087
+            },
+            {
+              "x": 28.233,
+              "y": 12.078
+            },
+            {
+              "x": 28.224834,
+              "y": 12.160913
+            },
+            {
+              "x": 28.200649,
+              "y": 12.24064
+            },
+            {
+              "x": 28.161375,
+              "y": 12.314117
+            },
+            {
+              "x": 28.10852,
+              "y": 12.37852
+            },
+            {
+              "x": 28.044117,
+              "y": 12.431375
+            },
+            {
+              "x": 27.97064,
+              "y": 12.470649
+            },
+            {
+              "x": 27.890913,
+              "y": 12.494834
+            },
+            {
+              "x": 27.808,
+              "y": 12.503
+            },
+            {
+              "x": 27.725087,
+              "y": 12.494834
+            },
+            {
+              "x": 27.64536,
+              "y": 12.470649
+            },
+            {
+              "x": 27.571883,
+              "y": 12.431375
+            },
+            {
+              "x": 27.50748,
+              "y": 12.37852
+            },
+            {
+              "x": 27.454625,
+              "y": 12.314117
+            },
+            {
+              "x": 27.415351,
+              "y": 12.24064
+            },
+            {
+              "x": 27.391166,
+              "y": 12.160913
+            },
+            {
+              "x": 27.383,
+              "y": 12.078
+            },
+            {
+              "x": 27.391166,
+              "y": 11.995087
+            },
+            {
+              "x": 27.415351,
+              "y": 11.91536
+            },
+            {
+              "x": 27.454625,
+              "y": 11.841883
+            },
+            {
+              "x": 27.50748,
+              "y": 11.77748
+            },
+            {
+              "x": 27.533,
+              "y": 11.756536
+            },
+            {
+              "x": 27.533,
+              "y": 9.0776
+            },
+            {
+              "x": 27.484853,
+              "y": 9.029454
+            },
+            {
+              "x": 27.459,
+              "y": 9.032
+            },
+            {
+              "x": 27.376087,
+              "y": 9.023834
+            },
+            {
+              "x": 27.29636,
+              "y": 8.999649
+            },
+            {
+              "x": 27.222883,
+              "y": 8.960375
+            },
+            {
+              "x": 27.15848,
+              "y": 8.90752
+            },
+            {
+              "x": 27.105625,
+              "y": 8.843117
+            },
+            {
+              "x": 27.066351,
+              "y": 8.76964
+            },
+            {
+              "x": 27.042166,
+              "y": 8.689913
+            },
+            {
+              "x": 27.034,
+              "y": 8.607
+            },
+            {
+              "x": 27.042166,
+              "y": 8.524087
+            },
+            {
+              "x": 27.066351,
+              "y": 8.44436
+            },
+            {
+              "x": 27.105625,
+              "y": 8.370883
+            },
+            {
+              "x": 27.15848,
+              "y": 8.30648
+            },
+            {
+              "x": 27.222883,
+              "y": 8.253625
+            },
+            {
+              "x": 27.29636,
+              "y": 8.214351
+            },
+            {
+              "x": 27.376087,
+              "y": 8.190166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 36,
+              "y": 5.800643
+            },
+            {
+              "x": 36.331653,
+              "y": 5.833308
+            },
+            {
+              "x": 36.650561,
+              "y": 5.930048
+            },
+            {
+              "x": 36.944468,
+              "y": 6.087144
+            },
+            {
+              "x": 37.202079,
+              "y": 6.298561
+            },
+            {
+              "x": 37.413496,
+              "y": 6.556172
+            },
+            {
+              "x": 37.570592,
+              "y": 6.850079
+            },
+            {
+              "x": 37.667332,
+              "y": 7.168987
+            },
+            {
+              "x": 37.699997,
+              "y": 7.50064
+            },
+            {
+              "x": 37.667332,
+              "y": 7.832293
+            },
+            {
+              "x": 37.570592,
+              "y": 8.151201
+            },
+            {
+              "x": 37.413496,
+              "y": 8.445108
+            },
+            {
+              "x": 37.202079,
+              "y": 8.702719
+            },
+            {
+              "x": 36.944468,
+              "y": 8.914136
+            },
+            {
+              "x": 36.650561,
+              "y": 9.071232
+            },
+            {
+              "x": 36.331653,
+              "y": 9.167972
+            },
+            {
+              "x": 36,
+              "y": 9.200637
+            },
+            {
+              "x": 35.668347,
+              "y": 9.167972
+            },
+            {
+              "x": 35.349439,
+              "y": 9.071232
+            },
+            {
+              "x": 35.055532,
+              "y": 8.914136
+            },
+            {
+              "x": 34.797921,
+              "y": 8.702719
+            },
+            {
+              "x": 34.586504,
+              "y": 8.445108
+            },
+            {
+              "x": 34.429408,
+              "y": 8.151201
+            },
+            {
+              "x": 34.332668,
+              "y": 7.832293
+            },
+            {
+              "x": 34.300003,
+              "y": 7.50064
+            },
+            {
+              "x": 34.332668,
+              "y": 7.168987
+            },
+            {
+              "x": 34.429408,
+              "y": 6.850079
+            },
+            {
+              "x": 34.586504,
+              "y": 6.556172
+            },
+            {
+              "x": 34.797921,
+              "y": 6.298561
+            },
+            {
+              "x": 35.055532,
+              "y": 6.087144
+            },
+            {
+              "x": 35.349439,
+              "y": 5.930048
+            },
+            {
+              "x": 35.668347,
+              "y": 5.833308
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 18.805,
+              "y": -7.624
+            },
+            {
+              "x": 18.887913,
+              "y": -7.615834
+            },
+            {
+              "x": 18.96764,
+              "y": -7.591649
+            },
+            {
+              "x": 19.041117,
+              "y": -7.552375
+            },
+            {
+              "x": 19.10552,
+              "y": -7.49952
+            },
+            {
+              "x": 19.158375,
+              "y": -7.435117
+            },
+            {
+              "x": 19.197649,
+              "y": -7.36164
+            },
+            {
+              "x": 19.221834,
+              "y": -7.281913
+            },
+            {
+              "x": 19.23,
+              "y": -7.199
+            },
+            {
+              "x": 19.226752,
+              "y": -7.166026
+            },
+            {
+              "x": 23.642323,
+              "y": -2.750455
+            },
+            {
+              "x": 23.676523,
+              "y": -2.708782
+            },
+            {
+              "x": 23.701935,
+              "y": -2.661239
+            },
+            {
+              "x": 23.717584,
+              "y": -2.60965
+            },
+            {
+              "x": 23.722869,
+              "y": -2.556001
+            },
+            {
+              "x": 23.722868,
+              "y": 6.88628
+            },
+            {
+              "x": 23.748389,
+              "y": 6.907224
+            },
+            {
+              "x": 23.801243,
+              "y": 6.971627
+            },
+            {
+              "x": 23.840517,
+              "y": 7.045104
+            },
+            {
+              "x": 23.864702,
+              "y": 7.124831
+            },
+            {
+              "x": 23.872868,
+              "y": 7.207745
+            },
+            {
+              "x": 23.864702,
+              "y": 7.290658
+            },
+            {
+              "x": 23.840517,
+              "y": 7.370385
+            },
+            {
+              "x": 23.801243,
+              "y": 7.443862
+            },
+            {
+              "x": 23.748389,
+              "y": 7.508265
+            },
+            {
+              "x": 23.683986,
+              "y": 7.561119
+            },
+            {
+              "x": 23.610509,
+              "y": 7.600394
+            },
+            {
+              "x": 23.530782,
+              "y": 7.624579
+            },
+            {
+              "x": 23.447868,
+              "y": 7.632745
+            },
+            {
+              "x": 23.364955,
+              "y": 7.624579
+            },
+            {
+              "x": 23.285228,
+              "y": 7.600394
+            },
+            {
+              "x": 23.211751,
+              "y": 7.561119
+            },
+            {
+              "x": 23.147348,
+              "y": 7.508265
+            },
+            {
+              "x": 23.094494,
+              "y": 7.443862
+            },
+            {
+              "x": 23.055219,
+              "y": 7.370385
+            },
+            {
+              "x": 23.031035,
+              "y": 7.290658
+            },
+            {
+              "x": 23.022868,
+              "y": 7.207745
+            },
+            {
+              "x": 23.031035,
+              "y": 7.124831
+            },
+            {
+              "x": 23.055219,
+              "y": 7.045104
+            },
+            {
+              "x": 23.094494,
+              "y": 6.971627
+            },
+            {
+              "x": 23.147348,
+              "y": 6.907224
+            },
+            {
+              "x": 23.172868,
+              "y": 6.88628
+            },
+            {
+              "x": 23.172869,
+              "y": -2.442091
+            },
+            {
+              "x": 18.837737,
+              "y": -6.777224
+            },
+            {
+              "x": 18.805,
+              "y": -6.774
+            },
+            {
+              "x": 18.722087,
+              "y": -6.782166
+            },
+            {
+              "x": 18.64236,
+              "y": -6.806351
+            },
+            {
+              "x": 18.568883,
+              "y": -6.845625
+            },
+            {
+              "x": 18.50448,
+              "y": -6.89848
+            },
+            {
+              "x": 18.451625,
+              "y": -6.962883
+            },
+            {
+              "x": 18.412351,
+              "y": -7.03636
+            },
+            {
+              "x": 18.388166,
+              "y": -7.116087
+            },
+            {
+              "x": 18.38,
+              "y": -7.199
+            },
+            {
+              "x": 18.388166,
+              "y": -7.281913
+            },
+            {
+              "x": 18.412351,
+              "y": -7.36164
+            },
+            {
+              "x": 18.451625,
+              "y": -7.435117
+            },
+            {
+              "x": 18.50448,
+              "y": -7.49952
+            },
+            {
+              "x": 18.568883,
+              "y": -7.552375
+            },
+            {
+              "x": 18.64236,
+              "y": -7.591649
+            },
+            {
+              "x": 18.722087,
+              "y": -7.615834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 1.407,
+              "y": 0.428
+            },
+            {
+              "x": 1.489913,
+              "y": 0.436166
+            },
+            {
+              "x": 1.56964,
+              "y": 0.460351
+            },
+            {
+              "x": 1.643117,
+              "y": 0.499625
+            },
+            {
+              "x": 1.70752,
+              "y": 0.55248
+            },
+            {
+              "x": 1.760375,
+              "y": 0.616883
+            },
+            {
+              "x": 1.799649,
+              "y": 0.69036
+            },
+            {
+              "x": 1.823834,
+              "y": 0.770087
+            },
+            {
+              "x": 1.832,
+              "y": 0.853
+            },
+            {
+              "x": 1.828764,
+              "y": 0.885856
+            },
+            {
+              "x": 4.154252,
+              "y": 3.211343
+            },
+            {
+              "x": 8.195195,
+              "y": 3.211343
+            },
+            {
+              "x": 8.248845,
+              "y": 3.216627
+            },
+            {
+              "x": 8.25394,
+              "y": 3.218173
+            },
+            {
+              "x": 8.276,
+              "y": 3.216
+            },
+            {
+              "x": 8.358913,
+              "y": 3.224166
+            },
+            {
+              "x": 8.43864,
+              "y": 3.248351
+            },
+            {
+              "x": 8.512117,
+              "y": 3.287625
+            },
+            {
+              "x": 8.57652,
+              "y": 3.34048
+            },
+            {
+              "x": 8.629375,
+              "y": 3.404883
+            },
+            {
+              "x": 8.668649,
+              "y": 3.47836
+            },
+            {
+              "x": 8.692834,
+              "y": 3.558087
+            },
+            {
+              "x": 8.701,
+              "y": 3.641
+            },
+            {
+              "x": 8.692834,
+              "y": 3.723913
+            },
+            {
+              "x": 8.668649,
+              "y": 3.80364
+            },
+            {
+              "x": 8.629375,
+              "y": 3.877117
+            },
+            {
+              "x": 8.57652,
+              "y": 3.94152
+            },
+            {
+              "x": 8.512117,
+              "y": 3.994375
+            },
+            {
+              "x": 8.43864,
+              "y": 4.033649
+            },
+            {
+              "x": 8.358913,
+              "y": 4.057834
+            },
+            {
+              "x": 8.276,
+              "y": 4.066
+            },
+            {
+              "x": 8.193087,
+              "y": 4.057834
+            },
+            {
+              "x": 8.11336,
+              "y": 4.033649
+            },
+            {
+              "x": 8.039883,
+              "y": 3.994375
+            },
+            {
+              "x": 7.97548,
+              "y": 3.94152
+            },
+            {
+              "x": 7.922625,
+              "y": 3.877117
+            },
+            {
+              "x": 7.883351,
+              "y": 3.80364
+            },
+            {
+              "x": 7.87052,
+              "y": 3.761343
+            },
+            {
+              "x": 4.040343,
+              "y": 3.761343
+            },
+            {
+              "x": 3.986693,
+              "y": 3.756059
+            },
+            {
+              "x": 3.935105,
+              "y": 3.74041
+            },
+            {
+              "x": 3.887561,
+              "y": 3.714997
+            },
+            {
+              "x": 3.845889,
+              "y": 3.680798
+            },
+            {
+              "x": 1.439856,
+              "y": 1.274764
+            },
+            {
+              "x": 1.407,
+              "y": 1.278
+            },
+            {
+              "x": 1.324087,
+              "y": 1.269834
+            },
+            {
+              "x": 1.24436,
+              "y": 1.245649
+            },
+            {
+              "x": 1.170883,
+              "y": 1.206375
+            },
+            {
+              "x": 1.10648,
+              "y": 1.15352
+            },
+            {
+              "x": 1.053625,
+              "y": 1.089117
+            },
+            {
+              "x": 1.014351,
+              "y": 1.01564
+            },
+            {
+              "x": 0.990166,
+              "y": 0.935913
+            },
+            {
+              "x": 0.982,
+              "y": 0.853
+            },
+            {
+              "x": 0.990166,
+              "y": 0.770087
+            },
+            {
+              "x": 1.014351,
+              "y": 0.69036
+            },
+            {
+              "x": 1.053625,
+              "y": 0.616883
+            },
+            {
+              "x": 1.10648,
+              "y": 0.55248
+            },
+            {
+              "x": 1.170883,
+              "y": 0.499625
+            },
+            {
+              "x": 1.24436,
+              "y": 0.460351
+            },
+            {
+              "x": 1.324087,
+              "y": 0.436166
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.594433,
+              "y": 2.324912
+            },
+            {
+              "x": -36.482255,
+              "y": 2.335961
+            },
+            {
+              "x": -36.374388,
+              "y": 2.368682
+            },
+            {
+              "x": -36.274977,
+              "y": 2.421818
+            },
+            {
+              "x": -36.187842,
+              "y": 2.493328
+            },
+            {
+              "x": -36.116333,
+              "y": 2.580462
+            },
+            {
+              "x": -36.063197,
+              "y": 2.679873
+            },
+            {
+              "x": -36.030476,
+              "y": 2.78774
+            },
+            {
+              "x": -36.019427,
+              "y": 2.899918
+            },
+            {
+              "x": -36.030476,
+              "y": 3.012096
+            },
+            {
+              "x": -36.063197,
+              "y": 3.119963
+            },
+            {
+              "x": -36.116333,
+              "y": 3.219374
+            },
+            {
+              "x": -36.187842,
+              "y": 3.306508
+            },
+            {
+              "x": -36.274977,
+              "y": 3.378018
+            },
+            {
+              "x": -36.374388,
+              "y": 3.431154
+            },
+            {
+              "x": -36.482255,
+              "y": 3.463875
+            },
+            {
+              "x": -36.594433,
+              "y": 3.474924
+            },
+            {
+              "x": -36.706611,
+              "y": 3.463875
+            },
+            {
+              "x": -36.814478,
+              "y": 3.431154
+            },
+            {
+              "x": -36.913889,
+              "y": 3.378018
+            },
+            {
+              "x": -37.001023,
+              "y": 3.306508
+            },
+            {
+              "x": -37.072532,
+              "y": 3.219374
+            },
+            {
+              "x": -37.125669,
+              "y": 3.119963
+            },
+            {
+              "x": -37.15839,
+              "y": 3.012096
+            },
+            {
+              "x": -37.169438,
+              "y": 2.899918
+            },
+            {
+              "x": -37.15839,
+              "y": 2.78774
+            },
+            {
+              "x": -37.125669,
+              "y": 2.679873
+            },
+            {
+              "x": -37.072532,
+              "y": 2.580462
+            },
+            {
+              "x": -37.001023,
+              "y": 2.493328
+            },
+            {
+              "x": -36.913889,
+              "y": 2.421818
+            },
+            {
+              "x": -36.814478,
+              "y": 2.368682
+            },
+            {
+              "x": -36.706611,
+              "y": 2.335961
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -12.345,
+              "y": -1.002
+            },
+            {
+              "x": -12.262087,
+              "y": -0.993834
+            },
+            {
+              "x": -12.18236,
+              "y": -0.969649
+            },
+            {
+              "x": -12.108883,
+              "y": -0.930375
+            },
+            {
+              "x": -12.04448,
+              "y": -0.87752
+            },
+            {
+              "x": -11.991625,
+              "y": -0.813117
+            },
+            {
+              "x": -11.952351,
+              "y": -0.73964
+            },
+            {
+              "x": -11.928166,
+              "y": -0.659913
+            },
+            {
+              "x": -11.92,
+              "y": -0.577
+            },
+            {
+              "x": -11.928166,
+              "y": -0.494087
+            },
+            {
+              "x": -11.952351,
+              "y": -0.41436
+            },
+            {
+              "x": -11.991625,
+              "y": -0.340883
+            },
+            {
+              "x": -12.04448,
+              "y": -0.27648
+            },
+            {
+              "x": -12.108883,
+              "y": -0.223625
+            },
+            {
+              "x": -12.18236,
+              "y": -0.184351
+            },
+            {
+              "x": -12.262087,
+              "y": -0.160166
+            },
+            {
+              "x": -12.345,
+              "y": -0.152
+            },
+            {
+              "x": -12.352076,
+              "y": -0.152697
+            },
+            {
+              "x": -12.592328,
+              "y": 0.087555
+            },
+            {
+              "x": -12.557455,
+              "y": 1.581252
+            },
+            {
+              "x": -12.524359,
+              "y": 1.608413
+            },
+            {
+              "x": -12.471505,
+              "y": 1.672816
+            },
+            {
+              "x": -12.432231,
+              "y": 1.746293
+            },
+            {
+              "x": -12.408046,
+              "y": 1.82602
+            },
+            {
+              "x": -12.399879,
+              "y": 1.908933
+            },
+            {
+              "x": -12.408046,
+              "y": 1.991847
+            },
+            {
+              "x": -12.432231,
+              "y": 2.071574
+            },
+            {
+              "x": -12.471505,
+              "y": 2.14505
+            },
+            {
+              "x": -12.524359,
+              "y": 2.209454
+            },
+            {
+              "x": -12.588762,
+              "y": 2.262308
+            },
+            {
+              "x": -12.662239,
+              "y": 2.301582
+            },
+            {
+              "x": -12.741966,
+              "y": 2.325767
+            },
+            {
+              "x": -12.824879,
+              "y": 2.333933
+            },
+            {
+              "x": -12.907793,
+              "y": 2.325767
+            },
+            {
+              "x": -12.98752,
+              "y": 2.301582
+            },
+            {
+              "x": -13.060997,
+              "y": 2.262308
+            },
+            {
+              "x": -13.1254,
+              "y": 2.209454
+            },
+            {
+              "x": -13.178254,
+              "y": 2.14505
+            },
+            {
+              "x": -13.217528,
+              "y": 2.071574
+            },
+            {
+              "x": -13.241713,
+              "y": 1.991847
+            },
+            {
+              "x": -13.249879,
+              "y": 1.908933
+            },
+            {
+              "x": -13.241713,
+              "y": 1.82602
+            },
+            {
+              "x": -13.217528,
+              "y": 1.746293
+            },
+            {
+              "x": -13.178254,
+              "y": 1.672816
+            },
+            {
+              "x": -13.1254,
+              "y": 1.608413
+            },
+            {
+              "x": -13.107317,
+              "y": 1.593573
+            },
+            {
+              "x": -13.144925,
+              "y": -0.017262
+            },
+            {
+              "x": -13.144369,
+              "y": -0.017275
+            },
+            {
+              "x": -13.145,
+              "y": -0.023681
+            },
+            {
+              "x": -13.139716,
+              "y": -0.077331
+            },
+            {
+              "x": -13.124067,
+              "y": -0.128919
+            },
+            {
+              "x": -13.098654,
+              "y": -0.176463
+            },
+            {
+              "x": -13.064454,
+              "y": -0.218135
+            },
+            {
+              "x": -12.764225,
+              "y": -0.518365
+            },
+            {
+              "x": -12.77,
+              "y": -0.577
+            },
+            {
+              "x": -12.761834,
+              "y": -0.659913
+            },
+            {
+              "x": -12.737649,
+              "y": -0.73964
+            },
+            {
+              "x": -12.698375,
+              "y": -0.813117
+            },
+            {
+              "x": -12.64552,
+              "y": -0.87752
+            },
+            {
+              "x": -12.581117,
+              "y": -0.930375
+            },
+            {
+              "x": -12.50764,
+              "y": -0.969649
+            },
+            {
+              "x": -12.427913,
+              "y": -0.993834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -5.199,
+              "y": -5.425
+            },
+            {
+              "x": -5.116087,
+              "y": -5.416834
+            },
+            {
+              "x": -5.03636,
+              "y": -5.392649
+            },
+            {
+              "x": -4.962883,
+              "y": -5.353375
+            },
+            {
+              "x": -4.89848,
+              "y": -5.30052
+            },
+            {
+              "x": -4.845625,
+              "y": -5.236117
+            },
+            {
+              "x": -4.806351,
+              "y": -5.16264
+            },
+            {
+              "x": -4.782166,
+              "y": -5.082913
+            },
+            {
+              "x": -4.774,
+              "y": -5
+            },
+            {
+              "x": -4.782166,
+              "y": -4.917087
+            },
+            {
+              "x": -4.806351,
+              "y": -4.83736
+            },
+            {
+              "x": -4.845625,
+              "y": -4.763883
+            },
+            {
+              "x": -4.89848,
+              "y": -4.69948
+            },
+            {
+              "x": -4.924,
+              "y": -4.678536
+            },
+            {
+              "x": -4.924,
+              "y": -2.164616
+            },
+            {
+              "x": -4.91048,
+              "y": -2.15352
+            },
+            {
+              "x": -4.857625,
+              "y": -2.089117
+            },
+            {
+              "x": -4.818351,
+              "y": -2.01564
+            },
+            {
+              "x": -4.794166,
+              "y": -1.935913
+            },
+            {
+              "x": -4.786,
+              "y": -1.853
+            },
+            {
+              "x": -4.794166,
+              "y": -1.770087
+            },
+            {
+              "x": -4.818351,
+              "y": -1.69036
+            },
+            {
+              "x": -4.857625,
+              "y": -1.616883
+            },
+            {
+              "x": -4.91048,
+              "y": -1.55248
+            },
+            {
+              "x": -4.974883,
+              "y": -1.499625
+            },
+            {
+              "x": -5.04836,
+              "y": -1.460351
+            },
+            {
+              "x": -5.128087,
+              "y": -1.436166
+            },
+            {
+              "x": -5.211,
+              "y": -1.428
+            },
+            {
+              "x": -5.293913,
+              "y": -1.436166
+            },
+            {
+              "x": -5.37364,
+              "y": -1.460351
+            },
+            {
+              "x": -5.447117,
+              "y": -1.499625
+            },
+            {
+              "x": -5.51152,
+              "y": -1.55248
+            },
+            {
+              "x": -5.564375,
+              "y": -1.616883
+            },
+            {
+              "x": -5.603649,
+              "y": -1.69036
+            },
+            {
+              "x": -5.627834,
+              "y": -1.770087
+            },
+            {
+              "x": -5.636,
+              "y": -1.853
+            },
+            {
+              "x": -5.627834,
+              "y": -1.935913
+            },
+            {
+              "x": -5.603649,
+              "y": -2.01564
+            },
+            {
+              "x": -5.564375,
+              "y": -2.089117
+            },
+            {
+              "x": -5.51152,
+              "y": -2.15352
+            },
+            {
+              "x": -5.474,
+              "y": -2.184312
+            },
+            {
+              "x": -5.474,
+              "y": -4.678536
+            },
+            {
+              "x": -5.49952,
+              "y": -4.69948
+            },
+            {
+              "x": -5.552375,
+              "y": -4.763883
+            },
+            {
+              "x": -5.591649,
+              "y": -4.83736
+            },
+            {
+              "x": -5.615834,
+              "y": -4.917087
+            },
+            {
+              "x": -5.624,
+              "y": -5
+            },
+            {
+              "x": -5.615834,
+              "y": -5.082913
+            },
+            {
+              "x": -5.591649,
+              "y": -5.16264
+            },
+            {
+              "x": -5.552375,
+              "y": -5.236117
+            },
+            {
+              "x": -5.49952,
+              "y": -5.30052
+            },
+            {
+              "x": -5.435117,
+              "y": -5.353375
+            },
+            {
+              "x": -5.36164,
+              "y": -5.392649
+            },
+            {
+              "x": -5.281913,
+              "y": -5.416834
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": -36.594433,
+              "y": -3.474924
+            },
+            {
+              "x": -36.482255,
+              "y": -3.463875
+            },
+            {
+              "x": -36.374388,
+              "y": -3.431154
+            },
+            {
+              "x": -36.274977,
+              "y": -3.378018
+            },
+            {
+              "x": -36.187842,
+              "y": -3.306508
+            },
+            {
+              "x": -36.116333,
+              "y": -3.219374
+            },
+            {
+              "x": -36.063197,
+              "y": -3.119963
+            },
+            {
+              "x": -36.030476,
+              "y": -3.012096
+            },
+            {
+              "x": -36.019427,
+              "y": -2.899918
+            },
+            {
+              "x": -36.030476,
+              "y": -2.78774
+            },
+            {
+              "x": -36.063197,
+              "y": -2.679873
+            },
+            {
+              "x": -36.116333,
+              "y": -2.580462
+            },
+            {
+              "x": -36.187842,
+              "y": -2.493328
+            },
+            {
+              "x": -36.274977,
+              "y": -2.421818
+            },
+            {
+              "x": -36.374388,
+              "y": -2.368682
+            },
+            {
+              "x": -36.482255,
+              "y": -2.335961
+            },
+            {
+              "x": -36.594433,
+              "y": -2.324912
+            },
+            {
+              "x": -36.706611,
+              "y": -2.335961
+            },
+            {
+              "x": -36.814478,
+              "y": -2.368682
+            },
+            {
+              "x": -36.913889,
+              "y": -2.421818
+            },
+            {
+              "x": -37.001023,
+              "y": -2.493328
+            },
+            {
+              "x": -37.072532,
+              "y": -2.580462
+            },
+            {
+              "x": -37.125669,
+              "y": -2.679873
+            },
+            {
+              "x": -37.15839,
+              "y": -2.78774
+            },
+            {
+              "x": -37.169438,
+              "y": -2.899918
+            },
+            {
+              "x": -37.15839,
+              "y": -3.012096
+            },
+            {
+              "x": -37.125669,
+              "y": -3.119963
+            },
+            {
+              "x": -37.072532,
+              "y": -3.219374
+            },
+            {
+              "x": -37.001023,
+              "y": -3.306508
+            },
+            {
+              "x": -36.913889,
+              "y": -3.378018
+            },
+            {
+              "x": -36.814478,
+              "y": -3.431154
+            },
+            {
+              "x": -36.706611,
+              "y": -3.463875
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 32,
+              "y": -7.41
+            },
+            {
+              "x": 32.185336,
+              "y": -7.391746
+            },
+            {
+              "x": 32.363549,
+              "y": -7.337686
+            },
+            {
+              "x": 32.527792,
+              "y": -7.249896
+            },
+            {
+              "x": 32.671751,
+              "y": -7.131751
+            },
+            {
+              "x": 32.789896,
+              "y": -6.987792
+            },
+            {
+              "x": 32.877686,
+              "y": -6.823549
+            },
+            {
+              "x": 32.931746,
+              "y": -6.645336
+            },
+            {
+              "x": 32.95,
+              "y": -6.46
+            },
+            {
+              "x": 32.931746,
+              "y": -6.274664
+            },
+            {
+              "x": 32.877686,
+              "y": -6.096451
+            },
+            {
+              "x": 32.789896,
+              "y": -5.932208
+            },
+            {
+              "x": 32.671751,
+              "y": -5.788249
+            },
+            {
+              "x": 32.527792,
+              "y": -5.670104
+            },
+            {
+              "x": 32.363549,
+              "y": -5.582314
+            },
+            {
+              "x": 32.185336,
+              "y": -5.528254
+            },
+            {
+              "x": 32,
+              "y": -5.51
+            },
+            {
+              "x": 31.814664,
+              "y": -5.528254
+            },
+            {
+              "x": 31.636451,
+              "y": -5.582314
+            },
+            {
+              "x": 31.472208,
+              "y": -5.670104
+            },
+            {
+              "x": 31.328249,
+              "y": -5.788249
+            },
+            {
+              "x": 31.210104,
+              "y": -5.932208
+            },
+            {
+              "x": 31.122314,
+              "y": -6.096451
+            },
+            {
+              "x": 31.068254,
+              "y": -6.274664
+            },
+            {
+              "x": 31.05,
+              "y": -6.46
+            },
+            {
+              "x": 31.068254,
+              "y": -6.645336
+            },
+            {
+              "x": 31.122314,
+              "y": -6.823549
+            },
+            {
+              "x": 31.210104,
+              "y": -6.987792
+            },
+            {
+              "x": 31.328249,
+              "y": -7.131751
+            },
+            {
+              "x": 31.472208,
+              "y": -7.249896
+            },
+            {
+              "x": 31.636451,
+              "y": -7.337686
+            },
+            {
+              "x": 31.814664,
+              "y": -7.391746
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 32,
+              "y": -9.95
+            },
+            {
+              "x": 32.185336,
+              "y": -9.931746
+            },
+            {
+              "x": 32.363549,
+              "y": -9.877686
+            },
+            {
+              "x": 32.527792,
+              "y": -9.789896
+            },
+            {
+              "x": 32.671751,
+              "y": -9.671751
+            },
+            {
+              "x": 32.789896,
+              "y": -9.527792
+            },
+            {
+              "x": 32.877686,
+              "y": -9.363549
+            },
+            {
+              "x": 32.931746,
+              "y": -9.185336
+            },
+            {
+              "x": 32.95,
+              "y": -9
+            },
+            {
+              "x": 32.931746,
+              "y": -8.814664
+            },
+            {
+              "x": 32.877686,
+              "y": -8.636451
+            },
+            {
+              "x": 32.789896,
+              "y": -8.472208
+            },
+            {
+              "x": 32.671751,
+              "y": -8.328249
+            },
+            {
+              "x": 32.527792,
+              "y": -8.210104
+            },
+            {
+              "x": 32.363549,
+              "y": -8.122314
+            },
+            {
+              "x": 32.185336,
+              "y": -8.068254
+            },
+            {
+              "x": 32,
+              "y": -8.05
+            },
+            {
+              "x": 31.814664,
+              "y": -8.068254
+            },
+            {
+              "x": 31.636451,
+              "y": -8.122314
+            },
+            {
+              "x": 31.472208,
+              "y": -8.210104
+            },
+            {
+              "x": 31.328249,
+              "y": -8.328249
+            },
+            {
+              "x": 31.210104,
+              "y": -8.472208
+            },
+            {
+              "x": 31.122314,
+              "y": -8.636451
+            },
+            {
+              "x": 31.068254,
+              "y": -8.814664
+            },
+            {
+              "x": 31.05,
+              "y": -9
+            },
+            {
+              "x": 31.068254,
+              "y": -9.185336
+            },
+            {
+              "x": 31.122314,
+              "y": -9.363549
+            },
+            {
+              "x": 31.210104,
+              "y": -9.527792
+            },
+            {
+              "x": 31.328249,
+              "y": -9.671751
+            },
+            {
+              "x": 31.472208,
+              "y": -9.789896
+            },
+            {
+              "x": 31.636451,
+              "y": -9.877686
+            },
+            {
+              "x": 31.814664,
+              "y": -9.931746
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 28.454,
+              "y": -12.379196
+            },
+            {
+              "x": 28.536913,
+              "y": -12.37103
+            },
+            {
+              "x": 28.61664,
+              "y": -12.346845
+            },
+            {
+              "x": 28.690117,
+              "y": -12.307571
+            },
+            {
+              "x": 28.75452,
+              "y": -12.254716
+            },
+            {
+              "x": 28.807374,
+              "y": -12.190313
+            },
+            {
+              "x": 28.846649,
+              "y": -12.116837
+            },
+            {
+              "x": 28.870833,
+              "y": -12.037109
+            },
+            {
+              "x": 28.879,
+              "y": -11.954196
+            },
+            {
+              "x": 28.870833,
+              "y": -11.871283
+            },
+            {
+              "x": 28.846649,
+              "y": -11.791556
+            },
+            {
+              "x": 28.807374,
+              "y": -11.718079
+            },
+            {
+              "x": 28.75452,
+              "y": -11.653676
+            },
+            {
+              "x": 28.729,
+              "y": -11.632732
+            },
+            {
+              "x": 28.729,
+              "y": -10.797
+            },
+            {
+              "x": 28.723716,
+              "y": -10.74335
+            },
+            {
+              "x": 28.708067,
+              "y": -10.691762
+            },
+            {
+              "x": 28.682654,
+              "y": -10.644218
+            },
+            {
+              "x": 28.648454,
+              "y": -10.602546
+            },
+            {
+              "x": 27.727764,
+              "y": -9.681855
+            },
+            {
+              "x": 27.731,
+              "y": -9.649
+            },
+            {
+              "x": 27.722834,
+              "y": -9.566087
+            },
+            {
+              "x": 27.698649,
+              "y": -9.48636
+            },
+            {
+              "x": 27.659375,
+              "y": -9.412883
+            },
+            {
+              "x": 27.60652,
+              "y": -9.34848
+            },
+            {
+              "x": 27.542117,
+              "y": -9.295625
+            },
+            {
+              "x": 27.46864,
+              "y": -9.256351
+            },
+            {
+              "x": 27.388913,
+              "y": -9.232166
+            },
+            {
+              "x": 27.306,
+              "y": -9.224
+            },
+            {
+              "x": 27.223087,
+              "y": -9.232166
+            },
+            {
+              "x": 27.14336,
+              "y": -9.256351
+            },
+            {
+              "x": 27.069883,
+              "y": -9.295625
+            },
+            {
+              "x": 27.00548,
+              "y": -9.34848
+            },
+            {
+              "x": 26.952625,
+              "y": -9.412883
+            },
+            {
+              "x": 26.913351,
+              "y": -9.48636
+            },
+            {
+              "x": 26.889166,
+              "y": -9.566087
+            },
+            {
+              "x": 26.881,
+              "y": -9.649
+            },
+            {
+              "x": 26.889166,
+              "y": -9.731913
+            },
+            {
+              "x": 26.913351,
+              "y": -9.81164
+            },
+            {
+              "x": 26.952625,
+              "y": -9.885117
+            },
+            {
+              "x": 27.00548,
+              "y": -9.94952
+            },
+            {
+              "x": 27.069883,
+              "y": -10.002375
+            },
+            {
+              "x": 27.14336,
+              "y": -10.041649
+            },
+            {
+              "x": 27.223087,
+              "y": -10.065834
+            },
+            {
+              "x": 27.306,
+              "y": -10.074
+            },
+            {
+              "x": 27.338855,
+              "y": -10.070764
+            },
+            {
+              "x": 28.179,
+              "y": -10.910908
+            },
+            {
+              "x": 28.179,
+              "y": -11.632731
+            },
+            {
+              "x": 28.153479,
+              "y": -11.653676
+            },
+            {
+              "x": 28.100625,
+              "y": -11.718079
+            },
+            {
+              "x": 28.061351,
+              "y": -11.791556
+            },
+            {
+              "x": 28.037166,
+              "y": -11.871283
+            },
+            {
+              "x": 28.029,
+              "y": -11.954196
+            },
+            {
+              "x": 28.037166,
+              "y": -12.037109
+            },
+            {
+              "x": 28.061351,
+              "y": -12.116837
+            },
+            {
+              "x": 28.100625,
+              "y": -12.190313
+            },
+            {
+              "x": 28.153479,
+              "y": -12.254716
+            },
+            {
+              "x": 28.217882,
+              "y": -12.307571
+            },
+            {
+              "x": 28.291359,
+              "y": -12.346845
+            },
+            {
+              "x": 28.371086,
+              "y": -12.37103
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 32,
+              "y": -12.49
+            },
+            {
+              "x": 32.185336,
+              "y": -12.471746
+            },
+            {
+              "x": 32.363549,
+              "y": -12.417686
+            },
+            {
+              "x": 32.527792,
+              "y": -12.329896
+            },
+            {
+              "x": 32.671751,
+              "y": -12.211751
+            },
+            {
+              "x": 32.789896,
+              "y": -12.067792
+            },
+            {
+              "x": 32.877686,
+              "y": -11.903549
+            },
+            {
+              "x": 32.931746,
+              "y": -11.725336
+            },
+            {
+              "x": 32.95,
+              "y": -11.54
+            },
+            {
+              "x": 32.931746,
+              "y": -11.354664
+            },
+            {
+              "x": 32.877686,
+              "y": -11.176451
+            },
+            {
+              "x": 32.789896,
+              "y": -11.012208
+            },
+            {
+              "x": 32.671751,
+              "y": -10.868249
+            },
+            {
+              "x": 32.527792,
+              "y": -10.750104
+            },
+            {
+              "x": 32.363549,
+              "y": -10.662314
+            },
+            {
+              "x": 32.185336,
+              "y": -10.608254
+            },
+            {
+              "x": 32,
+              "y": -10.59
+            },
+            {
+              "x": 31.814664,
+              "y": -10.608254
+            },
+            {
+              "x": 31.636451,
+              "y": -10.662314
+            },
+            {
+              "x": 31.472208,
+              "y": -10.750104
+            },
+            {
+              "x": 31.328249,
+              "y": -10.868249
+            },
+            {
+              "x": 31.210104,
+              "y": -11.012208
+            },
+            {
+              "x": 31.122314,
+              "y": -11.176451
+            },
+            {
+              "x": 31.068254,
+              "y": -11.354664
+            },
+            {
+              "x": 31.05,
+              "y": -11.54
+            },
+            {
+              "x": 31.068254,
+              "y": -11.725336
+            },
+            {
+              "x": 31.122314,
+              "y": -11.903549
+            },
+            {
+              "x": 31.210104,
+              "y": -12.067792
+            },
+            {
+              "x": 31.328249,
+              "y": -12.211751
+            },
+            {
+              "x": 31.472208,
+              "y": -12.329896
+            },
+            {
+              "x": 31.636451,
+              "y": -12.417686
+            },
+            {
+              "x": 31.814664,
+              "y": -12.471746
+            }
+          ]
+        },
+        {
+          "vertices": [
+            {
+              "x": 31.05,
+              "y": -15.03
+            },
+            {
+              "x": 32.95,
+              "y": -15.03
+            },
+            {
+              "x": 32.95,
+              "y": -13.13
+            },
+            {
+              "x": 31.05,
+              "y": -13.13
+            }
+          ]
+        }
+      ]
+    },
+    "source_net_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "covered_with_solder_mask": true
+  }
+]

--- a/tests/pcb/repros/repro18-through-obstacle-route-point.test.tsx
+++ b/tests/pcb/repros/repro18-through-obstacle-route-point.test.tsx
@@ -1,44 +1,21 @@
 import { expect, test } from "bun:test"
-import type { CircuitJson } from "circuit-json"
 import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
-
-const circuitJson: CircuitJson = [
-  {
-    type: "source_net",
-    source_net_id: "source_net_1",
-    name: "N1",
-    subcircuit_connectivity_map_key: "net1",
-  },
-  {
-    type: "source_trace",
-    source_trace_id: "source_trace_1",
-    connected_source_net_ids: ["source_net_1"],
-    subcircuit_connectivity_map_key: "net1",
-  },
-  {
-    type: "pcb_trace",
-    pcb_trace_id: "pcb_trace_1",
-    source_trace_id: "source_trace_1",
-    route: [
-      { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
-      {
-        route_type: "through_obstacle",
-        start: { x: 0, y: 0 },
-        end: { x: 0, y: 0 },
-        from_layer: "top",
-        to_layer: "inner1",
-        width: 0.15,
-      },
-      { route_type: "wire", x: 1, y: 0, width: 0.15, layer: "inner1" },
-    ],
-  },
-] as any
+import circuitJson from "tests/assets/diy-power-delivery-trigger.circuit.json"
+import type { CircuitJson } from "circuit-json"
 
 test("repro18: through_obstacle route points do not emit NaN segments", () => {
-  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  const hasThroughObstacle = (circuitJson as CircuitJson).some(
+    (elm) =>
+      elm.type === "pcb_trace" &&
+      elm.route?.some(
+        (routePoint: any) => routePoint.route_type === "through_obstacle",
+      ),
+  )
+  expect(hasThroughObstacle).toBe(true)
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
   converter.runUntilFinished()
   const output = converter.getOutputString()
 
   expect(output).not.toContain("NaN")
-  expect(output).toContain("(end 101 100)")
 })

--- a/tests/pcb/repros/repro18-through-obstacle-route-point.test.tsx
+++ b/tests/pcb/repros/repro18-through-obstacle-route-point.test.tsx
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+const circuitJson: CircuitJson = [
+  {
+    type: "source_net",
+    source_net_id: "source_net_1",
+    name: "N1",
+    subcircuit_connectivity_map_key: "net1",
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_1",
+    connected_source_net_ids: ["source_net_1"],
+    subcircuit_connectivity_map_key: "net1",
+  },
+  {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_1",
+    source_trace_id: "source_trace_1",
+    route: [
+      { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+      {
+        route_type: "through_obstacle",
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+        from_layer: "top",
+        to_layer: "inner1",
+        width: 0.15,
+      },
+      { route_type: "wire", x: 1, y: 0, width: 0.15, layer: "inner1" },
+    ],
+  },
+] as any
+
+test("repro18: through_obstacle route points do not emit NaN segments", () => {
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  expect(output).not.toContain("NaN")
+  expect(output).toContain("(end 101 100)")
+})


### PR DESCRIPTION
closes #290 

This fixes a KiCad export bug where through_obstacle entries in pcb_trace.route could generate invalid segments like (end NaN NaN).

AddTracesStage now reads coordinates from either top-level x/y route points or start/end route points, and skips invalid or zero-length segments.

Also adds a focused regression test for through_obstacle route points to ensure the exporter no longer emits NaN in generated .kicad_pcb output.

Board rendering successfully: 

<img width="1198" height="597" alt="image" src="https://github.com/user-attachments/assets/830a9db0-a2d6-4c07-bec7-38843fe22413" />
