### PR TITLE
fix(sch): round schematic wire coordinates to prevent floating-point disconnections

### DIFF
--- a/lib/schematic/stages/AddSchematicTracesStage.ts
+++ b/lib/schematic/stages/AddSchematicTracesStage.ts
@@ -75,10 +75,14 @@ export class AddSchematicTracesStage extends ConverterStage<
       y: edge.to.y,
     })
 
-    const x1 = from.x
-    const y1 = from.y
-    const x2 = to.x
-    const y2 = to.y
+    // Round to 4 decimal places (0.0001mm) to eliminate floating-point drift
+    // from the c2kMatSch matrix transformation, which can cause tiny misalignments
+    // that break wire-to-pin connectivity in KiCad (issues #283, #292).
+    const snap = (n: number) => Math.round(n * 10000) / 10000
+    const x1 = snap(from.x)
+    const y1 = snap(from.y)
+    const x2 = snap(to.x)
+    const y2 = snap(to.y)
 
     // Create points for the wire
     const pts = new Pts([new Xy(x1, y1), new Xy(x2, y2)])
@@ -107,10 +111,13 @@ export class AddSchematicTracesStage extends ConverterStage<
     }
 
     // Transform circuit-json coordinates to KiCad coordinates using c2kMatSch
-    const { x, y } = applyToPoint(this.ctx.c2kMatSch, {
+    const raw = applyToPoint(this.ctx.c2kMatSch, {
       x: junction.x,
       y: junction.y,
     })
+    const snap = (n: number) => Math.round(n * 10000) / 10000
+    const x = snap(raw.x)
+    const y = snap(raw.y)
 
     const kicadJunction = new Junction({
       at: [x, y],

--- a/lib/schematic/stages/AddSchematicTracesStage.ts
+++ b/lib/schematic/stages/AddSchematicTracesStage.ts
@@ -78,7 +78,7 @@ export class AddSchematicTracesStage extends ConverterStage<
     // Round to 4 decimal places (0.0001mm) to eliminate floating-point drift
     // from the c2kMatSch matrix transformation, which can cause tiny misalignments
     // that break wire-to-pin connectivity in KiCad (issues #283, #292).
-    const snap = (n: number) => Math.round(n * 10000) / 10000
+    const snap = (n: number) => Number(n.toFixed(4))
     const x1 = snap(from.x)
     const y1 = snap(from.y)
     const x2 = snap(to.x)
@@ -115,7 +115,7 @@ export class AddSchematicTracesStage extends ConverterStage<
       x: junction.x,
       y: junction.y,
     })
-    const snap = (n: number) => Math.round(n * 10000) / 10000
+    const snap = (n: number) => Number(n.toFixed(4))
     const x = snap(raw.x)
     const y = snap(raw.y)
 

--- a/tests/sch/repros/repro11-wire-floating-point-precision.test.tsx
+++ b/tests/sch/repros/repro11-wire-floating-point-precision.test.tsx
@@ -27,13 +27,7 @@ test("repro11: schematic wire endpoints have at most 4 decimal places (no floati
         schY={0}
         connections={{ pin1: "R1.pin1" }}
       />
-      <resistor
-        name="R1"
-        resistance="100"
-        footprint="0402"
-        schX={3}
-        schY={0}
-      />
+      <resistor name="R1" resistance="100" footprint="0402" schX={3} schY={0} />
     </board>,
   )
 

--- a/tests/sch/repros/repro11-wire-floating-point-precision.test.tsx
+++ b/tests/sch/repros/repro11-wire-floating-point-precision.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadSchConverter } from "lib"
+
+/**
+ * Regression test for issues #283 and #292:
+ * Schematic wires disconnected from component pins due to floating-point
+ * precision issues in coordinate calculations.
+ *
+ * After the c2kMatSch matrix transformation, coordinates can accumulate
+ * floating-point errors (e.g., 10.1599999 instead of 10.16), causing
+ * wires to appear visually connected but electrically disconnected in KiCad.
+ *
+ * Fix: round wire endpoint coordinates to 4 decimal places in
+ * AddSchematicTracesStage.ts.
+ */
+test("repro11: schematic wire endpoints have at most 4 decimal places (no floating-point drift)", async () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board>
+      <inductor
+        name="L1"
+        inductance="10uH"
+        footprint="0402"
+        schX={-3}
+        schY={0}
+        connections={{ pin1: "R1.pin1" }}
+      />
+      <resistor
+        name="R1"
+        resistance="100"
+        footprint="0402"
+        schX={3}
+        schY={0}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const converter = new CircuitJsonToKicadSchConverter(circuit.getCircuitJson())
+  converter.runUntilFinished()
+
+  const kicadSchOutput = converter.getOutputString()
+
+  // Extract all (xy ...) coordinate values from wire blocks
+  const wireBlocks = kicadSchOutput.match(/\(wire[\s\S]*?\n  \)/g) ?? []
+  expect(wireBlocks.length).toBeGreaterThan(0)
+
+  const xyPattern = /\(xy ([\d.eE+-]+) ([\d.eE+-]+)\)/g
+  const allCoords: number[] = []
+  for (const block of wireBlocks) {
+    let m: RegExpExecArray | null
+    while ((m = xyPattern.exec(block)) !== null) {
+      allCoords.push(Number(m[1]), Number(m[2]))
+    }
+  }
+
+  expect(allCoords.length).toBeGreaterThan(0)
+
+  // Each coordinate should have at most 4 decimal places — no drift like 10.1599999
+  for (const coord of allCoords) {
+    const str = coord.toString()
+    const dotIndex = str.indexOf(".")
+    if (dotIndex !== -1) {
+      const decimals = str.length - dotIndex - 1
+      expect(
+        decimals,
+        `Coordinate ${coord} has ${decimals} decimal places (expected ≤ 4)`,
+      ).toBeLessThanOrEqual(4)
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Fixes schematic wire-to-pin disconnections caused by floating-point precision errors in coordinate transformations (issues #283, #292).

### Root Cause

After `applyToPoint(c2kMatSch, ...)`, coordinates can accumulate floating-point drift:
- `10.1599999...` instead of `10.16`
- `3.9999999...` instead of `4.0`

Because KiCad determines connectivity by exact coordinate matching, these tiny errors cause wires to appear visually connected but register as electrically disconnected in the netlist.

### Fix

Round all transformed wire endpoint and junction coordinates to **4 decimal places** (0.0001mm = 100nm precision) in `AddSchematicTracesStage.ts`. This eliminates drift artifacts while preserving far more accuracy than KiCad's actual grid resolution (0.25mm).

### Test

Added `repro11-wire-floating-point-precision.test.tsx`: verifies all exported wire `(xy ...)` coordinates have ≤ 4 decimal places.

Closes #292
Closes #283