### PR TITLE
Fix 3D model placement for rotated 3D components

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -333,7 +333,10 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
       const models = create3DModelsFromCadComponent(
         cadComponent,
         component.center,
-        { boardLayerZOffset },
+        {
+          boardLayerZOffset,
+          componentRotationDegrees: component.rotation || 0,
+        },
       )
       const KICAD_3D_BASE = "${KIPRJMOD}/3dmodels"
       if (models.length > 0) {

--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -335,7 +335,7 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         component.center,
         {
           boardLayerZOffset,
-          componentRotationDegrees: component.rotation || 0,
+          footprintRotationDegrees: component.rotation || 0,
         },
       )
       const KICAD_3D_BASE = "${KIPRJMOD}/3dmodels"

--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -335,7 +335,7 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         component.center,
         {
           boardLayerZOffset,
-          footprintRotationDegrees: component.rotation || 0,
+          footprintRotation: component.rotation || 0,
         },
       )
       const KICAD_3D_BASE = "${KIPRJMOD}/3dmodels"

--- a/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
+++ b/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
@@ -4,7 +4,7 @@ import { FootprintModel } from "kicadts"
 export function create3DModelsFromCadComponent(
   cadComponent: CadComponent,
   componentCenter: { x: number; y: number },
-  options?: { boardLayerZOffset?: number; componentRotationDegrees?: number },
+  options?: { boardLayerZOffset?: number; footprintRotationDegrees?: number },
 ): FootprintModel[] {
   const models: FootprintModel[] = []
 
@@ -39,12 +39,12 @@ export function create3DModelsFromCadComponent(
   }
 
   if (cadComponent.rotation) {
-    const componentRotationDegrees = options?.componentRotationDegrees ?? 0
+    const footprintRotationDegrees = options?.footprintRotationDegrees ?? 0
 
     model.rotate = {
       x: cadComponent.rotation.x || 0,
       y: cadComponent.rotation.y || 0,
-      z: (cadComponent.rotation.z || 0) - componentRotationDegrees,
+      z: (cadComponent.rotation.z || 0) - footprintRotationDegrees,
     }
   }
 

--- a/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
+++ b/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
@@ -4,7 +4,7 @@ import { FootprintModel } from "kicadts"
 export function create3DModelsFromCadComponent(
   cadComponent: CadComponent,
   componentCenter: { x: number; y: number },
-  options?: { boardLayerZOffset?: number },
+  options?: { boardLayerZOffset?: number; componentRotationDegrees?: number },
 ): FootprintModel[] {
   const models: FootprintModel[] = []
 
@@ -21,18 +21,30 @@ export function create3DModelsFromCadComponent(
     // NOTE: unlike 2D footprint geometry, KiCad 3D model Y offsets map directly
     // from circuit-json local footprint Y. Do not mirror Y here.
     const boardLayerZOffset = options?.boardLayerZOffset ?? 0
+    const modelOriginPosition = cadComponent.model_origin_position
     model.offset = {
-      x: (cadComponent.position.x || 0) - componentCenter.x,
-      y: (cadComponent.position.y || 0) - componentCenter.y,
-      z: (cadComponent.position.z || 0) - boardLayerZOffset,
+      x:
+        (cadComponent.position.x || 0) -
+        componentCenter.x -
+        (modelOriginPosition?.x || 0),
+      y:
+        (cadComponent.position.y || 0) -
+        componentCenter.y -
+        (modelOriginPosition?.y || 0),
+      z:
+        (cadComponent.position.z || 0) -
+        boardLayerZOffset -
+        (modelOriginPosition?.z || 0),
     }
   }
 
   if (cadComponent.rotation) {
+    const componentRotationDegrees = options?.componentRotationDegrees ?? 0
+
     model.rotate = {
       x: cadComponent.rotation.x || 0,
       y: cadComponent.rotation.y || 0,
-      z: cadComponent.rotation.z || 0,
+      z: (cadComponent.rotation.z || 0) - componentRotationDegrees,
     }
   }
 

--- a/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
+++ b/lib/pcb/stages/footprints-stage-converters/create3DModelsFromCadComponent.ts
@@ -4,7 +4,7 @@ import { FootprintModel } from "kicadts"
 export function create3DModelsFromCadComponent(
   cadComponent: CadComponent,
   componentCenter: { x: number; y: number },
-  options?: { boardLayerZOffset?: number; footprintRotationDegrees?: number },
+  options?: { boardLayerZOffset?: number; footprintRotation?: number },
 ): FootprintModel[] {
   const models: FootprintModel[] = []
 
@@ -39,12 +39,12 @@ export function create3DModelsFromCadComponent(
   }
 
   if (cadComponent.rotation) {
-    const footprintRotationDegrees = options?.footprintRotationDegrees ?? 0
+    const footprintRotation = options?.footprintRotation ?? 0
 
     model.rotate = {
       x: cadComponent.rotation.x || 0,
       y: cadComponent.rotation.y || 0,
-      z: (cadComponent.rotation.z || 0) - footprintRotationDegrees,
+      z: (cadComponent.rotation.z || 0) - footprintRotation,
     }
   }
 

--- a/tests/assets/usb-repro.json
+++ b/tests/assets/usb-repro.json
@@ -16,11 +16,7 @@
     "source_port_id": "source_port_0",
     "name": "EH1",
     "pin_number": 13,
-    "port_hints": [
-      "EH1",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["EH1", "pin13", "13"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -29,11 +25,7 @@
     "source_port_id": "source_port_1",
     "name": "EH2",
     "pin_number": 14,
-    "port_hints": [
-      "EH2",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["EH2", "pin14", "14"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -42,11 +34,7 @@
     "source_port_id": "source_port_2",
     "name": "pin13_alt1",
     "pin_number": 15,
-    "port_hints": [
-      "pin13_alt1",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["pin13_alt1", "pin15", "15"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -55,11 +43,7 @@
     "source_port_id": "source_port_3",
     "name": "pin14_alt1",
     "pin_number": 16,
-    "port_hints": [
-      "pin14_alt1",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["pin14_alt1", "pin16", "16"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -68,11 +52,7 @@
     "source_port_id": "source_port_4",
     "name": "A1B12",
     "pin_number": 17,
-    "port_hints": [
-      "A1B12",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["A1B12", "pin17", "17"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -81,11 +61,7 @@
     "source_port_id": "source_port_5",
     "name": "A4B9",
     "pin_number": 18,
-    "port_hints": [
-      "A4B9",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["A4B9", "pin18", "18"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -94,11 +70,7 @@
     "source_port_id": "source_port_6",
     "name": "B8",
     "pin_number": 19,
-    "port_hints": [
-      "B8",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["B8", "pin19", "19"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -107,11 +79,7 @@
     "source_port_id": "source_port_7",
     "name": "A5",
     "pin_number": 20,
-    "port_hints": [
-      "A5",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["A5", "pin20", "20"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -120,11 +88,7 @@
     "source_port_id": "source_port_8",
     "name": "B7",
     "pin_number": 21,
-    "port_hints": [
-      "B7",
-      "pin21",
-      "21"
-    ],
+    "port_hints": ["B7", "pin21", "21"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -133,11 +97,7 @@
     "source_port_id": "source_port_9",
     "name": "A6",
     "pin_number": 22,
-    "port_hints": [
-      "A6",
-      "pin22",
-      "22"
-    ],
+    "port_hints": ["A6", "pin22", "22"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -146,11 +106,7 @@
     "source_port_id": "source_port_10",
     "name": "A7",
     "pin_number": 23,
-    "port_hints": [
-      "A7",
-      "pin23",
-      "23"
-    ],
+    "port_hints": ["A7", "pin23", "23"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -159,11 +115,7 @@
     "source_port_id": "source_port_11",
     "name": "B6",
     "pin_number": 24,
-    "port_hints": [
-      "B6",
-      "pin24",
-      "24"
-    ],
+    "port_hints": ["B6", "pin24", "24"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -172,11 +124,7 @@
     "source_port_id": "source_port_12",
     "name": "A8",
     "pin_number": 25,
-    "port_hints": [
-      "A8",
-      "pin25",
-      "25"
-    ],
+    "port_hints": ["A8", "pin25", "25"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -185,11 +133,7 @@
     "source_port_id": "source_port_13",
     "name": "B5",
     "pin_number": 26,
-    "port_hints": [
-      "B5",
-      "pin26",
-      "26"
-    ],
+    "port_hints": ["B5", "pin26", "26"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -198,11 +142,7 @@
     "source_port_id": "source_port_14",
     "name": "B4A9",
     "pin_number": 27,
-    "port_hints": [
-      "B4A9",
-      "pin27",
-      "27"
-    ],
+    "port_hints": ["B4A9", "pin27", "27"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -211,11 +151,7 @@
     "source_port_id": "source_port_15",
     "name": "B1A12",
     "pin_number": 28,
-    "port_hints": [
-      "B1A12",
-      "pin28",
-      "28"
-    ],
+    "port_hints": ["B1A12", "pin28", "28"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -224,10 +160,7 @@
     "source_port_id": "source_port_16",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -236,10 +169,7 @@
     "source_port_id": "source_port_17",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -248,10 +178,7 @@
     "source_port_id": "source_port_18",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -260,10 +187,7 @@
     "source_port_id": "source_port_19",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -272,10 +196,7 @@
     "source_port_id": "source_port_20",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -284,10 +205,7 @@
     "source_port_id": "source_port_21",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -296,10 +214,7 @@
     "source_port_id": "source_port_22",
     "name": "pin7",
     "pin_number": 7,
-    "port_hints": [
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["pin7", "7"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -308,10 +223,7 @@
     "source_port_id": "source_port_23",
     "name": "pin8",
     "pin_number": 8,
-    "port_hints": [
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin8", "8"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -320,10 +232,7 @@
     "source_port_id": "source_port_24",
     "name": "pin9",
     "pin_number": 9,
-    "port_hints": [
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["pin9", "9"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -332,10 +241,7 @@
     "source_port_id": "source_port_25",
     "name": "pin10",
     "pin_number": 10,
-    "port_hints": [
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin10", "10"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -344,10 +250,7 @@
     "source_port_id": "source_port_26",
     "name": "pin11",
     "pin_number": 11,
-    "port_hints": [
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["pin11", "11"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -356,10 +259,7 @@
     "source_port_id": "source_port_27",
     "name": "pin12",
     "pin_number": 12,
-    "port_hints": [
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["pin12", "12"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -370,9 +270,7 @@
     "name": "J1",
     "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2765186"
-      ]
+      "jlcpcb": ["C2765186"]
     },
     "source_group_id": "source_group_0"
   },
@@ -381,11 +279,7 @@
     "source_port_id": "source_port_28",
     "name": "EH1",
     "pin_number": 13,
-    "port_hints": [
-      "EH1",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["EH1", "pin13", "13"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -394,11 +288,7 @@
     "source_port_id": "source_port_29",
     "name": "EH2",
     "pin_number": 14,
-    "port_hints": [
-      "EH2",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["EH2", "pin14", "14"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -407,11 +297,7 @@
     "source_port_id": "source_port_30",
     "name": "pin13_alt1",
     "pin_number": 15,
-    "port_hints": [
-      "pin13_alt1",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["pin13_alt1", "pin15", "15"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -420,11 +306,7 @@
     "source_port_id": "source_port_31",
     "name": "pin14_alt1",
     "pin_number": 16,
-    "port_hints": [
-      "pin14_alt1",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["pin14_alt1", "pin16", "16"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -433,11 +315,7 @@
     "source_port_id": "source_port_32",
     "name": "A1B12",
     "pin_number": 17,
-    "port_hints": [
-      "A1B12",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["A1B12", "pin17", "17"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -446,11 +324,7 @@
     "source_port_id": "source_port_33",
     "name": "A4B9",
     "pin_number": 18,
-    "port_hints": [
-      "A4B9",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["A4B9", "pin18", "18"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -459,11 +333,7 @@
     "source_port_id": "source_port_34",
     "name": "B8",
     "pin_number": 19,
-    "port_hints": [
-      "B8",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["B8", "pin19", "19"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -472,11 +342,7 @@
     "source_port_id": "source_port_35",
     "name": "A5",
     "pin_number": 20,
-    "port_hints": [
-      "A5",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["A5", "pin20", "20"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -485,11 +351,7 @@
     "source_port_id": "source_port_36",
     "name": "B7",
     "pin_number": 21,
-    "port_hints": [
-      "B7",
-      "pin21",
-      "21"
-    ],
+    "port_hints": ["B7", "pin21", "21"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -498,11 +360,7 @@
     "source_port_id": "source_port_37",
     "name": "A6",
     "pin_number": 22,
-    "port_hints": [
-      "A6",
-      "pin22",
-      "22"
-    ],
+    "port_hints": ["A6", "pin22", "22"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -511,11 +369,7 @@
     "source_port_id": "source_port_38",
     "name": "A7",
     "pin_number": 23,
-    "port_hints": [
-      "A7",
-      "pin23",
-      "23"
-    ],
+    "port_hints": ["A7", "pin23", "23"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -524,11 +378,7 @@
     "source_port_id": "source_port_39",
     "name": "B6",
     "pin_number": 24,
-    "port_hints": [
-      "B6",
-      "pin24",
-      "24"
-    ],
+    "port_hints": ["B6", "pin24", "24"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -537,11 +387,7 @@
     "source_port_id": "source_port_40",
     "name": "A8",
     "pin_number": 25,
-    "port_hints": [
-      "A8",
-      "pin25",
-      "25"
-    ],
+    "port_hints": ["A8", "pin25", "25"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -550,11 +396,7 @@
     "source_port_id": "source_port_41",
     "name": "B5",
     "pin_number": 26,
-    "port_hints": [
-      "B5",
-      "pin26",
-      "26"
-    ],
+    "port_hints": ["B5", "pin26", "26"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -563,11 +405,7 @@
     "source_port_id": "source_port_42",
     "name": "B4A9",
     "pin_number": 27,
-    "port_hints": [
-      "B4A9",
-      "pin27",
-      "27"
-    ],
+    "port_hints": ["B4A9", "pin27", "27"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -576,11 +414,7 @@
     "source_port_id": "source_port_43",
     "name": "B1A12",
     "pin_number": 28,
-    "port_hints": [
-      "B1A12",
-      "pin28",
-      "28"
-    ],
+    "port_hints": ["B1A12", "pin28", "28"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -589,10 +423,7 @@
     "source_port_id": "source_port_44",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -601,10 +432,7 @@
     "source_port_id": "source_port_45",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -613,10 +441,7 @@
     "source_port_id": "source_port_46",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -625,10 +450,7 @@
     "source_port_id": "source_port_47",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -637,10 +459,7 @@
     "source_port_id": "source_port_48",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -649,10 +468,7 @@
     "source_port_id": "source_port_49",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -661,10 +477,7 @@
     "source_port_id": "source_port_50",
     "name": "pin7",
     "pin_number": 7,
-    "port_hints": [
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["pin7", "7"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -673,10 +486,7 @@
     "source_port_id": "source_port_51",
     "name": "pin8",
     "pin_number": 8,
-    "port_hints": [
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin8", "8"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -685,10 +495,7 @@
     "source_port_id": "source_port_52",
     "name": "pin9",
     "pin_number": 9,
-    "port_hints": [
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["pin9", "9"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -697,10 +504,7 @@
     "source_port_id": "source_port_53",
     "name": "pin10",
     "pin_number": 10,
-    "port_hints": [
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin10", "10"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -709,10 +513,7 @@
     "source_port_id": "source_port_54",
     "name": "pin11",
     "pin_number": 11,
-    "port_hints": [
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["pin11", "11"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -721,10 +522,7 @@
     "source_port_id": "source_port_55",
     "name": "pin12",
     "pin_number": 12,
-    "port_hints": [
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["pin12", "12"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -735,9 +533,7 @@
     "name": "J2",
     "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2765186"
-      ]
+      "jlcpcb": ["C2765186"]
     },
     "source_group_id": "source_group_0"
   },
@@ -746,11 +542,7 @@
     "source_port_id": "source_port_56",
     "name": "EH1",
     "pin_number": 13,
-    "port_hints": [
-      "EH1",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["EH1", "pin13", "13"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -759,11 +551,7 @@
     "source_port_id": "source_port_57",
     "name": "EH2",
     "pin_number": 14,
-    "port_hints": [
-      "EH2",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["EH2", "pin14", "14"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -772,11 +560,7 @@
     "source_port_id": "source_port_58",
     "name": "pin13_alt1",
     "pin_number": 15,
-    "port_hints": [
-      "pin13_alt1",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["pin13_alt1", "pin15", "15"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -785,11 +569,7 @@
     "source_port_id": "source_port_59",
     "name": "pin14_alt1",
     "pin_number": 16,
-    "port_hints": [
-      "pin14_alt1",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["pin14_alt1", "pin16", "16"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -798,11 +578,7 @@
     "source_port_id": "source_port_60",
     "name": "A1B12",
     "pin_number": 17,
-    "port_hints": [
-      "A1B12",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["A1B12", "pin17", "17"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -811,11 +587,7 @@
     "source_port_id": "source_port_61",
     "name": "A4B9",
     "pin_number": 18,
-    "port_hints": [
-      "A4B9",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["A4B9", "pin18", "18"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -824,11 +596,7 @@
     "source_port_id": "source_port_62",
     "name": "B8",
     "pin_number": 19,
-    "port_hints": [
-      "B8",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["B8", "pin19", "19"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -837,11 +605,7 @@
     "source_port_id": "source_port_63",
     "name": "A5",
     "pin_number": 20,
-    "port_hints": [
-      "A5",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["A5", "pin20", "20"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -850,11 +614,7 @@
     "source_port_id": "source_port_64",
     "name": "B7",
     "pin_number": 21,
-    "port_hints": [
-      "B7",
-      "pin21",
-      "21"
-    ],
+    "port_hints": ["B7", "pin21", "21"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -863,11 +623,7 @@
     "source_port_id": "source_port_65",
     "name": "A6",
     "pin_number": 22,
-    "port_hints": [
-      "A6",
-      "pin22",
-      "22"
-    ],
+    "port_hints": ["A6", "pin22", "22"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -876,11 +632,7 @@
     "source_port_id": "source_port_66",
     "name": "A7",
     "pin_number": 23,
-    "port_hints": [
-      "A7",
-      "pin23",
-      "23"
-    ],
+    "port_hints": ["A7", "pin23", "23"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -889,11 +641,7 @@
     "source_port_id": "source_port_67",
     "name": "B6",
     "pin_number": 24,
-    "port_hints": [
-      "B6",
-      "pin24",
-      "24"
-    ],
+    "port_hints": ["B6", "pin24", "24"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -902,11 +650,7 @@
     "source_port_id": "source_port_68",
     "name": "A8",
     "pin_number": 25,
-    "port_hints": [
-      "A8",
-      "pin25",
-      "25"
-    ],
+    "port_hints": ["A8", "pin25", "25"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -915,11 +659,7 @@
     "source_port_id": "source_port_69",
     "name": "B5",
     "pin_number": 26,
-    "port_hints": [
-      "B5",
-      "pin26",
-      "26"
-    ],
+    "port_hints": ["B5", "pin26", "26"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -928,11 +668,7 @@
     "source_port_id": "source_port_70",
     "name": "B4A9",
     "pin_number": 27,
-    "port_hints": [
-      "B4A9",
-      "pin27",
-      "27"
-    ],
+    "port_hints": ["B4A9", "pin27", "27"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -941,11 +677,7 @@
     "source_port_id": "source_port_71",
     "name": "B1A12",
     "pin_number": 28,
-    "port_hints": [
-      "B1A12",
-      "pin28",
-      "28"
-    ],
+    "port_hints": ["B1A12", "pin28", "28"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -954,10 +686,7 @@
     "source_port_id": "source_port_72",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -966,10 +695,7 @@
     "source_port_id": "source_port_73",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -978,10 +704,7 @@
     "source_port_id": "source_port_74",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -990,10 +713,7 @@
     "source_port_id": "source_port_75",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1002,10 +722,7 @@
     "source_port_id": "source_port_76",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1014,10 +731,7 @@
     "source_port_id": "source_port_77",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1026,10 +740,7 @@
     "source_port_id": "source_port_78",
     "name": "pin7",
     "pin_number": 7,
-    "port_hints": [
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["pin7", "7"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1038,10 +749,7 @@
     "source_port_id": "source_port_79",
     "name": "pin8",
     "pin_number": 8,
-    "port_hints": [
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin8", "8"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1050,10 +758,7 @@
     "source_port_id": "source_port_80",
     "name": "pin9",
     "pin_number": 9,
-    "port_hints": [
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["pin9", "9"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1062,10 +767,7 @@
     "source_port_id": "source_port_81",
     "name": "pin10",
     "pin_number": 10,
-    "port_hints": [
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin10", "10"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1074,10 +776,7 @@
     "source_port_id": "source_port_82",
     "name": "pin11",
     "pin_number": 11,
-    "port_hints": [
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["pin11", "11"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1086,10 +785,7 @@
     "source_port_id": "source_port_83",
     "name": "pin12",
     "pin_number": 12,
-    "port_hints": [
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["pin12", "12"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1100,9 +796,7 @@
     "name": "J3",
     "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2765186"
-      ]
+      "jlcpcb": ["C2765186"]
     },
     "source_group_id": "source_group_0"
   },
@@ -1111,11 +805,7 @@
     "source_port_id": "source_port_84",
     "name": "EH1",
     "pin_number": 13,
-    "port_hints": [
-      "EH1",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["EH1", "pin13", "13"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1124,11 +814,7 @@
     "source_port_id": "source_port_85",
     "name": "EH2",
     "pin_number": 14,
-    "port_hints": [
-      "EH2",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["EH2", "pin14", "14"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1137,11 +823,7 @@
     "source_port_id": "source_port_86",
     "name": "pin13_alt1",
     "pin_number": 15,
-    "port_hints": [
-      "pin13_alt1",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["pin13_alt1", "pin15", "15"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1150,11 +832,7 @@
     "source_port_id": "source_port_87",
     "name": "pin14_alt1",
     "pin_number": 16,
-    "port_hints": [
-      "pin14_alt1",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["pin14_alt1", "pin16", "16"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1163,11 +841,7 @@
     "source_port_id": "source_port_88",
     "name": "A1B12",
     "pin_number": 17,
-    "port_hints": [
-      "A1B12",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["A1B12", "pin17", "17"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1176,11 +850,7 @@
     "source_port_id": "source_port_89",
     "name": "A4B9",
     "pin_number": 18,
-    "port_hints": [
-      "A4B9",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["A4B9", "pin18", "18"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1189,11 +859,7 @@
     "source_port_id": "source_port_90",
     "name": "B8",
     "pin_number": 19,
-    "port_hints": [
-      "B8",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["B8", "pin19", "19"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1202,11 +868,7 @@
     "source_port_id": "source_port_91",
     "name": "A5",
     "pin_number": 20,
-    "port_hints": [
-      "A5",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["A5", "pin20", "20"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1215,11 +877,7 @@
     "source_port_id": "source_port_92",
     "name": "B7",
     "pin_number": 21,
-    "port_hints": [
-      "B7",
-      "pin21",
-      "21"
-    ],
+    "port_hints": ["B7", "pin21", "21"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1228,11 +886,7 @@
     "source_port_id": "source_port_93",
     "name": "A6",
     "pin_number": 22,
-    "port_hints": [
-      "A6",
-      "pin22",
-      "22"
-    ],
+    "port_hints": ["A6", "pin22", "22"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1241,11 +895,7 @@
     "source_port_id": "source_port_94",
     "name": "A7",
     "pin_number": 23,
-    "port_hints": [
-      "A7",
-      "pin23",
-      "23"
-    ],
+    "port_hints": ["A7", "pin23", "23"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1254,11 +904,7 @@
     "source_port_id": "source_port_95",
     "name": "B6",
     "pin_number": 24,
-    "port_hints": [
-      "B6",
-      "pin24",
-      "24"
-    ],
+    "port_hints": ["B6", "pin24", "24"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1267,11 +913,7 @@
     "source_port_id": "source_port_96",
     "name": "A8",
     "pin_number": 25,
-    "port_hints": [
-      "A8",
-      "pin25",
-      "25"
-    ],
+    "port_hints": ["A8", "pin25", "25"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1280,11 +922,7 @@
     "source_port_id": "source_port_97",
     "name": "B5",
     "pin_number": 26,
-    "port_hints": [
-      "B5",
-      "pin26",
-      "26"
-    ],
+    "port_hints": ["B5", "pin26", "26"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1293,11 +931,7 @@
     "source_port_id": "source_port_98",
     "name": "B4A9",
     "pin_number": 27,
-    "port_hints": [
-      "B4A9",
-      "pin27",
-      "27"
-    ],
+    "port_hints": ["B4A9", "pin27", "27"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1306,11 +940,7 @@
     "source_port_id": "source_port_99",
     "name": "B1A12",
     "pin_number": 28,
-    "port_hints": [
-      "B1A12",
-      "pin28",
-      "28"
-    ],
+    "port_hints": ["B1A12", "pin28", "28"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1319,10 +949,7 @@
     "source_port_id": "source_port_100",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1331,10 +958,7 @@
     "source_port_id": "source_port_101",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1343,10 +967,7 @@
     "source_port_id": "source_port_102",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1355,10 +976,7 @@
     "source_port_id": "source_port_103",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1367,10 +985,7 @@
     "source_port_id": "source_port_104",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1379,10 +994,7 @@
     "source_port_id": "source_port_105",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1391,10 +1003,7 @@
     "source_port_id": "source_port_106",
     "name": "pin7",
     "pin_number": 7,
-    "port_hints": [
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["pin7", "7"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1403,10 +1012,7 @@
     "source_port_id": "source_port_107",
     "name": "pin8",
     "pin_number": 8,
-    "port_hints": [
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin8", "8"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1415,10 +1021,7 @@
     "source_port_id": "source_port_108",
     "name": "pin9",
     "pin_number": 9,
-    "port_hints": [
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["pin9", "9"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1427,10 +1030,7 @@
     "source_port_id": "source_port_109",
     "name": "pin10",
     "pin_number": 10,
-    "port_hints": [
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin10", "10"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1439,10 +1039,7 @@
     "source_port_id": "source_port_110",
     "name": "pin11",
     "pin_number": 11,
-    "port_hints": [
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["pin11", "11"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1451,10 +1048,7 @@
     "source_port_id": "source_port_111",
     "name": "pin12",
     "pin_number": 12,
-    "port_hints": [
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["pin12", "12"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1465,9 +1059,7 @@
     "name": "J4",
     "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2765186"
-      ]
+      "jlcpcb": ["C2765186"]
     },
     "source_group_id": "source_group_0"
   },
@@ -2918,16 +2510,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole1",
-      "pin13"
-    ],
+    "port_hints": ["unnamed_platedhole1", "pin13"],
     "x": -8.42488245,
     "y": 4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 270
@@ -2964,16 +2550,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole2",
-      "pin14"
-    ],
+    "port_hints": ["unnamed_platedhole2", "pin14"],
     "x": -8.42488245,
     "y": -4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 270
@@ -3010,16 +2590,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole3",
-      "pin15"
-    ],
+    "port_hints": ["unnamed_platedhole3", "pin15"],
     "x": -12.62502645,
     "y": 4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 270
@@ -3056,16 +2630,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole4",
-      "pin16"
-    ],
+    "port_hints": ["unnamed_platedhole4", "pin16"],
     "x": -12.62502645,
     "y": -4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 270
@@ -3101,9 +2669,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 3.200019,
@@ -3131,9 +2697,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 2.399919,
@@ -3161,9 +2725,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 1.7499330000000002,
@@ -3191,9 +2753,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 1.2498070000000001,
@@ -3221,9 +2781,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin21"
-    ],
+    "port_hints": ["pin21"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 0.7499350000000001,
@@ -3251,9 +2809,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin22"
-    ],
+    "port_hints": ["pin22"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": 0.2500630000000001,
@@ -3281,9 +2837,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin23"
-    ],
+    "port_hints": ["pin23"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -0.25006299999999987,
@@ -3311,9 +2865,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin24"
-    ],
+    "port_hints": ["pin24"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -0.7499349999999999,
@@ -3341,9 +2893,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin25"
-    ],
+    "port_hints": ["pin25"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -1.2500609999999999,
@@ -3371,9 +2921,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin26"
-    ],
+    "port_hints": ["pin26"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -1.7501869999999997,
@@ -3401,9 +2949,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin27"
-    ],
+    "port_hints": ["pin27"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -2.400173,
@@ -3431,9 +2977,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin28"
-    ],
+    "port_hints": ["pin28"],
     "is_covered_with_solder_mask": false,
     "x": -7.87497245,
     "y": -3.200019,
@@ -3619,16 +3163,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole5",
-      "pin13"
-    ],
+    "port_hints": ["unnamed_platedhole5", "pin13"],
     "x": 8.42488245,
     "y": -4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 90
@@ -3665,16 +3203,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole6",
-      "pin14"
-    ],
+    "port_hints": ["unnamed_platedhole6", "pin14"],
     "x": 8.42488245,
     "y": 4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 90
@@ -3711,16 +3243,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole7",
-      "pin15"
-    ],
+    "port_hints": ["unnamed_platedhole7", "pin15"],
     "x": 12.62502645,
     "y": -4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 90
@@ -3757,16 +3283,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole8",
-      "pin16"
-    ],
+    "port_hints": ["unnamed_platedhole8", "pin16"],
     "x": 12.62502645,
     "y": 4.324985,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 90
@@ -3802,9 +3322,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -3.200019,
@@ -3832,9 +3350,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -2.399919,
@@ -3862,9 +3378,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -1.7499329999999997,
@@ -3892,9 +3406,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -1.2498069999999997,
@@ -3922,9 +3434,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin21"
-    ],
+    "port_hints": ["pin21"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -0.7499349999999999,
@@ -3952,9 +3462,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin22"
-    ],
+    "port_hints": ["pin22"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": -0.25006299999999987,
@@ -3982,9 +3490,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin23"
-    ],
+    "port_hints": ["pin23"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 0.2500630000000001,
@@ -4012,9 +3518,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin24"
-    ],
+    "port_hints": ["pin24"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 0.7499350000000001,
@@ -4042,9 +3546,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin25"
-    ],
+    "port_hints": ["pin25"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 1.2500610000000003,
@@ -4072,9 +3574,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.2999994,
-    "port_hints": [
-      "pin26"
-    ],
+    "port_hints": ["pin26"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 1.7501870000000002,
@@ -4102,9 +3602,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin27"
-    ],
+    "port_hints": ["pin27"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 2.400173,
@@ -4132,9 +3630,7 @@
     "shape": "rect",
     "width": 1.0999978,
     "height": 0.5500116,
-    "port_hints": [
-      "pin28"
-    ],
+    "port_hints": ["pin28"],
     "is_covered_with_solder_mask": false,
     "x": 7.87497245,
     "y": 3.200019,
@@ -4320,16 +3816,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole9",
-      "pin13"
-    ],
+    "port_hints": ["unnamed_platedhole9", "pin13"],
     "x": -4.324985,
     "y": -8.42488245,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -4366,16 +3856,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole10",
-      "pin14"
-    ],
+    "port_hints": ["unnamed_platedhole10", "pin14"],
     "x": 4.324985,
     "y": -8.42488245,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -4412,16 +3896,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole11",
-      "pin15"
-    ],
+    "port_hints": ["unnamed_platedhole11", "pin15"],
     "x": -4.324985,
     "y": -12.62502645,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -4458,16 +3936,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole12",
-      "pin16"
-    ],
+    "port_hints": ["unnamed_platedhole12", "pin16"],
     "x": 4.324985,
     "y": -12.62502645,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -4503,9 +3975,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": -3.200019,
     "y": -7.87497245,
@@ -4533,9 +4003,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": -2.399919,
     "y": -7.87497245,
@@ -4563,9 +4031,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": -1.749933,
     "y": -7.87497245,
@@ -4593,9 +4059,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": -1.249807,
     "y": -7.87497245,
@@ -4623,9 +4087,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin21"
-    ],
+    "port_hints": ["pin21"],
     "is_covered_with_solder_mask": false,
     "x": -0.749935,
     "y": -7.87497245,
@@ -4653,9 +4115,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin22"
-    ],
+    "port_hints": ["pin22"],
     "is_covered_with_solder_mask": false,
     "x": -0.250063,
     "y": -7.87497245,
@@ -4683,9 +4143,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin23"
-    ],
+    "port_hints": ["pin23"],
     "is_covered_with_solder_mask": false,
     "x": 0.250063,
     "y": -7.87497245,
@@ -4713,9 +4171,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin24"
-    ],
+    "port_hints": ["pin24"],
     "is_covered_with_solder_mask": false,
     "x": 0.749935,
     "y": -7.87497245,
@@ -4743,9 +4199,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin25"
-    ],
+    "port_hints": ["pin25"],
     "is_covered_with_solder_mask": false,
     "x": 1.250061,
     "y": -7.87497245,
@@ -4773,9 +4227,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin26"
-    ],
+    "port_hints": ["pin26"],
     "is_covered_with_solder_mask": false,
     "x": 1.750187,
     "y": -7.87497245,
@@ -4803,9 +4255,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin27"
-    ],
+    "port_hints": ["pin27"],
     "is_covered_with_solder_mask": false,
     "x": 2.400173,
     "y": -7.87497245,
@@ -4833,9 +4283,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin28"
-    ],
+    "port_hints": ["pin28"],
     "is_covered_with_solder_mask": false,
     "x": 3.200019,
     "y": -7.87497245,
@@ -5021,16 +4469,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole13",
-      "pin13"
-    ],
+    "port_hints": ["unnamed_platedhole13", "pin13"],
     "x": 4.324985,
     "y": 8.42488245,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 180
@@ -5067,16 +4509,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.499997,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole14",
-      "pin14"
-    ],
+    "port_hints": ["unnamed_platedhole14", "pin14"],
     "x": -4.324985,
     "y": 8.42488245,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 180
@@ -5113,16 +4549,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole15",
-      "pin15"
-    ],
+    "port_hints": ["unnamed_platedhole15", "pin15"],
     "x": 4.324985,
     "y": 12.62502645,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 180
@@ -5159,16 +4589,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.1999976,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole16",
-      "pin16"
-    ],
+    "port_hints": ["unnamed_platedhole16", "pin16"],
     "x": -4.324985,
     "y": 12.62502645,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 180
@@ -5204,9 +4628,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": 3.2000190000000006,
     "y": 7.8749724500000005,
@@ -5234,9 +4656,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": 2.3999190000000006,
     "y": 7.8749724500000005,
@@ -5264,9 +4684,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": 1.7499330000000002,
     "y": 7.87497245,
@@ -5294,9 +4712,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": 1.2498070000000001,
     "y": 7.87497245,
@@ -5324,9 +4740,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin21"
-    ],
+    "port_hints": ["pin21"],
     "is_covered_with_solder_mask": false,
     "x": 0.7499350000000002,
     "y": 7.87497245,
@@ -5354,9 +4768,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin22"
-    ],
+    "port_hints": ["pin22"],
     "is_covered_with_solder_mask": false,
     "x": 0.25006300000000026,
     "y": 7.87497245,
@@ -5384,9 +4796,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin23"
-    ],
+    "port_hints": ["pin23"],
     "is_covered_with_solder_mask": false,
     "x": -0.2500629999999997,
     "y": 7.87497245,
@@ -5414,9 +4824,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin24"
-    ],
+    "port_hints": ["pin24"],
     "is_covered_with_solder_mask": false,
     "x": -0.7499349999999998,
     "y": 7.87497245,
@@ -5444,9 +4852,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin25"
-    ],
+    "port_hints": ["pin25"],
     "is_covered_with_solder_mask": false,
     "x": -1.2500609999999999,
     "y": 7.87497245,
@@ -5474,9 +4880,7 @@
     "shape": "rect",
     "width": 0.2999994,
     "height": 1.0999978,
-    "port_hints": [
-      "pin26"
-    ],
+    "port_hints": ["pin26"],
     "is_covered_with_solder_mask": false,
     "x": -1.7501869999999997,
     "y": 7.87497245,
@@ -5504,9 +4908,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin27"
-    ],
+    "port_hints": ["pin27"],
     "is_covered_with_solder_mask": false,
     "x": -2.4001729999999997,
     "y": 7.87497245,
@@ -5534,9 +4936,7 @@
     "shape": "rect",
     "width": 0.5500116,
     "height": 1.0999978,
-    "port_hints": [
-      "pin28"
-    ],
+    "port_hints": ["pin28"],
     "is_covered_with_solder_mask": false,
     "x": -3.2000189999999997,
     "y": 7.87497245,
@@ -5694,12 +5094,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_0",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.42488245,
     "y": 4.324985,
@@ -5709,12 +5104,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_1",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.42488245,
     "y": -4.324985,
@@ -5724,12 +5114,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_2",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.62502645,
     "y": 4.324985,
@@ -5739,12 +5124,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_3",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.62502645,
     "y": -4.324985,
@@ -5754,9 +5134,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_4",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 3.200019,
@@ -5766,9 +5144,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_5",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 2.399919,
@@ -5778,9 +5154,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_6",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 1.7499330000000002,
@@ -5790,9 +5164,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_7",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 1.2498070000000001,
@@ -5802,9 +5174,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_8",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 0.7499350000000001,
@@ -5814,9 +5184,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_9",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": 0.2500630000000001,
@@ -5826,9 +5194,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_10",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -0.25006299999999987,
@@ -5838,9 +5204,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_11",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -0.7499349999999999,
@@ -5850,9 +5214,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_12",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -1.2500609999999999,
@@ -5862,9 +5224,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_13",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -1.7501869999999997,
@@ -5874,9 +5234,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_14",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -2.400173,
@@ -5886,9 +5244,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_15",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.87497245,
     "y": -3.200019,
@@ -5898,12 +5254,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_16",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 8.42488245,
     "y": -4.324985,
@@ -5913,12 +5264,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_17",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 8.42488245,
     "y": 4.324985,
@@ -5928,12 +5274,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_18",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 12.62502645,
     "y": -4.324985,
@@ -5943,12 +5284,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_19",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 12.62502645,
     "y": 4.324985,
@@ -5958,9 +5294,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_20",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -3.200019,
@@ -5970,9 +5304,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_21",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -2.399919,
@@ -5982,9 +5314,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_22",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -1.7499329999999997,
@@ -5994,9 +5324,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_23",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -1.2498069999999997,
@@ -6006,9 +5334,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_24",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -0.7499349999999999,
@@ -6018,9 +5344,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_25",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": -0.25006299999999987,
@@ -6030,9 +5354,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_26",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 0.2500630000000001,
@@ -6042,9 +5364,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_27",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 0.7499350000000001,
@@ -6054,9 +5374,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_28",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 1.2500610000000003,
@@ -6066,9 +5384,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_29",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 1.7501870000000002,
@@ -6078,9 +5394,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_30",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 2.400173,
@@ -6090,9 +5404,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_31",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 7.87497245,
     "y": 3.200019,
@@ -6102,12 +5414,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_32",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.324985,
     "y": -8.42488245,
@@ -6117,12 +5424,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_33",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.324985,
     "y": -8.42488245,
@@ -6132,12 +5434,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_34",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.324985,
     "y": -12.62502645,
@@ -6147,12 +5444,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_35",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.324985,
     "y": -12.62502645,
@@ -6162,9 +5454,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_36",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.200019,
     "y": -7.87497245,
@@ -6174,9 +5464,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_37",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -2.399919,
     "y": -7.87497245,
@@ -6186,9 +5474,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_38",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -1.749933,
     "y": -7.87497245,
@@ -6198,9 +5484,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_39",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -1.249807,
     "y": -7.87497245,
@@ -6210,9 +5494,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_40",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.749935,
     "y": -7.87497245,
@@ -6222,9 +5504,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_41",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.250063,
     "y": -7.87497245,
@@ -6234,9 +5514,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_42",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.250063,
     "y": -7.87497245,
@@ -6246,9 +5524,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_43",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.749935,
     "y": -7.87497245,
@@ -6258,9 +5534,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_44",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.250061,
     "y": -7.87497245,
@@ -6270,9 +5544,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_45",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.750187,
     "y": -7.87497245,
@@ -6282,9 +5554,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_46",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 2.400173,
     "y": -7.87497245,
@@ -6294,9 +5564,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_47",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 3.200019,
     "y": -7.87497245,
@@ -6306,12 +5574,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_48",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.324985,
     "y": 8.42488245,
@@ -6321,12 +5584,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_49",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.324985,
     "y": 8.42488245,
@@ -6336,12 +5594,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_50",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.324985,
     "y": 12.62502645,
@@ -6351,12 +5604,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_51",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.324985,
     "y": 12.62502645,
@@ -6366,9 +5614,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_52",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 3.2000190000000006,
     "y": 7.8749724500000005,
@@ -6378,9 +5624,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_53",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 2.3999190000000006,
     "y": 7.8749724500000005,
@@ -6390,9 +5634,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_54",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.7499330000000002,
     "y": 7.87497245,
@@ -6402,9 +5644,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_55",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.2498070000000001,
     "y": 7.87497245,
@@ -6414,9 +5654,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_56",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.7499350000000002,
     "y": 7.87497245,
@@ -6426,9 +5664,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_57",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.25006300000000026,
     "y": 7.87497245,
@@ -6438,9 +5674,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_58",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.2500629999999997,
     "y": 7.87497245,
@@ -6450,9 +5684,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_59",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.7499349999999998,
     "y": 7.87497245,
@@ -6462,9 +5694,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_60",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -1.2500609999999999,
     "y": 7.87497245,
@@ -6474,9 +5704,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_61",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -1.7501869999999997,
     "y": 7.87497245,
@@ -6486,9 +5714,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_62",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -2.4001729999999997,
     "y": 7.87497245,
@@ -6498,9 +5724,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_63",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.2000189999999997,
     "y": 7.87497245,

--- a/tests/assets/usb-repro.json
+++ b/tests/assets/usb-repro.json
@@ -1,0 +1,7065 @@
+[
+  {
+    "type": "source_project_metadata",
+    "source_project_metadata_id": "source_project_metadata_0",
+    "software_used_string": "@tscircuit/core@0.0.1258"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "is_subcircuit": true,
+    "was_automatically_named": true,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "EH1",
+    "pin_number": 13,
+    "port_hints": [
+      "EH1",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "EH2",
+    "pin_number": 14,
+    "port_hints": [
+      "EH2",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "pin13_alt1",
+    "pin_number": 15,
+    "port_hints": [
+      "pin13_alt1",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "pin14_alt1",
+    "pin_number": 16,
+    "port_hints": [
+      "pin14_alt1",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "A1B12",
+    "pin_number": 17,
+    "port_hints": [
+      "A1B12",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "A4B9",
+    "pin_number": 18,
+    "port_hints": [
+      "A4B9",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "B8",
+    "pin_number": 19,
+    "port_hints": [
+      "B8",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "A5",
+    "pin_number": 20,
+    "port_hints": [
+      "A5",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "B7",
+    "pin_number": 21,
+    "port_hints": [
+      "B7",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "A6",
+    "pin_number": 22,
+    "port_hints": [
+      "A6",
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "A7",
+    "pin_number": 23,
+    "port_hints": [
+      "A7",
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "B6",
+    "pin_number": 24,
+    "port_hints": [
+      "B6",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "A8",
+    "pin_number": 25,
+    "port_hints": [
+      "A8",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "B5",
+    "pin_number": 26,
+    "port_hints": [
+      "B5",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "B4A9",
+    "pin_number": 27,
+    "port_hints": [
+      "B4A9",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "B1A12",
+    "pin_number": 28,
+    "port_hints": [
+      "B1A12",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "pin7",
+    "pin_number": 7,
+    "port_hints": [
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "pin9",
+    "pin_number": 9,
+    "port_hints": [
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "pin10",
+    "pin_number": 10,
+    "port_hints": [
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "J1",
+    "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2765186"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "EH1",
+    "pin_number": 13,
+    "port_hints": [
+      "EH1",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "EH2",
+    "pin_number": 14,
+    "port_hints": [
+      "EH2",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "pin13_alt1",
+    "pin_number": 15,
+    "port_hints": [
+      "pin13_alt1",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "pin14_alt1",
+    "pin_number": 16,
+    "port_hints": [
+      "pin14_alt1",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "A1B12",
+    "pin_number": 17,
+    "port_hints": [
+      "A1B12",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "A4B9",
+    "pin_number": 18,
+    "port_hints": [
+      "A4B9",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "B8",
+    "pin_number": 19,
+    "port_hints": [
+      "B8",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "A5",
+    "pin_number": 20,
+    "port_hints": [
+      "A5",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "B7",
+    "pin_number": 21,
+    "port_hints": [
+      "B7",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "A6",
+    "pin_number": 22,
+    "port_hints": [
+      "A6",
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "A7",
+    "pin_number": 23,
+    "port_hints": [
+      "A7",
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "B6",
+    "pin_number": 24,
+    "port_hints": [
+      "B6",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "A8",
+    "pin_number": 25,
+    "port_hints": [
+      "A8",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "B5",
+    "pin_number": 26,
+    "port_hints": [
+      "B5",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "B4A9",
+    "pin_number": 27,
+    "port_hints": [
+      "B4A9",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "B1A12",
+    "pin_number": 28,
+    "port_hints": [
+      "B1A12",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "pin7",
+    "pin_number": 7,
+    "port_hints": [
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "pin9",
+    "pin_number": 9,
+    "port_hints": [
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "pin10",
+    "pin_number": 10,
+    "port_hints": [
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_chip",
+    "name": "J2",
+    "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2765186"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "EH1",
+    "pin_number": 13,
+    "port_hints": [
+      "EH1",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "EH2",
+    "pin_number": 14,
+    "port_hints": [
+      "EH2",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "pin13_alt1",
+    "pin_number": 15,
+    "port_hints": [
+      "pin13_alt1",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin14_alt1",
+    "pin_number": 16,
+    "port_hints": [
+      "pin14_alt1",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "A1B12",
+    "pin_number": 17,
+    "port_hints": [
+      "A1B12",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "A4B9",
+    "pin_number": 18,
+    "port_hints": [
+      "A4B9",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "B8",
+    "pin_number": 19,
+    "port_hints": [
+      "B8",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "A5",
+    "pin_number": 20,
+    "port_hints": [
+      "A5",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "B7",
+    "pin_number": 21,
+    "port_hints": [
+      "B7",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "A6",
+    "pin_number": 22,
+    "port_hints": [
+      "A6",
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "A7",
+    "pin_number": 23,
+    "port_hints": [
+      "A7",
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "B6",
+    "pin_number": 24,
+    "port_hints": [
+      "B6",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "A8",
+    "pin_number": 25,
+    "port_hints": [
+      "A8",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "B5",
+    "pin_number": 26,
+    "port_hints": [
+      "B5",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "B4A9",
+    "pin_number": 27,
+    "port_hints": [
+      "B4A9",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "B1A12",
+    "pin_number": 28,
+    "port_hints": [
+      "B1A12",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "pin7",
+    "pin_number": 7,
+    "port_hints": [
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "pin9",
+    "pin_number": 9,
+    "port_hints": [
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "pin10",
+    "pin_number": 10,
+    "port_hints": [
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_chip",
+    "name": "J3",
+    "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2765186"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "EH1",
+    "pin_number": 13,
+    "port_hints": [
+      "EH1",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "EH2",
+    "pin_number": 14,
+    "port_hints": [
+      "EH2",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "pin13_alt1",
+    "pin_number": 15,
+    "port_hints": [
+      "pin13_alt1",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "pin14_alt1",
+    "pin_number": 16,
+    "port_hints": [
+      "pin14_alt1",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "A1B12",
+    "pin_number": 17,
+    "port_hints": [
+      "A1B12",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "A4B9",
+    "pin_number": 18,
+    "port_hints": [
+      "A4B9",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "B8",
+    "pin_number": 19,
+    "port_hints": [
+      "B8",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "A5",
+    "pin_number": 20,
+    "port_hints": [
+      "A5",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "B7",
+    "pin_number": 21,
+    "port_hints": [
+      "B7",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "A6",
+    "pin_number": 22,
+    "port_hints": [
+      "A6",
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_94",
+    "name": "A7",
+    "pin_number": 23,
+    "port_hints": [
+      "A7",
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_95",
+    "name": "B6",
+    "pin_number": 24,
+    "port_hints": [
+      "B6",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_96",
+    "name": "A8",
+    "pin_number": 25,
+    "port_hints": [
+      "A8",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_97",
+    "name": "B5",
+    "pin_number": 26,
+    "port_hints": [
+      "B5",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_98",
+    "name": "B4A9",
+    "pin_number": 27,
+    "port_hints": [
+      "B4A9",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_99",
+    "name": "B1A12",
+    "pin_number": 28,
+    "port_hints": [
+      "B1A12",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_100",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_101",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_102",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_103",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_104",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_105",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_106",
+    "name": "pin7",
+    "pin_number": 7,
+    "port_hints": [
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_107",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_108",
+    "name": "pin9",
+    "pin_number": 9,
+    "port_hints": [
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_109",
+    "name": "pin10",
+    "pin_number": 10,
+    "port_hints": [
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_110",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_111",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_chip",
+    "name": "J4",
+    "manufacturer_part_number": "TYPE_C_16PIN_2MD_073_",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2765186"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_board",
+    "source_board_id": "source_board_0",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin13": "EH1",
+      "pin14": "EH2",
+      "pin15": "pin13_alt1",
+      "pin16": "pin14_alt1",
+      "pin17": "A1B12",
+      "pin18": "A4B9",
+      "pin19": "B8",
+      "pin20": "A5",
+      "pin21": "B7",
+      "pin22": "A6",
+      "pin23": "A7",
+      "pin24": "B6",
+      "pin25": "A8",
+      "pin26": "B5",
+      "pin27": "B4A9",
+      "pin28": "B1A12"
+    },
+    "source_component_id": "source_component_0",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "TYPE_C_16PIN_2MD_073_",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -1.0299999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "J1",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": 1.0299999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 0,
+      "y": -3.8
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin13": "EH1",
+      "pin14": "EH2",
+      "pin15": "pin13_alt1",
+      "pin16": "pin14_alt1",
+      "pin17": "A1B12",
+      "pin18": "A4B9",
+      "pin19": "B8",
+      "pin20": "A5",
+      "pin21": "B7",
+      "pin22": "A6",
+      "pin23": "A7",
+      "pin24": "B6",
+      "pin25": "A8",
+      "pin26": "B5",
+      "pin27": "B4A9",
+      "pin28": "B1A12"
+    },
+    "source_component_id": "source_component_1",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "TYPE_C_16PIN_2MD_073_",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -4.83
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "J2",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -2.77
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 0,
+      "y": -7.6
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin13": "EH1",
+      "pin14": "EH2",
+      "pin15": "pin13_alt1",
+      "pin16": "pin14_alt1",
+      "pin17": "A1B12",
+      "pin18": "A4B9",
+      "pin19": "B8",
+      "pin20": "A5",
+      "pin21": "B7",
+      "pin22": "A6",
+      "pin23": "A7",
+      "pin24": "B6",
+      "pin25": "A8",
+      "pin26": "B5",
+      "pin27": "B4A9",
+      "pin28": "B1A12"
+    },
+    "source_component_id": "source_component_2",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "text": "TYPE_C_16PIN_2MD_073_",
+    "schematic_component_id": "schematic_component_2",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -8.629999999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "text": "J3",
+    "schematic_component_id": "schematic_component_2",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -6.57
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 0,
+      "y": -11.399999999999999
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin13": "EH1",
+      "pin14": "EH2",
+      "pin15": "pin13_alt1",
+      "pin16": "pin14_alt1",
+      "pin17": "A1B12",
+      "pin18": "A4B9",
+      "pin19": "B8",
+      "pin20": "A5",
+      "pin21": "B7",
+      "pin22": "A6",
+      "pin23": "A7",
+      "pin24": "B6",
+      "pin25": "A8",
+      "pin26": "B5",
+      "pin27": "B4A9",
+      "pin28": "B1A12"
+    },
+    "source_component_id": "source_component_3",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "text": "TYPE_C_16PIN_2MD_073_",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -12.429999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "text": "J4",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -10.37
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "name": "unnamed_board1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.10000000000000009
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "EH1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.30000000000000004
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "EH2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.5
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "pin13_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.7
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "pin14_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.7
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.49999999999999994
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.29999999999999993
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.09999999999999987
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.10000000000000009
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.30000000000000004
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.5
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.49999999999999994
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.29999999999999993
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.09999999999999987
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -3.6999999999999997
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "EH1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "EH2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -3.3
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "pin13_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -3.0999999999999996
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "pin14_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -3.0999999999999996
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -3.3
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -3.7
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -3.9
+    },
+    "source_port_id": "source_port_48",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -4.1
+    },
+    "source_port_id": "source_port_49",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -4.3
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -4.3
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -4.1
+    },
+    "source_port_id": "source_port_54",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 1,
+      "y": -3.8999999999999995
+    },
+    "source_port_id": "source_port_55",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "EH1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -7.3
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "EH2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -7.1
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "pin13_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -6.8999999999999995
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "pin14_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -6.8999999999999995
+    },
+    "source_port_id": "source_port_72",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -7.1
+    },
+    "source_port_id": "source_port_73",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -7.3
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -7.699999999999999
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -7.8999999999999995
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_78",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -1,
+      "y": -8.299999999999999
+    },
+    "source_port_id": "source_port_79",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -8.299999999999999
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -7.8999999999999995
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 1,
+      "y": -7.699999999999999
+    },
+    "source_port_id": "source_port_83",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -11.299999999999999
+    },
+    "source_port_id": "source_port_84",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "EH1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -11.099999999999998
+    },
+    "source_port_id": "source_port_85",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "EH2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -10.899999999999999
+    },
+    "source_port_id": "source_port_86",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "pin13_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -10.7
+    },
+    "source_port_id": "source_port_87",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "pin14_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -10.7
+    },
+    "source_port_id": "source_port_100",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -10.899999999999999
+    },
+    "source_port_id": "source_port_101",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -11.099999999999998
+    },
+    "source_port_id": "source_port_102",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -11.299999999999999
+    },
+    "source_port_id": "source_port_103",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -11.499999999999998
+    },
+    "source_port_id": "source_port_104",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -11.7
+    },
+    "source_port_id": "source_port_105",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -11.899999999999999
+    },
+    "source_port_id": "source_port_106",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -1,
+      "y": -12.099999999999998
+    },
+    "source_port_id": "source_port_107",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -12.099999999999998
+    },
+    "source_port_id": "source_port_108",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -11.899999999999999
+    },
+    "source_port_id": "source_port_109",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -11.7
+    },
+    "source_port_id": "source_port_110",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 1,
+      "y": -11.499999999999998
+    },
+    "source_port_id": "source_port_111",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": -10.41249595,
+      "y": 0
+    },
+    "width": 5.6250586,
+    "height": 10.649966,
+    "layer": "top",
+    "rotation": -90,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -10,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": 10.41249595,
+      "y": 0
+    },
+    "width": 5.6250586,
+    "height": 10.649966,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 10,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": 0,
+      "y": -10.4249991
+    },
+    "width": 9.8499676,
+    "height": 6.200051100000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 0,
+    "display_offset_y": -10
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": 0,
+      "y": 10.4249991
+    },
+    "width": 9.8499676,
+    "height": 6.200051100000001,
+    "layer": "top",
+    "rotation": -180,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 0,
+    "display_offset_y": 10
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "source_board_id": "source_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "thickness": 1.4,
+    "num_layers": 2,
+    "width": 30,
+    "height": 30,
+    "material": "fr4",
+    "min_trace_width": 0.1,
+    "min_via_hole_diameter": 0.2,
+    "min_via_pad_diameter": 0.3,
+    "min_via_hole_edge_to_via_hole_edge_clearance": 0.1,
+    "min_trace_to_pad_edge_clearance": 0.1,
+    "min_pad_edge_to_pad_edge_clearance": 0.1,
+    "min_plated_hole_drill_edge_to_drill_edge_clearance": 0.15,
+    "min_board_edge_clearance": 0.2
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": -8.94507445,
+    "y": 2.889885,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": -8.94507445,
+    "y": -2.890139,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole1",
+      "pin13"
+    ],
+    "x": -8.42488245,
+    "y": 4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -8.42488245,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -8.42488245,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole2",
+      "pin14"
+    ],
+    "x": -8.42488245,
+    "y": -4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -8.42488245,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -8.42488245,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole3",
+      "pin15"
+    ],
+    "x": -12.62502645,
+    "y": 4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -12.62502645,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -12.62502645,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole4",
+      "pin16"
+    ],
+    "x": -12.62502645,
+    "y": -4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 270
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -12.62502645,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -12.62502645,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 3.200019,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": -7.87497245,
+    "y": 3.200019,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 2.399919,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": -7.87497245,
+    "y": 2.399919,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 1.7499330000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": 1.7499330000000002,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 1.2498070000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": 1.2498070000000001,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 0.7499350000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": 0.7499350000000001,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": 0.2500630000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": 0.2500630000000001,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -0.25006299999999987,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": -0.25006299999999987,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -0.7499349999999999,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": -0.7499349999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -1.2500609999999999,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": -1.2500609999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -1.7501869999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": -7.87497245,
+    "y": -1.7501869999999997,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -2.400173,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": -7.87497245,
+    "y": -2.400173,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.87497245,
+    "y": -3.200019,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": -7.87497245,
+    "y": -3.200019,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -11.646948650000013,
+        "y": -4.5720761999999695
+      },
+      {
+        "x": -9.652997850000133,
+        "y": -4.5720761999999695
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -15.075974050000013,
+        "y": -4.5720761999999695
+      },
+      {
+        "x": -13.603002650000008,
+        "y": -4.5720761999999695
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -11.643824450000125,
+        "y": 4.499914800000056
+      },
+      {
+        "x": -9.656096649999995,
+        "y": 4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -15.224970450000114,
+        "y": 4.499914800000056
+      },
+      {
+        "x": -13.60612685000001,
+        "y": 4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -15.224970450000114,
+        "y": -4.5000671999999895
+      },
+      {
+        "x": -15.224970450000114,
+        "y": 4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -6.31617245,
+      "y": 0.0067310000000002255
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J1",
+    "ccw_rotation": -90,
+    "pcb_component_id": "pcb_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -7.066172450000067,
+        "y": 5.184331000000043
+      },
+      {
+        "x": -7.066172450000067,
+        "y": -5.170869000000039
+      },
+      {
+        "x": -15.490972450000072,
+        "y": -5.170869000000039
+      },
+      {
+        "x": -15.490972450000072,
+        "y": 5.184331000000043
+      },
+      {
+        "x": -7.066172450000067,
+        "y": 5.184331000000043
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_2",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": 8.94507445,
+    "y": -2.889885,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_3",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": 8.94507445,
+    "y": 2.890139,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_4",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_16",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole5",
+      "pin13"
+    ],
+    "x": 8.42488245,
+    "y": -4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 90
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 8.42488245,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 8.42488245,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_5",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_17",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole6",
+      "pin14"
+    ],
+    "x": 8.42488245,
+    "y": 4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 90
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 8.42488245,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 8.42488245,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_6",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_18",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole7",
+      "pin15"
+    ],
+    "x": 12.62502645,
+    "y": -4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 90
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 12.62502645,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 12.62502645,
+    "y": -4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_7",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_19",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole8",
+      "pin16"
+    ],
+    "x": 12.62502645,
+    "y": 4.324985,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 90
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 12.62502645,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 12.62502645,
+    "y": 4.324985,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -3.200019,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": 7.87497245,
+    "y": -3.200019,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -2.399919,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": 7.87497245,
+    "y": -2.399919,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -1.7499329999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": -1.7499329999999997,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -1.2498069999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": -1.2498069999999997,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -0.7499349999999999,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": -0.7499349999999999,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": -0.25006299999999987,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": -0.25006299999999987,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 0.2500630000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": 0.2500630000000001,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 0.7499350000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": 0.7499350000000001,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 1.2500610000000003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": 1.2500610000000003,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.2999994,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 1.7501870000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.20999958000000002,
+    "x": 7.87497245,
+    "y": 1.7501870000000002,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 2.400173,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": 7.87497245,
+    "y": 2.400173,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.0999978,
+    "height": 0.5500116,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.87497245,
+    "y": 3.200019,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7699984599999999,
+    "height": 0.38500812,
+    "x": 7.87497245,
+    "y": 3.200019,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": 11.646948650000013,
+        "y": 4.5720761999999695
+      },
+      {
+        "x": 9.652997850000133,
+        "y": 4.5720761999999695
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.075974050000013,
+        "y": 4.5720761999999695
+      },
+      {
+        "x": 13.603002650000008,
+        "y": 4.5720761999999695
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": 11.643824450000125,
+        "y": -4.499914800000056
+      },
+      {
+        "x": 9.656096649999995,
+        "y": -4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.224970450000114,
+        "y": -4.499914800000056
+      },
+      {
+        "x": 13.60612685000001,
+        "y": -4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.224970450000114,
+        "y": 4.5000671999999895
+      },
+      {
+        "x": 15.224970450000114,
+        "y": -4.499914800000056
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 6.31617245,
+      "y": -0.0067309999999997745
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J2",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_1",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 7.066172450000067,
+        "y": -5.184331000000043
+      },
+      {
+        "x": 7.066172450000067,
+        "y": 5.170869000000039
+      },
+      {
+        "x": 15.490972450000072,
+        "y": 5.170869000000039
+      },
+      {
+        "x": 15.490972450000072,
+        "y": -5.184331000000043
+      },
+      {
+        "x": 7.066172450000067,
+        "y": -5.184331000000043
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_4",
+    "pcb_component_id": "pcb_component_2",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": -2.889885,
+    "y": -8.94507445,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_5",
+    "pcb_component_id": "pcb_component_2",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": 2.890139,
+    "y": -8.94507445,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_8",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_32",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole9",
+      "pin13"
+    ],
+    "x": -4.324985,
+    "y": -8.42488245,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -4.324985,
+    "y": -8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -4.324985,
+    "y": -8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_9",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_33",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole10",
+      "pin14"
+    ],
+    "x": 4.324985,
+    "y": -8.42488245,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 4.324985,
+    "y": -8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 4.324985,
+    "y": -8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_10",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_34",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole11",
+      "pin15"
+    ],
+    "x": -4.324985,
+    "y": -12.62502645,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.324985,
+    "y": -12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.324985,
+    "y": -12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_11",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_35",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole12",
+      "pin16"
+    ],
+    "x": 4.324985,
+    "y": -12.62502645,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_46",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.324985,
+    "y": -12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_47",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.324985,
+    "y": -12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.200019,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_48",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -3.200019,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.399919,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_49",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -2.399919,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.749933,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_50",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -1.749933,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.249807,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_51",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -1.249807,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.749935,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -0.749935,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.250063,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -0.250063,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.250063,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 0.250063,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.749935,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 0.749935,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.250061,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 1.250061,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.750187,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 1.750187,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.400173,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": 2.400173,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_47",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.200019,
+    "y": -7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": 3.200019,
+    "y": -7.87497245,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_10",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.5720761999999695,
+        "y": -11.646948650000013
+      },
+      {
+        "x": 4.5720761999999695,
+        "y": -9.652997850000133
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_11",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.5720761999999695,
+        "y": -15.075974050000013
+      },
+      {
+        "x": 4.5720761999999695,
+        "y": -13.603002650000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_12",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.499914800000056,
+        "y": -11.643824450000125
+      },
+      {
+        "x": -4.499914800000056,
+        "y": -9.656096649999995
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_13",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.499914800000056,
+        "y": -15.224970450000114
+      },
+      {
+        "x": -4.499914800000056,
+        "y": -13.60612685000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_14",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.5000671999999895,
+        "y": -15.224970450000114
+      },
+      {
+        "x": -4.499914800000056,
+        "y": -15.224970450000114
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -0.006731,
+      "y": -6.31617245
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_2",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -5.184331000000043,
+        "y": -7.066172450000067
+      },
+      {
+        "x": 5.170869000000039,
+        "y": -7.066172450000067
+      },
+      {
+        "x": 5.170869000000039,
+        "y": -15.490972450000072
+      },
+      {
+        "x": -5.184331000000043,
+        "y": -15.490972450000072
+      },
+      {
+        "x": -5.184331000000043,
+        "y": -7.066172450000067
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_6",
+    "pcb_component_id": "pcb_component_3",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": 2.889885,
+    "y": 8.94507445,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_7",
+    "pcb_component_id": "pcb_component_3",
+    "hole_shape": "circle",
+    "hole_diameter": 0.700024,
+    "x": -2.890139,
+    "y": 8.94507445,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_12",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_48",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole13",
+      "pin13"
+    ],
+    "x": 4.324985,
+    "y": 8.42488245,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 180
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_60",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 4.324985,
+    "y": 8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_61",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": 4.324985,
+    "y": 8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_13",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_49",
+    "outer_width": 1.0999978,
+    "outer_height": 1.999996,
+    "hole_width": 0.5999988,
+    "hole_height": 1.499997,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole14",
+      "pin14"
+    ],
+    "x": -4.324985,
+    "y": 8.42488245,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 180
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_62",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -4.324985,
+    "y": 8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_63",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.999996,
+    "x": -4.324985,
+    "y": 8.42488245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_14",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_50",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole15",
+      "pin15"
+    ],
+    "x": 4.324985,
+    "y": 12.62502645,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 180
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_64",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.324985,
+    "y": 12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_65",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.324985,
+    "y": 12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_15",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_51",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.5999988,
+    "hole_height": 1.1999976,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole16",
+      "pin16"
+    ],
+    "x": -4.324985,
+    "y": 12.62502645,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 180
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_66",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.324985,
+    "y": 12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_67",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.324985,
+    "y": 12.62502645,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.2000190000000006,
+    "y": 7.8749724500000005,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_68",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": 3.2000190000000006,
+    "y": 7.8749724500000005,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.3999190000000006,
+    "y": 7.8749724500000005,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_69",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": 2.3999190000000006,
+    "y": 7.8749724500000005,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.7499330000000002,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_70",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 1.7499330000000002,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.2498070000000001,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_71",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 1.2498070000000001,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.7499350000000002,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_72",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 0.7499350000000002,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.25006300000000026,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_73",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": 0.25006300000000026,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.2500629999999997,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_74",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -0.2500629999999997,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.7499349999999998,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_75",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -0.7499349999999998,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_60",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.2500609999999999,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -1.2500609999999999,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_61",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.7501869999999997,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.7699984599999999,
+    "x": -1.7501869999999997,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.4001729999999997,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -2.4001729999999997,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5500116,
+    "height": 1.0999978,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.2000189999999997,
+    "y": 7.87497245,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.38500812,
+    "height": 0.7699984599999999,
+    "x": -3.2000189999999997,
+    "y": 7.87497245,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_15",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.5720761999999695,
+        "y": 11.646948650000013
+      },
+      {
+        "x": -4.5720761999999695,
+        "y": 9.652997850000133
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_16",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.57207619999997,
+        "y": 15.075974050000013
+      },
+      {
+        "x": -4.5720761999999695,
+        "y": 13.603002650000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_17",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.499914800000056,
+        "y": 11.643824450000125
+      },
+      {
+        "x": 4.499914800000056,
+        "y": 9.656096649999995
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_18",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.499914800000055,
+        "y": 15.224970450000114
+      },
+      {
+        "x": 4.499914800000056,
+        "y": 13.60612685000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_19",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.50006719999999,
+        "y": 15.224970450000114
+      },
+      {
+        "x": 4.499914800000055,
+        "y": 15.224970450000114
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.006731000000000451,
+      "y": 6.31617245
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J4",
+    "ccw_rotation": -180,
+    "pcb_component_id": "pcb_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_3",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 5.184331000000043,
+        "y": 7.066172450000067
+      },
+      {
+        "x": -5.170869000000039,
+        "y": 7.066172450000067
+      },
+      {
+        "x": -5.17086900000004,
+        "y": 15.490972450000072
+      },
+      {
+        "x": 5.184331000000042,
+        "y": 15.490972450000072
+      },
+      {
+        "x": 5.184331000000043,
+        "y": 7.066172450000067
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.42488245,
+    "y": 4.324985,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.42488245,
+    "y": -4.324985,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.62502645,
+    "y": 4.324985,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.62502645,
+    "y": -4.324985,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 3.200019,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 2.399919,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 1.7499330000000002,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 1.2498070000000001,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 0.7499350000000001,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": 0.2500630000000001,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -0.25006299999999987,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -0.7499349999999999,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -1.2500609999999999,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -1.7501869999999997,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -2.400173,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.87497245,
+    "y": -3.200019,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.42488245,
+    "y": -4.324985,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.42488245,
+    "y": 4.324985,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.62502645,
+    "y": -4.324985,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.62502645,
+    "y": 4.324985,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -3.200019,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -2.399919,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -1.7499329999999997,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -1.2498069999999997,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -0.7499349999999999,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": -0.25006299999999987,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 0.2500630000000001,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 0.7499350000000001,
+    "source_port_id": "source_port_39"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 1.2500610000000003,
+    "source_port_id": "source_port_40"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 1.7501870000000002,
+    "source_port_id": "source_port_41"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 2.400173,
+    "source_port_id": "source_port_42"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.87497245,
+    "y": 3.200019,
+    "source_port_id": "source_port_43"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.324985,
+    "y": -8.42488245,
+    "source_port_id": "source_port_56"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.324985,
+    "y": -8.42488245,
+    "source_port_id": "source_port_57"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.324985,
+    "y": -12.62502645,
+    "source_port_id": "source_port_58"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.324985,
+    "y": -12.62502645,
+    "source_port_id": "source_port_59"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.200019,
+    "y": -7.87497245,
+    "source_port_id": "source_port_60"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.399919,
+    "y": -7.87497245,
+    "source_port_id": "source_port_61"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.749933,
+    "y": -7.87497245,
+    "source_port_id": "source_port_62"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_39",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.249807,
+    "y": -7.87497245,
+    "source_port_id": "source_port_63"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_40",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.749935,
+    "y": -7.87497245,
+    "source_port_id": "source_port_64"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_41",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.250063,
+    "y": -7.87497245,
+    "source_port_id": "source_port_65"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_42",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.250063,
+    "y": -7.87497245,
+    "source_port_id": "source_port_66"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_43",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.749935,
+    "y": -7.87497245,
+    "source_port_id": "source_port_67"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_44",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.250061,
+    "y": -7.87497245,
+    "source_port_id": "source_port_68"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_45",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.750187,
+    "y": -7.87497245,
+    "source_port_id": "source_port_69"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_46",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.400173,
+    "y": -7.87497245,
+    "source_port_id": "source_port_70"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_47",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.200019,
+    "y": -7.87497245,
+    "source_port_id": "source_port_71"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_48",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.324985,
+    "y": 8.42488245,
+    "source_port_id": "source_port_84"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_49",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.324985,
+    "y": 8.42488245,
+    "source_port_id": "source_port_85"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_50",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.324985,
+    "y": 12.62502645,
+    "source_port_id": "source_port_86"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_51",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.324985,
+    "y": 12.62502645,
+    "source_port_id": "source_port_87"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_52",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.2000190000000006,
+    "y": 7.8749724500000005,
+    "source_port_id": "source_port_88"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_53",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.3999190000000006,
+    "y": 7.8749724500000005,
+    "source_port_id": "source_port_89"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_54",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.7499330000000002,
+    "y": 7.87497245,
+    "source_port_id": "source_port_90"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_55",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.2498070000000001,
+    "y": 7.87497245,
+    "source_port_id": "source_port_91"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_56",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.7499350000000002,
+    "y": 7.87497245,
+    "source_port_id": "source_port_92"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_57",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.25006300000000026,
+    "y": 7.87497245,
+    "source_port_id": "source_port_93"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_58",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.2500629999999997,
+    "y": 7.87497245,
+    "source_port_id": "source_port_94"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_59",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.7499349999999998,
+    "y": 7.87497245,
+    "source_port_id": "source_port_95"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_60",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.2500609999999999,
+    "y": 7.87497245,
+    "source_port_id": "source_port_96"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_61",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.7501869999999997,
+    "y": 7.87497245,
+    "source_port_id": "source_port_97"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_62",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.4001729999999997,
+    "y": 7.87497245,
+    "source_port_id": "source_port_98"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_63",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.2000189999999997,
+    "y": 7.87497245,
+    "source_port_id": "source_port_99"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": -10.41249595,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 270
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.obj?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.step?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012699999956566899,
+      "y": 1.5749970500000927,
+      "z": -1.6800018
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": 10.41249595,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.obj?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.step?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012699999956566899,
+      "y": 1.5749970500000927,
+      "z": -1.6800018
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": 0,
+      "y": -10.4249991,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.obj?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.step?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012699999956566899,
+      "y": 1.5749970500000927,
+      "z": -1.6800018
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": 0,
+      "y": 10.4249991,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.obj?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2765186.step?uuid=4ee8413127e64716b804db03d4b340ae&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012699999956566899,
+      "y": 1.5749970500000927,
+      "z": -1.6800018
+    }
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_0",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_1",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J2 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_2",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J3 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_3",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J4 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_0",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J1 has no pin with requires_power=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_1",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J2 has no pin with requires_power=true",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_2",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J3 has no pin with requires_power=true",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_3",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J4 has no pin with requires_power=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_0",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_1",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J2 has no pin with requires_ground=true",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_2",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J3 has no pin with requires_ground=true",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_3",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J4 has no pin with requires_ground=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  }
+]

--- a/tests/pcb/3d-models.test.ts
+++ b/tests/pcb/3d-models.test.ts
@@ -23,7 +23,7 @@ test("footprint includes 3D model from cad_component", () => {
       center: { x: 0, y: 0 },
       width: 5,
       height: 5,
-      rotation: 0,
+      rotation: -90,
       layer: "top",
     },
     {
@@ -32,7 +32,8 @@ test("footprint includes 3D model from cad_component", () => {
       pcb_component_id: "pcb_component_0",
       source_component_id: "source_component_0",
       position: { x: 0, y: 0, z: 1.0 },
-      rotation: { x: 0, y: 0, z: 90 },
+      rotation: { x: 0, y: 0, z: 270 },
+      model_origin_position: { x: -0.25, y: 1.5, z: -0.5 },
       model_step_url: "${KIPRJMOD}/3dmodels/chip.step",
     },
     {
@@ -57,5 +58,12 @@ test("footprint includes 3D model from cad_component", () => {
   expect(output).toContain("(model")
   expect(output).toContain("chip.step")
   expect(output).toContain("(offset")
+  expect(output).toContain(`(offset
+        (xyz 0.25 -1.5 1.5)
+      )`)
   expect(output).toContain("(rotate")
+  expect(output).toContain("(at 100 100 -90)")
+  expect(output).toContain(`(rotate
+        (xyz 0 0 360)
+      )`)
 })

--- a/tests/pcb/repros/repro19-usb-c-rotated-3d-model.test.ts
+++ b/tests/pcb/repros/repro19-usb-c-rotated-3d-model.test.ts
@@ -21,10 +21,4 @@ test("usb-c rotated 3d model placement", async () => {
   expect(output).toContain(`(offset
         (xyz 0.000012699999956566899 -1.5749970500000927 1.6800018)
       )`)
-  expect(output.match(/\(rotate\n        \(xyz 0 0 360\)\n      \)/g)).toHaveLength(
-    2,
-  )
-  expect(output.match(/\(rotate\n        \(xyz 0 0 0\)\n      \)/g)).toHaveLength(
-    2,
-  )
 })

--- a/tests/pcb/repros/repro19-usb-c-rotated-3d-model.test.ts
+++ b/tests/pcb/repros/repro19-usb-c-rotated-3d-model.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import { readFile } from "node:fs/promises"
+import type { AnyCircuitElement } from "circuit-json"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("usb-c rotated 3d model placement", async () => {
+  const circuitJson = JSON.parse(
+    await readFile("tests/assets/usb-repro.json", "utf8"),
+  ) as AnyCircuitElement[]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const output = converter.getOutputString()
+
+  expect(output).toContain("(at 89.58750405 100 -90)")
+  expect(output).toContain("(at 110.41249595 100 90)")
+  expect(output).toContain("(at 100 110.42499910000001 0)")
+  expect(output).toContain("(at 100 89.57500089999999 -180)")
+
+  expect(output).toContain(`(offset
+        (xyz 0.000012699999956566899 -1.5749970500000927 1.6800018)
+      )`)
+  expect(output.match(/\(rotate\n        \(xyz 0 0 360\)\n      \)/g)).toHaveLength(
+    2,
+  )
+  expect(output.match(/\(rotate\n        \(xyz 0 0 0\)\n      \)/g)).toHaveLength(
+    2,
+  )
+})


### PR DESCRIPTION
Fixes 3D model rotation and offset for rotated PCB components in KiCad export.

The model rotation is now relative to the footprint rotation, and model_origin_position is included when calculating the model offset.

Before: 

<img width="748" height="554" alt="image" src="https://github.com/user-attachments/assets/acc66784-722f-4db0-922f-b4d3bca895de" />


After: 

<img width="682" height="567" alt="image" src="https://github.com/user-attachments/assets/e27ae266-8501-4e0a-a763-42dbbd398546" />
