### PR TITLE
fix(footprint): emit (layer B.Cu) for bottom-layer components

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -122,9 +122,17 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
     })
 
     const footprintData = `footprint:${component.pcb_component_id}:${transformedPos.x},${transformedPos.y}`
+    // The (layer ...) line at the top of a (footprint ...) block is what
+    // KiCad reads to set the footprint's "Board Side" property. Pad-level
+    // layers within the footprint (B.Cu / B.Paste / B.Mask etc.) are
+    // already correctly emitted from CreateSmdPadFromCircuitJson, but
+    // without setting this header, KiCad shows "Front" for every component
+    // regardless of its actual side. Map the circuit-json `pcb_component`'s
+    // `layer` ("top"/"bottom") to the corresponding KiCad copper layer.
+    const footprintLayer = component.layer === "bottom" ? "B.Cu" : "F.Cu"
     const footprint = new Footprint({
       libraryLink: `tscircuit:${footprintName}`,
-      layer: "F.Cu",
+      layer: footprintLayer,
       at: [transformedPos.x, transformedPos.y, component.rotation || 0],
       uuid: generateDeterministicUuid(footprintData),
     })

--- a/tests/pcb/basics/basics17-bottom-layer-footprint.test.tsx
+++ b/tests/pcb/basics/basics17-bottom-layer-footprint.test.tsx
@@ -1,0 +1,93 @@
+// bun test tests/pcb/basics/basics17-bottom-layer-footprint.test.tsx
+// BUN_UPDATE_SNAPSHOTS=1 bun test tests/pcb/basics/basics17-bottom-layer-footprint.test.tsx
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import { Circuit } from "tscircuit"
+
+// Regression: when a component is placed on the bottom copper layer
+// (`pcb_component.layer === "bottom"`), the exported KiCad `.kicad_pcb`
+// must emit `(layer B.Cu)` at the top of the corresponding `(footprint
+// ...)` block. Previously the converter always emitted `(layer F.Cu)`,
+// so KiCad showed "Board Side: Front" for every component — including
+// ones whose pads were correctly on B.Cu/B.Paste/B.Mask. The footprint
+// header layer is the field KiCad reads for the side property.
+
+test("pcb basics17 bottom-layer component → (layer B.Cu) in footprint header", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="14mm">
+      <resistor
+        name="R_TOP"
+        resistance="10k"
+        footprint="0402"
+        pcbX={-5}
+        pcbY={0}
+      />
+      <resistor
+        name="R_BOTTOM"
+        resistance="10k"
+        footprint="0402"
+        pcbX={5}
+        pcbY={0}
+        layer="bottom"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const sExpr = converter.getOutputString()
+
+  // Pull each (footprint ...) block; classify by whether any pad inside
+  // is on B.Cu / B.Paste / B.Mask, then read the footprint-header layer.
+  const blocks = extractFootprintBlocks(sExpr)
+  expect(blocks.length).toBe(2)
+
+  const headerLayer = (block: string): string | null => {
+    // First (layer ...) inside the block is the footprint-header layer.
+    // Skip past `(footprint\n  "..."\n` to find the first one.
+    const after = block.slice(block.indexOf("\n") + 1)
+    const m = after.match(/\(layer\s+"?([^"\s)]+)"?\s*\)/)
+    return m ? m[1]! : null
+  }
+
+  const isBottomByPad = (block: string): boolean =>
+    /\(layers\s+B\.Cu\b/.test(block)
+
+  const topBlock = blocks.find((b) => !isBottomByPad(b))!
+  const bottomBlock = blocks.find((b) => isBottomByPad(b))!
+
+  expect(topBlock).toBeDefined()
+  expect(bottomBlock).toBeDefined()
+  expect(headerLayer(topBlock)).toBe("F.Cu")
+  // Regression: this used to be "F.Cu", which made KiCad show
+  // "Board Side: Front" for back-side components.
+  expect(headerLayer(bottomBlock)).toBe("B.Cu")
+})
+
+/**
+ * Returns the paren-balanced text of every (footprint ...) block in
+ * the s-expression input.
+ */
+function extractFootprintBlocks(sExpr: string): string[] {
+  const out: string[] = []
+  const re = /\(footprint\b/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(sExpr)) !== null) {
+    const start = m.index
+    let depth = 0
+    for (let i = start; i < sExpr.length; i++) {
+      if (sExpr[i] === "(") depth++
+      else if (sExpr[i] === ")") {
+        depth--
+        if (depth === 0) {
+          out.push(sExpr.slice(start, i + 1))
+          break
+        }
+      }
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

When a circuit-json `pcb_component` has `layer: "bottom"`, the KiCad
exporter currently emits `(layer F.Cu)` at the top of the resulting
`(footprint ...)` block. KiCad's pcbnew reads that header line to
populate the footprint's "Board Side" property, so every back-side
component shows up as **"Board Side: Front"** even though its pads,
silkscreen and paste are correctly placed on B.Cu / B.Paste / B.Mask
inside the same block.

Reproducible on a board with any `layer="bottom"` component:

```tsx
<board width="20mm" height="14mm">
  <resistor name="R_BOTTOM" resistance="10k" footprint="0402"
    pcbX={5} pcbY={0} layer="bottom" />
</board>
```

Output before this PR — `R_BOTTOM` opens "Front" in pcbnew:

```
(footprint
  "tscircuit:resistor_0402"
  (layer F.Cu)        ← wrong
  ...
  (pad ... (layers B.Cu B.Paste B.Mask) ...)   ← pads are right
```

## Fix

`AddFootprintsStage._step` builds the footprint with a hardcoded
`layer: "F.Cu"`. Read `component.layer` from the circuit-json
`pcb_component` and map `"bottom"` → `"B.Cu"`, everything else
(`"top"`, undefined, inner layers) keeps `"F.Cu"`.

```ts
const footprintLayer = component.layer === "bottom" ? "B.Cu" : "F.Cu"
const footprint = new Footprint({
  libraryLink: `tscircuit:${footprintName}`,
  layer: footprintLayer,
  at: [...],
  uuid: ...,
})
```

Total diff: +9 / −1 lines in `AddFootprintsStage.ts` (most of which
is an explanatory comment), plus a new regression test.

## Tests

`tests/pcb/basics/basics17-bottom-layer-footprint.test.tsx` builds
a board with one `layer="top"` and one `layer="bottom"` resistor,
extracts both `(footprint ...)` blocks from the rendered s-expression,
classifies each by whether any pad inside is on B.Cu, and asserts
the footprint header layer is `F.Cu` / `B.Cu` respectively.

The suite goes from **8 pass / 10 fail on main** to **9 pass / 10 fail
on this branch** — one more pass (the new test). The 10 pre-existing
failures are PNG-snapshot environmental diffs (KiCad CLI version)
unrelated to this fix; the basics01–basics05 / 06 / 09 / 10 / 14 / 15
PNGs differ on main as well.

## Test plan

- [x] New regression test passes locally
- [x] Suite count check vs `upstream/main`: same `fail` count, +1 `pass`
- [ ] CI green
- [ ] Reviewer can open the test fixture in KiCad pcbnew and confirm
      the back-side resistor's "Properties → Board Side" reads "Back"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
