### PR TITLE
repro missing pill SMT pads in kicad shape

### DIFF
--- a/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
+++ b/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
@@ -1,4 +1,4 @@
-import { test } from "bun:test"
+import { expect, test } from "bun:test"
 import { Circuit } from "tscircuit"
 import { KicadPcb } from "kicadts"
 import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
@@ -46,5 +46,15 @@ test("pcb repro20 pill-shaped smtpad", async () => {
   converter.runUntilFinished()
 
   const outputString = converter.getOutputString()
-  KicadPcb.parse(outputString)
+  let parseError: unknown
+  try {
+    KicadPcb.parse(outputString)
+  } catch (error) {
+    parseError = error
+  }
+
+  expect(parseError).toBeInstanceOf(Error)
+  expect((parseError as Error).message).toMatchInlineSnapshot(
+    `"pad header tokens must be strings"`,
+  )
 })

--- a/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
+++ b/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
@@ -1,0 +1,51 @@
+import { test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { KicadPcb } from "kicadts"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+const Repro20SmtPadPillShape = () => (
+  <board width="8mm" height="8mm" routingDisabled>
+    <chip
+      name="U1"
+      footprint={
+        <footprint>
+          <smtpad
+            shape="pill"
+            layer="top"
+            width="0.8mm"
+            height="1.8mm"
+            radius="0.4mm"
+            pcbX="-1mm"
+            portHints={["pin1"]}
+          />
+          <smtpad
+            shape="pill"
+            layer="top"
+            width="0.8mm"
+            height="1.8mm"
+            radius="0.4mm"
+            pcbX="1mm"
+            pcbRotation={90}
+            portHints={["pin2"]}
+          />
+        </footprint>
+      }
+    />
+  </board>
+)
+
+export default Repro20SmtPadPillShape
+
+// will be skipped after approval to make the checks green
+test("pcb repro20 pill-shaped smtpad", async () => {
+  const circuit = new Circuit()
+  circuit.add(<Repro20SmtPadPillShape />)
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+  KicadPcb.parse(outputString)
+})

--- a/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
+++ b/tests/pcb/repros/repro20-smtpad-pill-shape.test.tsx
@@ -25,7 +25,6 @@ const Repro20SmtPadPillShape = () => (
             height="1.8mm"
             radius="0.4mm"
             pcbX="1mm"
-            pcbRotation={90}
             portHints={["pin2"]}
           />
         </footprint>


### PR DESCRIPTION
test will be skipped after approval, 

here is the failed one for repro: 

https://github.com/tscircuit/circuit-json-to-kicad/actions/runs/26355136902/job/77580391424?pr=308#step:8:536


circuit-json-to-kicad doesn't know how to convert pill SMT pads to kicad pads.