### PR TITLE
Add high-level KiCad project ZIP export with packaged 3D models

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./schematic/CircuitJsonToKicadSchConverter"
 export * from "./pcb/CircuitJsonToKicadPcbConverter"
 export * from "./project/CircuitJsonToKicadProConverter"
+export * from "./project/convertCircuitJsonToKicadProjectZip"
 export * from "./kicad-library/CircuitJsonToKicadLibraryConverter"
 export * from "./kicad-library/KicadLibraryConverter"

--- a/lib/project/convertCircuitJsonToKicadProjectZip.ts
+++ b/lib/project/convertCircuitJsonToKicadProjectZip.ts
@@ -1,0 +1,87 @@
+import type { CircuitJson } from "circuit-json"
+import JSZip from "jszip"
+import { readFile } from "node:fs/promises"
+import { CircuitJsonToKicadPcbConverter } from "../pcb/CircuitJsonToKicadPcbConverter"
+import { CircuitJsonToKicadSchConverter } from "../schematic/CircuitJsonToKicadSchConverter"
+import { CircuitJsonToKicadProConverter } from "./CircuitJsonToKicadProConverter"
+
+type ModelFileContent = ArrayBuffer | Uint8Array
+
+export interface ConvertCircuitJsonToKicadProjectZipOptions {
+  projectName: string
+  fetchModel?: (modelPath: string) => Promise<ModelFileContent>
+}
+
+const getModelFileName = (modelPath: string) => {
+  const pathWithoutQuery = modelPath.split("?")[0] ?? modelPath
+  const parts = pathWithoutQuery.split(/[/\\]/)
+  return parts[parts.length - 1] || pathWithoutQuery
+}
+
+const isRemotePath = (modelPath: string) =>
+  modelPath.startsWith("http://") || modelPath.startsWith("https://")
+
+const isBuiltinModelPath = (modelPath: string) =>
+  modelPath.startsWith("http://modelcdn.tscircuit.com") ||
+  modelPath.startsWith("https://modelcdn.tscircuit.com")
+
+const fetchModelFile = async (modelPath: string): Promise<ModelFileContent> => {
+  if (!isRemotePath(modelPath)) {
+    return readFile(modelPath)
+  }
+
+  const response = await fetch(modelPath)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch 3D model from ${modelPath}`)
+  }
+
+  return response.arrayBuffer()
+}
+
+export const convertCircuitJsonToKicadProjectZip = async (
+  circuitJson: CircuitJson,
+  options: ConvertCircuitJsonToKicadProjectZipOptions,
+) => {
+  let projectName = options.projectName.trim()
+  if (projectName.length === 0) {
+    projectName = "project"
+  }
+  const schematicFileName = `${projectName}.kicad_sch`
+  const boardFileName = `${projectName}.kicad_pcb`
+  const projectFileName = `${projectName}.kicad_pro`
+
+  const schConverter = new CircuitJsonToKicadSchConverter(circuitJson)
+  schConverter.runUntilFinished()
+
+  const pcbConverter = new CircuitJsonToKicadPcbConverter(circuitJson, {
+    includeBuiltin3dModels: true,
+    projectName,
+  })
+  pcbConverter.runUntilFinished()
+
+  const proConverter = new CircuitJsonToKicadProConverter(circuitJson, {
+    projectName,
+    schematicFilename: schematicFileName,
+    pcbFilename: boardFileName,
+  })
+  proConverter.runUntilFinished()
+
+  const zip = new JSZip()
+  zip.file(schematicFileName, schConverter.getOutputString())
+  zip.file(boardFileName, pcbConverter.getOutputString())
+  zip.file(projectFileName, proConverter.getOutputString())
+
+  const loadModel = options.fetchModel ?? fetchModelFile
+  for (const modelPath of pcbConverter.getModel3dSourcePaths()) {
+    const fileName = getModelFileName(modelPath)
+    let shapesDir = `${projectName}.3dshapes`
+    if (isBuiltinModelPath(modelPath)) {
+      shapesDir = "tscircuit_builtin.3dshapes"
+    }
+    const zipPath = `3dmodels/${shapesDir}/${fileName}`
+
+    zip.file(zipPath, await loadModel(modelPath))
+  }
+
+  return zip
+}

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -1,6 +1,4 @@
-import { CircuitJsonToKicadSchConverter } from "../lib/schematic/CircuitJsonToKicadSchConverter"
-import { CircuitJsonToKicadPcbConverter } from "../lib/pcb/CircuitJsonToKicadPcbConverter"
-import { CircuitJsonToKicadProConverter } from "../lib/project/CircuitJsonToKicadProConverter"
+import { convertCircuitJsonToKicadProjectZip } from "../lib/project/convertCircuitJsonToKicadProjectZip"
 
 // Get DOM elements
 const uploadArea = document.getElementById("uploadArea")!
@@ -95,30 +93,14 @@ convertBtn.addEventListener("click", async () => {
     // Get base filename without extension
     const baseName = currentFile!.name.replace(/\.json$/i, "")
 
-    // Convert to schematic
-    const schConverter = new CircuitJsonToKicadSchConverter(circuitJson)
-    schConverter.runUntilFinished()
-    const schContent = schConverter.getOutputString()
+    const zip = await convertCircuitJsonToKicadProjectZip(circuitJson, {
+      projectName: baseName,
+    })
+    const zipBlob = await zip.generateAsync({ type: "blob" })
 
-    // Convert to PCB
-    const pcbConverter = new CircuitJsonToKicadPcbConverter(circuitJson)
-    pcbConverter.runUntilFinished()
-    const pcbContent = pcbConverter.getOutputString()
+    downloadFile(`${baseName}_kicad_project.zip`, zipBlob)
 
-    // Convert to project file
-    const proConverter = new CircuitJsonToKicadProConverter(circuitJson)
-    proConverter.runUntilFinished()
-    const proContent = proConverter.getOutputString()
-
-    // Create zip file with all outputs
-    // For simplicity, we'll download them separately
-    // In a real app, you might want to use JSZip library
-
-    downloadFile(`${baseName}.kicad_sch`, schContent)
-    downloadFile(`${baseName}.kicad_pcb`, pcbContent)
-    downloadFile(`${baseName}.kicad_pro`, proContent)
-
-    showStatus("Conversion complete! Files downloaded.", "success")
+    showStatus("Conversion complete! Project zip downloaded.", "success")
     convertBtn.disabled = false
   } catch (error) {
     showStatus(
@@ -141,8 +123,11 @@ clearBtn.addEventListener("click", () => {
 })
 
 // Helper function to download a file
-function downloadFile(filename: string, content: string) {
-  const blob = new Blob([content], { type: "text/plain" })
+function downloadFile(filename: string, content: string | Blob) {
+  let blob = content
+  if (typeof content === "string") {
+    blob = new Blob([content], { type: "text/plain" })
+  }
   const url = URL.createObjectURL(blob)
   const a = document.createElement("a")
   a.href = url

--- a/tests/project/kicad-project-zip-3d-models01.test.tsx
+++ b/tests/project/kicad-project-zip-3d-models01.test.tsx
@@ -1,0 +1,74 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "tscircuit"
+import { convertCircuitJsonToKicadProjectZip } from "lib"
+import path from "node:path"
+
+const SWITCH_STEP_URL = path.resolve(
+  __dirname,
+  "../assets/SW_Push_1P1T_NO_CK_KMR2.step",
+)
+const REMOTE_USER_STEP_URL = "https://example.com/models/custom-switch.step"
+
+test("project zip includes KiCad files and 3D model assets", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={0} />
+      <chip
+        name="SW1"
+        footprint="tssop8"
+        pcbX={8}
+        cadModel={{
+          stepUrl: SWITCH_STEP_URL,
+          rotationOffset: { x: 0, y: 0, z: 0 },
+        }}
+      />
+      <chip
+        name="SW2"
+        footprint="tssop8"
+        pcbX={12}
+        cadModel={{
+          stepUrl: REMOTE_USER_STEP_URL,
+          rotationOffset: { x: 0, y: 0, z: 0 },
+        }}
+      />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const zip = await convertCircuitJsonToKicadProjectZip(
+    circuit.getCircuitJson(),
+    {
+      projectName: "my_project",
+      fetchModel: async (modelPath) => new TextEncoder().encode(modelPath),
+    },
+  )
+
+  const zipFiles = Object.keys(zip.files).sort()
+  expect(zipFiles).toContain("my_project.kicad_pcb")
+  expect(zipFiles).toContain("my_project.kicad_sch")
+  expect(zipFiles).toContain("my_project.kicad_pro")
+  expect(zipFiles).toContain("3dmodels/tscircuit_builtin.3dshapes/0402.step")
+  expect(zipFiles).toContain(
+    "3dmodels/my_project.3dshapes/SW_Push_1P1T_NO_CK_KMR2.step",
+  )
+  expect(zipFiles).toContain("3dmodels/my_project.3dshapes/custom-switch.step")
+
+  const pcbFile = zip.file("my_project.kicad_pcb")
+  expect(pcbFile).toBeDefined()
+  const pcbContent = await pcbFile!.async("string")
+  expect(pcbContent).toContain(
+    "${KIPRJMOD}/3dmodels/tscircuit_builtin.3dshapes/0402.step",
+  )
+  expect(pcbContent).toContain(
+    "${KIPRJMOD}/3dmodels/my_project.3dshapes/custom-switch.step",
+  )
+
+  const remoteUserStepFile = zip.file(
+    "3dmodels/my_project.3dshapes/custom-switch.step",
+  )
+  expect(remoteUserStepFile).toBeDefined()
+  const remoteUserStep = await remoteUserStepFile!.async("string")
+  expect(remoteUserStep).toBe(REMOTE_USER_STEP_URL)
+})


### PR DESCRIPTION
**You can verify using live deployment**

This adds a simple convertCircuitJsonToKicadProjectZip API that creates a full KiCad project ZIP from circuit JSON, including .kicad_pcb, .kicad_sch, .kicad_pro, and referenced STEP models. Built-in tscircuit models are packaged under 3dmodels/tscircuit_builtin.3dshapes, while user-provided models are packaged under the project’s own .3dshapes folder.

