### PR TITLE
feat(pcb): export pcb_copper_pour records as KiCad zones

### DIFF
--- a/lib/pcb/CircuitJsonToKicadPcbConverter.ts
+++ b/lib/pcb/CircuitJsonToKicadPcbConverter.ts
@@ -10,6 +10,7 @@ import { AddTracesStage } from "./stages/AddTracesStage"
 import { AddViasStage } from "./stages/AddViasStage"
 import { AddStandalonePcbElements } from "./stages/AddStandalonePcbElements"
 import { AddGraphicsStage } from "./stages/AddGraphicsStage"
+import { AddCopperPoursStage } from "./stages/AddCopperPoursStage"
 
 interface CircuitJsonToKicadPcbOptions {
   /**
@@ -71,6 +72,7 @@ export class CircuitJsonToKicadPcbConverter {
       new AddTracesStage(circuitJson, this.ctx),
       new AddViasStage(circuitJson, this.ctx),
       new AddStandalonePcbElements(circuitJson, this.ctx),
+      new AddCopperPoursStage(circuitJson, this.ctx),
       new AddGraphicsStage(circuitJson, this.ctx),
     ]
   }

--- a/lib/pcb/stages/AddCopperPoursStage.ts
+++ b/lib/pcb/stages/AddCopperPoursStage.ts
@@ -1,0 +1,175 @@
+import type { CircuitJson } from "circuit-json"
+import type { KicadPcb } from "kicadts"
+import {
+  Zone,
+  ZoneFill,
+  ZoneHatch,
+  ZoneNet,
+  ZoneNetName,
+  ZonePolygon,
+  Pts,
+  Xy,
+} from "kicadts"
+import { ConverterStage, type ConverterContext } from "../../types"
+import { applyToPoint } from "transformation-matrix"
+import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
+import { getKicadLayer } from "../utils/layerMapping"
+
+type CopperPourLike = {
+  type: "pcb_copper_pour"
+  pcb_copper_pour_id: string
+  layer: string
+  source_net_id?: string
+  covered_with_solder_mask?: boolean
+  shape: "rect" | "polygon" | "brep"
+  // rect
+  center?: { x: number; y: number }
+  width?: number
+  height?: number
+  rotation?: number
+  // polygon
+  points?: Array<{ x: number; y: number }>
+}
+
+/**
+ * Converts pcb_copper_pour records from circuit-json into KiCad zone blocks.
+ *
+ * Supports:
+ *   - shape: "rect"    → 4-corner rectangular zone polygon
+ *   - shape: "polygon" → arbitrary polygon zone
+ *   - shape: "brep"    → currently unsupported (skipped with a warning)
+ *
+ * Fixes: https://github.com/tscircuit/circuit-json-to-kicad/issues/284
+ */
+export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
+  private pours: CopperPourLike[] = []
+  private poursProcessed = 0
+
+  constructor(input: CircuitJson, ctx: ConverterContext) {
+    super(input, ctx)
+    this.pours = (this.ctx.db.pcb_copper_pour?.list() ??
+      []) as CopperPourLike[]
+  }
+
+  override _step(): void {
+    if (this.poursProcessed >= this.pours.length) {
+      this.finished = true
+      return
+    }
+
+    const { kicadPcb, c2kMatPcb, pcbNetMap } = this.ctx
+
+    if (!kicadPcb) throw new Error("KicadPcb not initialized in context")
+    if (!c2kMatPcb) throw new Error("PCB transform matrix not initialized")
+
+    const pour = this.pours[this.poursProcessed]!
+    this.poursProcessed++
+
+    if (pour.shape === "brep") {
+      // BRep pours require tessellation; skip for now.
+      console.warn(
+        `[AddCopperPoursStage] Skipping brep copper pour ${pour.pcb_copper_pour_id} (not yet supported)`,
+      )
+      return
+    }
+
+    const kicadLayer = getKicadLayer(pour.layer)
+
+    // Resolve net info from pcbNetMap
+    let netId = 0
+    let netName = ""
+    if (pcbNetMap && pour.source_net_id) {
+      // pcbNetMap is keyed by subcircuit_connectivity_map_key; we also try
+      // source_net_id directly since copper pours reference it that way.
+      let netInfo = pcbNetMap.get(pour.source_net_id)
+      if (!netInfo) {
+        // Fall back: scan for matching source_net
+        const sourceNet = this.ctx.db.source_net?.get(pour.source_net_id)
+        if (sourceNet?.subcircuit_connectivity_map_key) {
+          netInfo = pcbNetMap.get(sourceNet.subcircuit_connectivity_map_key)
+        }
+      }
+      if (netInfo) {
+        netId = netInfo.id
+        netName = netInfo.name
+      }
+    }
+
+    // Build polygon points in KiCad coordinates
+    const kicadPoints = this.getKicadPoints(pour, c2kMatPcb)
+    if (kicadPoints.length < 3) {
+      console.warn(
+        `[AddCopperPoursStage] Skipping copper pour ${pour.pcb_copper_pour_id}: fewer than 3 points`,
+      )
+      return
+    }
+
+    const pts = new Pts(kicadPoints.map((p) => new Xy(p.x, p.y)))
+    const polygon = new ZonePolygon(pts)
+
+    const zone = new Zone({
+      net: new ZoneNet(netId),
+      netName: new ZoneNetName(netName || ""),
+      layer: kicadLayer,
+      hatch: new ZoneHatch("edge", 0.508),
+      fill: new ZoneFill({ filled: true }),
+      polygons: [polygon],
+    })
+
+    // Assign a deterministic UUID derived from pour identity + layer
+    const seed = `copper_pour:${pour.pcb_copper_pour_id}:${kicadLayer}`
+    ;(zone as any)._sxUuid = { getString: () => `(uuid "${generateDeterministicUuid(seed)}")` }
+
+    const zones = kicadPcb.zones ?? []
+    zones.push(zone)
+    kicadPcb.zones = zones
+  }
+
+  private getKicadPoints(
+    pour: CopperPourLike,
+    transform: import("transformation-matrix").Matrix,
+  ): Array<{ x: number; y: number }> {
+    if (pour.shape === "rect") {
+      if (
+        pour.center === undefined ||
+        pour.width === undefined ||
+        pour.height === undefined
+      ) {
+        return []
+      }
+
+      const { x: cx, y: cy } = pour.center
+      const hw = pour.width / 2
+      const hh = pour.height / 2
+      const rot = ((pour.rotation ?? 0) * Math.PI) / 180
+
+      // 4 corners in circuit-json space (before rotation), then rotate
+      const corners = [
+        { x: cx - hw, y: cy - hh },
+        { x: cx + hw, y: cy - hh },
+        { x: cx + hw, y: cy + hh },
+        { x: cx - hw, y: cy + hh },
+      ].map(({ x, y }) => {
+        const dx = x - cx
+        const dy = y - cy
+        return {
+          x: cx + dx * Math.cos(rot) - dy * Math.sin(rot),
+          y: cy + dx * Math.sin(rot) + dy * Math.cos(rot),
+        }
+      })
+
+      return corners.map((p) => applyToPoint(transform, p))
+    }
+
+    if (pour.shape === "polygon") {
+      if (!pour.points?.length) return []
+      return pour.points.map((p) => applyToPoint(transform, p))
+    }
+
+    return []
+  }
+
+  override getOutput(): KicadPcb {
+    return this.ctx.kicadPcb!
+  }
+}

--- a/lib/pcb/stages/AddCopperPoursStage.ts
+++ b/lib/pcb/stages/AddCopperPoursStage.ts
@@ -1,15 +1,7 @@
 import type { CircuitJson } from "circuit-json"
+import type { Matrix } from "transformation-matrix"
 import type { KicadPcb } from "kicadts"
-import {
-  Zone,
-  ZoneFill,
-  ZoneHatch,
-  ZoneNet,
-  ZoneNetName,
-  ZonePolygon,
-  Pts,
-  Xy,
-} from "kicadts"
+import { Zone } from "kicadts"
 import { ConverterStage, type ConverterContext } from "../../types"
 import { applyToPoint } from "transformation-matrix"
 import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
@@ -47,8 +39,7 @@ export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
 
   constructor(input: CircuitJson, ctx: ConverterContext) {
     super(input, ctx)
-    this.pours = (this.ctx.db.pcb_copper_pour?.list() ??
-      []) as CopperPourLike[]
+    this.pours = (this.ctx.db.pcb_copper_pour?.list() ?? []) as CopperPourLike[]
   }
 
   override _step(): void {
@@ -79,11 +70,8 @@ export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
     let netId = 0
     let netName = ""
     if (pcbNetMap && pour.source_net_id) {
-      // pcbNetMap is keyed by subcircuit_connectivity_map_key; we also try
-      // source_net_id directly since copper pours reference it that way.
       let netInfo = pcbNetMap.get(pour.source_net_id)
       if (!netInfo) {
-        // Fall back: scan for matching source_net
         const sourceNet = this.ctx.db.source_net?.get(pour.source_net_id)
         if (sourceNet?.subcircuit_connectivity_map_key) {
           netInfo = pcbNetMap.get(sourceNet.subcircuit_connectivity_map_key)
@@ -104,21 +92,23 @@ export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
       return
     }
 
-    const pts = new Pts(kicadPoints.map((p) => new Xy(p.x, p.y)))
-    const polygon = new ZonePolygon(pts)
-
-    const zone = new Zone({
-      net: new ZoneNet(netId),
-      netName: new ZoneNetName(netName || ""),
-      layer: kicadLayer,
-      hatch: new ZoneHatch("edge", 0.508),
-      fill: new ZoneFill({ filled: true }),
-      polygons: [polygon],
-    })
-
-    // Assign a deterministic UUID derived from pour identity + layer
     const seed = `copper_pour:${pour.pcb_copper_pour_id}:${kicadLayer}`
-    ;(zone as any)._sxUuid = { getString: () => `(uuid "${generateDeterministicUuid(seed)}")` }
+    const zone = new Zone()
+    zone.rawChildren = [
+      ["net", netId],
+      ["net_name", netName],
+      ["layer", kicadLayer],
+      ["hatch", "edge", 0.508],
+      ["fill", "yes"],
+      ["uuid", generateDeterministicUuid(seed)],
+      [
+        "polygon",
+        [
+          "pts",
+          ...kicadPoints.map((p): [string, number, number] => ["xy", p.x, p.y]),
+        ],
+      ],
+    ]
 
     const zones = kicadPcb.zones ?? []
     zones.push(zone)
@@ -127,7 +117,7 @@ export class AddCopperPoursStage extends ConverterStage<CircuitJson, KicadPcb> {
 
   private getKicadPoints(
     pour: CopperPourLike,
-    transform: import("transformation-matrix").Matrix,
+    transform: Matrix,
   ): Array<{ x: number; y: number }> {
     if (pour.shape === "rect") {
       if (

--- a/tests/pcb/basics/__snapshots__/basics17-copper-pour.test.ts.snap
+++ b/tests/pcb/basics/__snapshots__/basics17-copper-pour.test.ts.snap
@@ -1,0 +1,101 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`pcb copper pour - rect shape is exported as KiCad zone 1`] = `
+"(kicad_pcb
+  (version 20241229)
+  (generator circuit-json-to-kicad)
+  (generator_version 0.0.1)
+  (general
+    (thickness 1.6)
+  )
+  (paper
+    A4
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user)
+    (33 "F.Adhes" user)
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user)
+    (37 "F.SilkS" user)
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (40 "Dwgs.User" user)
+    (41 "Cmts.User" user)
+    (42 "Eco1.User" user)
+    (43 "Eco2.User" user)
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user)
+    (47 "F.CrtYd" user)
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (zone
+    (net 1)
+    (net_name GND)
+    (layer F.Cu)
+    (hatch edge 0.508)
+    (fill yes)
+    (uuid 3c16c552-3b3e-9d4e-4d6c-001229e9628e)
+    (polygon (pts (xy 95 105) (xy 105 105) (xy 105 95) (xy 95 95)))
+  )
+)"
+`;
+
+exports[`pcb copper pour - polygon shape is exported as KiCad zone 1`] = `
+"(kicad_pcb
+  (version 20241229)
+  (generator circuit-json-to-kicad)
+  (generator_version 0.0.1)
+  (general
+    (thickness 1.6)
+  )
+  (paper
+    A4
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user)
+    (33 "F.Adhes" user)
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user)
+    (37 "F.SilkS" user)
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (40 "Dwgs.User" user)
+    (41 "Cmts.User" user)
+    (42 "Eco1.User" user)
+    (43 "Eco2.User" user)
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user)
+    (47 "F.CrtYd" user)
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (zone
+    (net 1)
+    (net_name VCC)
+    (layer B.Cu)
+    (hatch edge 0.508)
+    (fill yes)
+    (uuid 50f8034c-265d-5f54-624d-3e0c15082494)
+    (polygon (pts (xy 95 105) (xy 105 105) (xy 105 95) (xy 100 92) (xy 95 95)))
+  )
+)"
+`;

--- a/tests/pcb/basics/basics17-copper-pour.test.ts
+++ b/tests/pcb/basics/basics17-copper-pour.test.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import type { AnyCircuitElement } from "circuit-json"
+
+/**
+ * Regression test for: KiCad export drops pcb_copper_pour records
+ * https://github.com/tscircuit/circuit-json-to-kicad/issues/284
+ */
+
+test("pcb copper pour - rect shape is exported as KiCad zone", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "GND",
+      ftype: "simple_net",
+    } as any,
+    {
+      type: "source_net",
+      source_net_id: "sn1",
+      name: "GND",
+      member_source_group_ids: [],
+    } as any,
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour1",
+      layer: "top",
+      source_net_id: "sn1",
+      covered_with_solder_mask: true,
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    } as any,
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  // The output should contain a zone block
+  expect(output).toContain("(zone")
+
+  // Should contain the polygon with 4 corner points
+  expect(output).toContain("(polygon")
+  expect(output).toContain("(pts")
+
+  // The zone should be on the front copper layer
+  expect(output).toContain("F.Cu")
+
+  // Snapshot for stability
+  expect(output).toMatchSnapshot()
+})
+
+test("pcb copper pour - polygon shape is exported as KiCad zone", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_net",
+      source_net_id: "sn2",
+      name: "VCC",
+      member_source_group_ids: [],
+    } as any,
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour2",
+      layer: "bottom",
+      source_net_id: "sn2",
+      covered_with_solder_mask: false,
+      shape: "polygon",
+      points: [
+        { x: -5, y: -5 },
+        { x: 5, y: -5 },
+        { x: 5, y: 5 },
+        { x: 0, y: 8 },
+        { x: -5, y: 5 },
+      ],
+    } as any,
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  // Should contain a zone block on the back copper layer
+  expect(output).toContain("(zone")
+  expect(output).toContain("B.Cu")
+
+  // Should have 5 points in the polygon
+  const xyMatches = output.match(/\(xy [\d.eE+-]+ [\d.eE+-]+\)/g) ?? []
+  expect(xyMatches.length).toBeGreaterThanOrEqual(5)
+
+  expect(output).toMatchSnapshot()
+})
+
+test("pcb copper pour - no pours produces no zone blocks", () => {
+  const circuitJson: AnyCircuitElement[] = []
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  const output = converter.getOutputString()
+
+  expect(output).not.toContain("(zone")
+})


### PR DESCRIPTION
## Summary

Fixes #284 — `pcb_copper_pour` records in circuit-json were silently dropped during KiCad PCB export. Opening the resulting `.kicad_pcb` showed zero `(zone)` blocks even when copper pours were present.

### Root Cause

The PCB converter pipeline had stages for traces, vias, footprints, graphics, etc., but no stage existed to handle `pcb_copper_pour` elements. They were read into the circuit-json DB but never converted.

### Fix

Added `AddCopperPoursStage.ts` — a new pipeline stage that:

1. Reads all `pcb_copper_pour` records from the circuit-json DB
2. Converts each to a KiCad `(zone ...)` block using the `kicadts` `Zone` class
3. Handles the two common shapes:
   - **`rect`** → 4-corner rectangular polygon (with optional rotation support)
   - **`polygon`** → arbitrary polygon from the `points` array
4. Resolves the net number/name from `pcbNetMap` via `source_net_id`
5. **`brep`** shapes are logged and skipped (tessellation support is future work)

Registered the stage in `CircuitJsonToKicadPcbConverter.ts` between `AddViasStage`/`AddStandalonePcbElements` and `AddGraphicsStage`.

### Tests

Added `tests/pcb/basics/basics17-copper-pour.test.ts` covering:
- Rectangular pour → zone with 4 polygon corners on `F.Cu`
- Polygon pour → zone with N polygon points on `B.Cu`
- Empty circuit → no zone blocks emitted

## Test plan

- [x] `AddCopperPoursStage` created with stage pattern matching existing stages
- [x] `CircuitJsonToKicadPcbConverter` pipeline updated
- [x] Tests cover rect, polygon, and empty-circuit cases
- [x] KiCad layer mapping (`top` → `F.Cu`, `bottom` → `B.Cu`) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
