### PR TITLE
fix(sch): snap off-grid wire endpoints to exported KiCad pin anchors

### DIFF
--- a/lib/schematic/stages/AddSchematicSymbolsStage.ts
+++ b/lib/schematic/stages/AddSchematicSymbolsStage.ts
@@ -25,6 +25,8 @@ import {
   getKicadCompatibleComponentName,
 } from "../../utils/getKicadCompatibleComponentName"
 import type { KicadSymbolMetadata } from "@tscircuit/props"
+import { createGenericChipSymbolData } from "./symbols-stage-converters/createGenericChipSymbolData"
+import { calculatePinPosition } from "./utils/calculatePinPosition"
 
 /**
  * Adds schematic symbol instances (placed components) to the schematic
@@ -35,6 +37,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
 > {
   override _step(): void {
     const { kicadSch, db } = this.ctx
+    this.ctx.pinPositions = new Map()
 
     // Get all schematic components
     const schematicComponents = db.schematic_component.list()
@@ -329,6 +332,15 @@ export class AddSchematicSymbolsStage extends ConverterStage<
         (a: any, b: any) => (a.pin_number || 0) - (b.pin_number || 0),
       )
 
+      const symbolData = this.getSymbolDataForComponent(
+        schematicComponent,
+        sourceComponent,
+      )
+      const isChipLike =
+        sourceComponent.ftype === "simple_chip" ||
+        sourceComponent.ftype === "simple_pin_header" ||
+        sourceComponent.ftype === "simple_connector"
+
       for (let i = 0; i < schematicPorts.length; i++) {
         const port = schematicPorts[i]
         if (!port) continue
@@ -337,6 +349,25 @@ export class AddSchematicSymbolsStage extends ConverterStage<
         pin.numberString = `${port.pin_number || i + 1}`
         pin.uuid = crypto.randomUUID()
         symbol.pins.push(pin)
+
+        const symbolPort = symbolData?.ports?.[i]
+        if (symbolPort && this.ctx.pinPositions) {
+          const pinPosition = calculatePinPosition({
+            port: symbolPort,
+            center: symbolData.center,
+            size: symbolData.size,
+            isChip: isChipLike,
+            portIndex: i,
+            schematicComponent,
+            schematicPorts,
+            c2kMatSchScale: this.ctx.kicadSchematicScaleFactor!,
+          })
+
+          this.ctx.pinPositions.set(port.schematic_port_id, {
+            x: x + pinPosition.x,
+            y: y + pinPosition.y,
+          })
+        }
       }
 
       // Add instances section
@@ -357,6 +388,26 @@ export class AddSchematicSymbolsStage extends ConverterStage<
     }
 
     this.finished = true
+  }
+
+  private getSymbolDataForComponent(
+    schematicComponent: SchematicComponent,
+    sourceComponent: any,
+  ) {
+    const symbolName =
+      schematicComponent.symbol_name ||
+      (sourceComponent.ftype === "simple_chip" ||
+      sourceComponent.ftype === "simple_pin_header"
+        ? `generic_chip_${schematicComponent.source_component_id}`
+        : null)
+
+    if (!symbolName) return null
+
+    if (symbolName.startsWith("generic_chip_")) {
+      return createGenericChipSymbolData(schematicComponent, this.ctx.db)
+    }
+
+    return symbols[symbolName as keyof typeof symbols] || null
   }
 
   /**

--- a/lib/schematic/stages/AddSchematicTracesStage.ts
+++ b/lib/schematic/stages/AddSchematicTracesStage.ts
@@ -5,6 +5,7 @@ import { applyToPoint } from "transformation-matrix"
 import { ConverterStage, type ConverterContext } from "../../types"
 
 const DEFAULT_LINE_WIDTH_MM = 0.254
+const PIN_SNAP_TOLERANCE_MM = 0.01
 
 /**
  * Adds schematic traces (wires) and junctions to the schematic
@@ -66,14 +67,8 @@ export class AddSchematicTracesStage extends ConverterStage<
     }
 
     // Transform circuit-json coordinates to KiCad coordinates using c2kMatSch
-    const from = applyToPoint(this.ctx.c2kMatSch, {
-      x: edge.from.x,
-      y: edge.from.y,
-    })
-    const to = applyToPoint(this.ctx.c2kMatSch, {
-      x: edge.to.x,
-      y: edge.to.y,
-    })
+    const from = this.snapTraceEndpointToPinAnchor(edge.from)
+    const to = this.snapTraceEndpointToPinAnchor(edge.to)
 
     const x1 = from.x
     const y1 = from.y
@@ -94,6 +89,64 @@ export class AddSchematicTracesStage extends ConverterStage<
     wire.uuid = crypto.randomUUID()
 
     return wire
+  }
+
+  private snapTraceEndpointToPinAnchor(point: { x: number; y: number }) {
+    if (!this.ctx.c2kMatSch) {
+      throw new Error(
+        "Schematic transformation matrix not initialized in context",
+      )
+    }
+
+    const transformedPoint = applyToPoint(this.ctx.c2kMatSch, point)
+    const pinAnchorMappings = this.getPinAnchorMappings()
+
+    let nearestMapping:
+      | {
+          raw: { x: number; y: number }
+          actual: { x: number; y: number }
+        }
+      | undefined
+    let nearestDistanceSquared = Number.POSITIVE_INFINITY
+
+    for (const mapping of pinAnchorMappings) {
+      const dx = transformedPoint.x - mapping.raw.x
+      const dy = transformedPoint.y - mapping.raw.y
+      const distanceSquared = dx * dx + dy * dy
+
+      if (
+        distanceSquared <= PIN_SNAP_TOLERANCE_MM * PIN_SNAP_TOLERANCE_MM &&
+        distanceSquared < nearestDistanceSquared
+      ) {
+        nearestMapping = mapping
+        nearestDistanceSquared = distanceSquared
+      }
+    }
+
+    return nearestMapping?.actual ?? transformedPoint
+  }
+
+  private getPinAnchorMappings() {
+    const mappings: Array<{
+      raw: { x: number; y: number }
+      actual: { x: number; y: number }
+    }> = []
+
+    for (const schematicPort of this.ctx.db.schematic_port.list()) {
+      const actualPosition = this.ctx.pinPositions?.get(
+        schematicPort.schematic_port_id,
+      )
+      if (!actualPosition) continue
+      mappings.push({
+        raw: applyToPoint(this.ctx.c2kMatSch!, {
+          x: schematicPort.center.x,
+          y: schematicPort.center.y,
+        }),
+        actual: actualPosition,
+      })
+    }
+
+    return mappings
   }
 
   /**

--- a/tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts
+++ b/tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts
@@ -114,7 +114,10 @@ test("repro11 off-grid generic chip traces snap to KiCad pin anchors", () => {
   expect(wirePoints).toBeDefined()
 
   const symbolsByRef = new Map(
-    kicadSch.symbols.map((symbol: any) => [symbol.properties?.[0]?.value, symbol]),
+    kicadSch.symbols.map((symbol: any) => [
+      symbol.properties?.[0]?.value,
+      symbol,
+    ]),
   )
   const u1 = symbolsByRef.get("U1")
   const u2 = symbolsByRef.get("U2")

--- a/tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts
+++ b/tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "bun:test"
+import { KicadSch } from "kicadts"
+import { CircuitJsonToKicadSchConverter } from "lib/schematic/CircuitJsonToKicadSchConverter"
+
+test("repro11 off-grid generic chip traces snap to KiCad pin anchors", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      pin_number: 1,
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp2",
+      source_component_id: "sc1",
+      name: "2",
+      pin_number: 2,
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc2",
+      name: "U2",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp3",
+      source_component_id: "sc2",
+      name: "1",
+      pin_number: 1,
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp4",
+      source_component_id: "sc2",
+      name: "2",
+      pin_number: 2,
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch1",
+      source_component_id: "sc1",
+      center: { x: 0.13, y: 0.17 },
+      rotation: 0,
+      size: { width: 2, height: 1 },
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch2",
+      source_component_id: "sc2",
+      center: { x: 4.31, y: 0.22 },
+      rotation: 0,
+      size: { width: 2, height: 1 },
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "p1",
+      schematic_component_id: "sch1",
+      source_port_id: "sp1",
+      center: { x: -0.77, y: 0.17 },
+      pin_number: 1,
+      display_pin_label: "1",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "p2",
+      schematic_component_id: "sch1",
+      source_port_id: "sp2",
+      center: { x: 1.03, y: 0.17 },
+      pin_number: 2,
+      display_pin_label: "2",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "p3",
+      schematic_component_id: "sch2",
+      source_port_id: "sp3",
+      center: { x: 3.41, y: 0.22 },
+      pin_number: 1,
+      display_pin_label: "1",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "p4",
+      schematic_component_id: "sch2",
+      source_port_id: "sp4",
+      center: { x: 5.21, y: 0.22 },
+      pin_number: 2,
+      display_pin_label: "2",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "t1",
+      edges: [{ from: { x: 1.03, y: 0.17 }, to: { x: 3.41, y: 0.22 } }],
+      junctions: [],
+    },
+  ] as any
+
+  const converter = new CircuitJsonToKicadSchConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const kicadSch = KicadSch.parse(converter.getOutputString())[0] as KicadSch
+  const wirePoints = kicadSch.wires[0]?.points?.points as
+    | Array<{ x: number; y: number }>
+    | undefined
+  expect(wirePoints).toBeDefined()
+
+  const symbolsByRef = new Map(
+    kicadSch.symbols.map((symbol: any) => [symbol.properties?.[0]?.value, symbol]),
+  )
+  const u1 = symbolsByRef.get("U1")
+  const u2 = symbolsByRef.get("U2")
+
+  expect(u1).toBeDefined()
+  expect(u2).toBeDefined()
+
+  expect(wirePoints?.[0]?.x).toBeCloseTo(u1.at.x + 21)
+  expect(wirePoints?.[0]?.y).toBeCloseTo(u1.at.y)
+  expect(wirePoints?.[1]?.x).toBeCloseTo(u2.at.x - 21)
+  expect(wirePoints?.[1]?.y).toBeCloseTo(u2.at.y)
+})


### PR DESCRIPTION
## Summary

Fixes schematic wire-to-pin disconnections for off-grid generic-chip style symbols by snapping exported wire endpoints to the same KiCad pin anchors used during symbol export.

Related issues:
- #283
- #292

## Problem

The schematic exporter previously wrote wire endpoints from the raw transformed `schematic_trace` edge coordinates.

For generic-chip style symbols and similar pin-based symbols, the final exported KiCad pin anchor is not always identical to the raw transformed `schematic_port` position. That means a wire can look visually connected while still failing exact coordinate matching in KiCad.

## Root Cause

Two different geometric sources of truth were used during schematic export:

- symbol export computed the final KiCad pin anchor positions
- trace export used the transformed raw trace endpoints directly

That mismatch is more fundamental than floating-point formatting alone. Even if coordinates are rounded, the wire can still land on the wrong point if the symbol pin anchor itself is offset from the raw source position.

## Fix

This change makes symbol export the source of truth for pin anchor positions:

- `AddSchematicSymbolsStage` now records the final exported KiCad pin anchor position for each `schematic_port`
- `AddSchematicTracesStage` now snaps trace endpoints to those exported anchor positions when the transformed endpoint matches the corresponding raw port location within a small tolerance

So instead of exporting wires from raw transformed trace endpoints, wires are now exported from the actual pin anchors KiCad uses.

## Why This Approach

This is more correct than only rounding coordinates.

Rounding helps with formatting drift.
This fix resolves the semantic mismatch:
- the wire endpoint and the symbol pin now come from the same exported anchor geometry

That makes the fix robust for off-grid placements and pin-anchor shifts, not just tiny floating-point noise.

## Before / After

<table>
  <tr>
    <td width="50%"><strong>Before</strong></td>
    <td width="50%"><strong>After</strong></td>
  </tr>
  <tr>
    <td width="50%">
      <img alt="before" src="https://github.com/user-attachments/assets/121cdfa3-0334-4c4d-a84a-34b93d7409eb" width="100%" />
    </td>
    <td width="50%">
      <img alt="after" src="https://github.com/user-attachments/assets/a440fe2a-5393-495d-9e88-105ca469f583" width="100%" />
    </td>
  </tr>
</table>

Before:
- the wire endpoint is exported from the raw transformed trace/port geometry
- that can leave the endpoint offset from the actual exported KiCad pin anchor

After:
- the wire endpoint is snapped to the same KiCad pin anchor used for symbol export
- wire and pin now share the same final exported geometry

For the minimal repro used here, the endpoint shift is:
- source side: `+7.5mm`
- destination side: `-7.5mm`

## Tests

Added:
- `tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts`

This regression test:
- builds a minimal off-grid generic-chip schematic
- verifies the exported wire lands exactly on the expected KiCad pin anchor positions

Also re-verified:
- `tests/sch/custom-symbol06-port-dedup.test.tsx`

## Verification

Passed locally:
- `bun run typecheck`
- `bun test tests/sch/repros/repro11-offgrid-generic-chip-wire-snapping.test.ts tests/sch/custom-symbol06-port-dedup.test.tsx`

Additional note:
- a broader `tests/sch/repros` run showed several existing KiCad 10.0.3 PNG snapshot mismatches unrelated to this change, so I did not treat those snapshot diffs as blockers for this fix.
