### PR TITLE
repro: through_pad routes producing NaN KiCad PCB segments

### DIFF
--- a/tests/assets/alarmv2.json
+++ b/tests/assets/alarmv2.json
@@ -16,11 +16,7 @@
     "source_port_id": "source_port_0",
     "name": "GND1",
     "pin_number": 1,
-    "port_hints": [
-      "GND1",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["GND1", "pin1", "1"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -30,11 +26,7 @@
     "source_port_id": "source_port_1",
     "name": "3V3",
     "pin_number": 2,
-    "port_hints": [
-      "3V3",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["3V3", "pin2", "2"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -44,11 +36,7 @@
     "source_port_id": "source_port_2",
     "name": "EN",
     "pin_number": 3,
-    "port_hints": [
-      "EN",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["EN", "pin3", "3"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -58,11 +46,7 @@
     "source_port_id": "source_port_3",
     "name": "SENSOR_VP",
     "pin_number": 4,
-    "port_hints": [
-      "SENSOR_VP",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["SENSOR_VP", "pin4", "4"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -71,11 +55,7 @@
     "source_port_id": "source_port_4",
     "name": "SENSOR_VN",
     "pin_number": 5,
-    "port_hints": [
-      "SENSOR_VN",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["SENSOR_VN", "pin5", "5"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -84,11 +64,7 @@
     "source_port_id": "source_port_5",
     "name": "IO34",
     "pin_number": 6,
-    "port_hints": [
-      "IO34",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["IO34", "pin6", "6"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
@@ -98,11 +74,7 @@
     "source_port_id": "source_port_6",
     "name": "IO35",
     "pin_number": 7,
-    "port_hints": [
-      "IO35",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["IO35", "pin7", "7"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -111,11 +83,7 @@
     "source_port_id": "source_port_7",
     "name": "IO32",
     "pin_number": 8,
-    "port_hints": [
-      "IO32",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["IO32", "pin8", "8"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
@@ -125,11 +93,7 @@
     "source_port_id": "source_port_8",
     "name": "IO33",
     "pin_number": 9,
-    "port_hints": [
-      "IO33",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["IO33", "pin9", "9"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
@@ -139,11 +103,7 @@
     "source_port_id": "source_port_9",
     "name": "IO25",
     "pin_number": 10,
-    "port_hints": [
-      "IO25",
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["IO25", "pin10", "10"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net15"
@@ -153,11 +113,7 @@
     "source_port_id": "source_port_10",
     "name": "IO26",
     "pin_number": 11,
-    "port_hints": [
-      "IO26",
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["IO26", "pin11", "11"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net8"
@@ -167,11 +123,7 @@
     "source_port_id": "source_port_11",
     "name": "IO27",
     "pin_number": 12,
-    "port_hints": [
-      "IO27",
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["IO27", "pin12", "12"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net10"
@@ -181,11 +133,7 @@
     "source_port_id": "source_port_12",
     "name": "IO14",
     "pin_number": 13,
-    "port_hints": [
-      "IO14",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["IO14", "pin13", "13"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net12"
@@ -195,11 +143,7 @@
     "source_port_id": "source_port_13",
     "name": "IO12",
     "pin_number": 14,
-    "port_hints": [
-      "IO12",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["IO12", "pin14", "14"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -208,11 +152,7 @@
     "source_port_id": "source_port_14",
     "name": "GND2",
     "pin_number": 15,
-    "port_hints": [
-      "GND2",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["GND2", "pin15", "15"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -222,11 +162,7 @@
     "source_port_id": "source_port_15",
     "name": "IO13",
     "pin_number": 16,
-    "port_hints": [
-      "IO13",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["IO13", "pin16", "16"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
@@ -236,11 +172,7 @@
     "source_port_id": "source_port_16",
     "name": "NC1",
     "pin_number": 17,
-    "port_hints": [
-      "NC1",
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["NC1", "pin17", "17"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -249,11 +181,7 @@
     "source_port_id": "source_port_17",
     "name": "NC2",
     "pin_number": 18,
-    "port_hints": [
-      "NC2",
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["NC2", "pin18", "18"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -262,11 +190,7 @@
     "source_port_id": "source_port_18",
     "name": "NC3",
     "pin_number": 19,
-    "port_hints": [
-      "NC3",
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["NC3", "pin19", "19"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -275,11 +199,7 @@
     "source_port_id": "source_port_19",
     "name": "NC4",
     "pin_number": 20,
-    "port_hints": [
-      "NC4",
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["NC4", "pin20", "20"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -288,11 +208,7 @@
     "source_port_id": "source_port_20",
     "name": "NC5",
     "pin_number": 21,
-    "port_hints": [
-      "NC5",
-      "pin21",
-      "21"
-    ],
+    "port_hints": ["NC5", "pin21", "21"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -301,11 +217,7 @@
     "source_port_id": "source_port_21",
     "name": "NC6",
     "pin_number": 22,
-    "port_hints": [
-      "NC6",
-      "pin22",
-      "22"
-    ],
+    "port_hints": ["NC6", "pin22", "22"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -314,11 +226,7 @@
     "source_port_id": "source_port_22",
     "name": "IO15",
     "pin_number": 23,
-    "port_hints": [
-      "IO15",
-      "pin23",
-      "23"
-    ],
+    "port_hints": ["IO15", "pin23", "23"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -327,11 +235,7 @@
     "source_port_id": "source_port_23",
     "name": "IO2",
     "pin_number": 24,
-    "port_hints": [
-      "IO2",
-      "pin24",
-      "24"
-    ],
+    "port_hints": ["IO2", "pin24", "24"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -340,11 +244,7 @@
     "source_port_id": "source_port_24",
     "name": "IO0",
     "pin_number": 25,
-    "port_hints": [
-      "IO0",
-      "pin25",
-      "25"
-    ],
+    "port_hints": ["IO0", "pin25", "25"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -353,11 +253,7 @@
     "source_port_id": "source_port_25",
     "name": "IO4",
     "pin_number": 26,
-    "port_hints": [
-      "IO4",
-      "pin26",
-      "26"
-    ],
+    "port_hints": ["IO4", "pin26", "26"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -366,11 +262,7 @@
     "source_port_id": "source_port_26",
     "name": "IO16",
     "pin_number": 27,
-    "port_hints": [
-      "IO16",
-      "pin27",
-      "27"
-    ],
+    "port_hints": ["IO16", "pin27", "27"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -379,11 +271,7 @@
     "source_port_id": "source_port_27",
     "name": "IO17",
     "pin_number": 28,
-    "port_hints": [
-      "IO17",
-      "pin28",
-      "28"
-    ],
+    "port_hints": ["IO17", "pin28", "28"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -392,11 +280,7 @@
     "source_port_id": "source_port_28",
     "name": "IO5",
     "pin_number": 29,
-    "port_hints": [
-      "IO5",
-      "pin29",
-      "29"
-    ],
+    "port_hints": ["IO5", "pin29", "29"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -405,11 +289,7 @@
     "source_port_id": "source_port_29",
     "name": "IO18",
     "pin_number": 30,
-    "port_hints": [
-      "IO18",
-      "pin30",
-      "30"
-    ],
+    "port_hints": ["IO18", "pin30", "30"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -418,11 +298,7 @@
     "source_port_id": "source_port_30",
     "name": "IO19",
     "pin_number": 31,
-    "port_hints": [
-      "IO19",
-      "pin31",
-      "31"
-    ],
+    "port_hints": ["IO19", "pin31", "31"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -431,11 +307,7 @@
     "source_port_id": "source_port_31",
     "name": "NC7",
     "pin_number": 32,
-    "port_hints": [
-      "NC7",
-      "pin32",
-      "32"
-    ],
+    "port_hints": ["NC7", "pin32", "32"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -444,11 +316,7 @@
     "source_port_id": "source_port_32",
     "name": "IO21",
     "pin_number": 33,
-    "port_hints": [
-      "IO21",
-      "pin33",
-      "33"
-    ],
+    "port_hints": ["IO21", "pin33", "33"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net4"
@@ -458,11 +326,7 @@
     "source_port_id": "source_port_33",
     "name": "RXD0",
     "pin_number": 34,
-    "port_hints": [
-      "RXD0",
-      "pin34",
-      "34"
-    ],
+    "port_hints": ["RXD0", "pin34", "34"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -471,11 +335,7 @@
     "source_port_id": "source_port_34",
     "name": "TXD0",
     "pin_number": 35,
-    "port_hints": [
-      "TXD0",
-      "pin35",
-      "35"
-    ],
+    "port_hints": ["TXD0", "pin35", "35"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -484,11 +344,7 @@
     "source_port_id": "source_port_35",
     "name": "IO22",
     "pin_number": 36,
-    "port_hints": [
-      "IO22",
-      "pin36",
-      "36"
-    ],
+    "port_hints": ["IO22", "pin36", "36"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net5"
@@ -498,11 +354,7 @@
     "source_port_id": "source_port_36",
     "name": "IO23",
     "pin_number": 37,
-    "port_hints": [
-      "IO23",
-      "pin37",
-      "37"
-    ],
+    "port_hints": ["IO23", "pin37", "37"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -511,11 +363,7 @@
     "source_port_id": "source_port_37",
     "name": "GND3",
     "pin_number": 38,
-    "port_hints": [
-      "GND3",
-      "pin38",
-      "38"
-    ],
+    "port_hints": ["GND3", "pin38", "38"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -525,11 +373,7 @@
     "source_port_id": "source_port_38",
     "name": "GND4",
     "pin_number": 39,
-    "port_hints": [
-      "GND4",
-      "pin39",
-      "39"
-    ],
+    "port_hints": ["GND4", "pin39", "39"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -539,11 +383,7 @@
     "source_port_id": "source_port_39",
     "name": "pin39_alt1",
     "pin_number": 40,
-    "port_hints": [
-      "pin39_alt1",
-      "pin40",
-      "40"
-    ],
+    "port_hints": ["pin39_alt1", "pin40", "40"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -552,11 +392,7 @@
     "source_port_id": "source_port_40",
     "name": "pin39_alt1",
     "pin_number": 41,
-    "port_hints": [
-      "pin39_alt1",
-      "pin41",
-      "41"
-    ],
+    "port_hints": ["pin39_alt1", "pin41", "41"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -565,11 +401,7 @@
     "source_port_id": "source_port_41",
     "name": "pin39_alt1",
     "pin_number": 42,
-    "port_hints": [
-      "pin39_alt1",
-      "pin42",
-      "42"
-    ],
+    "port_hints": ["pin39_alt1", "pin42", "42"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -578,11 +410,7 @@
     "source_port_id": "source_port_42",
     "name": "pin39_alt1",
     "pin_number": 43,
-    "port_hints": [
-      "pin39_alt1",
-      "pin43",
-      "43"
-    ],
+    "port_hints": ["pin39_alt1", "pin43", "43"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -591,11 +419,7 @@
     "source_port_id": "source_port_43",
     "name": "pin39_alt1",
     "pin_number": 44,
-    "port_hints": [
-      "pin39_alt1",
-      "pin44",
-      "44"
-    ],
+    "port_hints": ["pin39_alt1", "pin44", "44"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -604,11 +428,7 @@
     "source_port_id": "source_port_44",
     "name": "pin39_alt1",
     "pin_number": 45,
-    "port_hints": [
-      "pin39_alt1",
-      "pin45",
-      "45"
-    ],
+    "port_hints": ["pin39_alt1", "pin45", "45"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -617,11 +437,7 @@
     "source_port_id": "source_port_45",
     "name": "pin39_alt1",
     "pin_number": 46,
-    "port_hints": [
-      "pin39_alt1",
-      "pin46",
-      "46"
-    ],
+    "port_hints": ["pin39_alt1", "pin46", "46"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -630,11 +446,7 @@
     "source_port_id": "source_port_46",
     "name": "pin39_alt1",
     "pin_number": 47,
-    "port_hints": [
-      "pin39_alt1",
-      "pin47",
-      "47"
-    ],
+    "port_hints": ["pin39_alt1", "pin47", "47"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -645,9 +457,7 @@
     "name": "U1",
     "manufacturer_part_number": "ESP32_WROOM_32E_N8",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C701342"
-      ]
+      "jlcpcb": ["C701342"]
     },
     "source_group_id": "source_group_0",
     "internally_connected_source_port_ids": [
@@ -668,11 +478,7 @@
     "source_port_id": "source_port_47",
     "name": "GND",
     "pin_number": 1,
-    "port_hints": [
-      "GND",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["GND", "pin1", "1"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -682,11 +488,7 @@
     "source_port_id": "source_port_48",
     "name": "VCC",
     "pin_number": 2,
-    "port_hints": [
-      "VCC",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["VCC", "pin2", "2"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -696,11 +498,7 @@
     "source_port_id": "source_port_49",
     "name": "SCL",
     "pin_number": 3,
-    "port_hints": [
-      "SCL",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["SCL", "pin3", "3"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net5"
@@ -710,11 +508,7 @@
     "source_port_id": "source_port_50",
     "name": "SDA",
     "pin_number": 4,
-    "port_hints": [
-      "SDA",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["SDA", "pin4", "4"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net4"
@@ -726,9 +520,7 @@
     "name": "OLED1",
     "manufacturer_part_number": "SSD1306 0.96in OLED",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C152912"
-      ]
+      "jlcpcb": ["C152912"]
     },
     "source_group_id": "source_group_0"
   },
@@ -737,10 +529,7 @@
     "source_port_id": "source_port_51",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -750,10 +539,7 @@
     "source_port_id": "source_port_52",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
@@ -763,10 +549,7 @@
     "source_port_id": "source_port_53",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -778,9 +561,7 @@
     "name": "J_TEMP",
     "manufacturer_part_number": "ZX_XH2_54_3PZZ",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C7429633"
-      ]
+      "jlcpcb": ["C7429633"]
     },
     "source_group_id": "source_group_0"
   },
@@ -789,10 +570,7 @@
     "source_port_id": "source_port_54",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
@@ -802,10 +580,7 @@
     "source_port_id": "source_port_55",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -817,9 +592,7 @@
     "name": "J_DOOR",
     "manufacturer_part_number": "ZX_XH2_54_2PWZ",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C7429641"
-      ]
+      "jlcpcb": ["C7429641"]
     },
     "source_group_id": "source_group_0"
   },
@@ -828,10 +601,7 @@
     "source_port_id": "source_port_56",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -841,10 +611,7 @@
     "source_port_id": "source_port_57",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -856,9 +623,7 @@
     "name": "J_PWR",
     "manufacturer_part_number": "WJ2EDGRC_5_08_02P_14_00A",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C3697"
-      ]
+      "jlcpcb": ["C3697"]
     },
     "source_group_id": "source_group_0"
   },
@@ -867,11 +632,7 @@
     "source_port_id": "source_port_58",
     "name": "EH1",
     "pin_number": 7,
-    "port_hints": [
-      "EH1",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["EH1", "pin7", "7"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -881,11 +642,7 @@
     "source_port_id": "source_port_59",
     "name": "pin7_alt1",
     "pin_number": 8,
-    "port_hints": [
-      "pin7_alt1",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin7_alt1", "pin8", "8"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -894,11 +651,7 @@
     "source_port_id": "source_port_60",
     "name": "pin7_alt1",
     "pin_number": 9,
-    "port_hints": [
-      "pin7_alt1",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["pin7_alt1", "pin9", "9"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -907,11 +660,7 @@
     "source_port_id": "source_port_61",
     "name": "pin7_alt1",
     "pin_number": 10,
-    "port_hints": [
-      "pin7_alt1",
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin7_alt1", "pin10", "10"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -920,11 +669,7 @@
     "source_port_id": "source_port_62",
     "name": "B12",
     "pin_number": 11,
-    "port_hints": [
-      "B12",
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["B12", "pin11", "11"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -934,11 +679,7 @@
     "source_port_id": "source_port_63",
     "name": "B9",
     "pin_number": 12,
-    "port_hints": [
-      "B9",
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["B9", "pin12", "12"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -948,11 +689,7 @@
     "source_port_id": "source_port_64",
     "name": "A5",
     "pin_number": 13,
-    "port_hints": [
-      "A5",
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["A5", "pin13", "13"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -961,11 +698,7 @@
     "source_port_id": "source_port_65",
     "name": "B5",
     "pin_number": 14,
-    "port_hints": [
-      "B5",
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["B5", "pin14", "14"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -974,11 +707,7 @@
     "source_port_id": "source_port_66",
     "name": "A9",
     "pin_number": 15,
-    "port_hints": [
-      "A9",
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["A9", "pin15", "15"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -988,11 +717,7 @@
     "source_port_id": "source_port_67",
     "name": "A12",
     "pin_number": 16,
-    "port_hints": [
-      "A12",
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["A12", "pin16", "16"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1002,10 +727,7 @@
     "source_port_id": "source_port_68",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1014,10 +736,7 @@
     "source_port_id": "source_port_69",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1026,10 +745,7 @@
     "source_port_id": "source_port_70",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1038,10 +754,7 @@
     "source_port_id": "source_port_71",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1050,10 +763,7 @@
     "source_port_id": "source_port_72",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1062,10 +772,7 @@
     "source_port_id": "source_port_73",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1076,17 +783,11 @@
     "name": "J_USB",
     "manufacturer_part_number": "TYPE_C_6P",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C456012"
-      ]
+      "jlcpcb": ["C456012"]
     },
     "source_group_id": "source_group_0",
     "internally_connected_source_port_ids": [
-      [
-        "source_port_59",
-        "source_port_60",
-        "source_port_61"
-      ]
+      ["source_port_59", "source_port_60", "source_port_61"]
     ]
   },
   {
@@ -1094,11 +795,7 @@
     "source_port_id": "source_port_74",
     "name": "SW",
     "pin_number": 1,
-    "port_hints": [
-      "SW",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["SW", "pin1", "1"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -1108,11 +805,7 @@
     "source_port_id": "source_port_75",
     "name": "EN",
     "pin_number": 2,
-    "port_hints": [
-      "EN",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["EN", "pin2", "2"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -1122,11 +815,7 @@
     "source_port_id": "source_port_76",
     "name": "COMP",
     "pin_number": 3,
-    "port_hints": [
-      "COMP",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["COMP", "pin3", "3"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1135,11 +824,7 @@
     "source_port_id": "source_port_77",
     "name": "FB",
     "pin_number": 4,
-    "port_hints": [
-      "FB",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["FB", "pin4", "4"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -1149,11 +834,7 @@
     "source_port_id": "source_port_78",
     "name": "GND",
     "pin_number": 5,
-    "port_hints": [
-      "GND",
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["GND", "pin5", "5"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1163,11 +844,7 @@
     "source_port_id": "source_port_79",
     "name": "FREQ",
     "pin_number": 6,
-    "port_hints": [
-      "FREQ",
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["FREQ", "pin6", "6"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1176,11 +853,7 @@
     "source_port_id": "source_port_80",
     "name": "VIN",
     "pin_number": 7,
-    "port_hints": [
-      "VIN",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["VIN", "pin7", "7"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -1190,11 +863,7 @@
     "source_port_id": "source_port_81",
     "name": "BST",
     "pin_number": 8,
-    "port_hints": [
-      "BST",
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["BST", "pin8", "8"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1203,11 +872,7 @@
     "source_port_id": "source_port_82",
     "name": "EP",
     "pin_number": 9,
-    "port_hints": [
-      "EP",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["EP", "pin9", "9"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1216,9 +881,7 @@
     "type": "source_port",
     "source_port_id": "source_port_83",
     "name": "top",
-    "port_hints": [
-      "top"
-    ],
+    "port_hints": ["top"],
     "source_component_id": "source_manually_placed_via_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1226,9 +889,7 @@
     "type": "source_port",
     "source_port_id": "source_port_84",
     "name": "bottom",
-    "port_hints": [
-      "bottom"
-    ],
+    "port_hints": ["bottom"],
     "source_component_id": "source_manually_placed_via_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1236,9 +897,7 @@
     "type": "source_port",
     "source_port_id": "source_port_85",
     "name": "pin1",
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "source_component_id": "source_manually_placed_via_0",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1253,9 +912,7 @@
     "type": "source_port",
     "source_port_id": "source_port_86",
     "name": "top",
-    "port_hints": [
-      "top"
-    ],
+    "port_hints": ["top"],
     "source_component_id": "source_manually_placed_via_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1263,9 +920,7 @@
     "type": "source_port",
     "source_port_id": "source_port_87",
     "name": "bottom",
-    "port_hints": [
-      "bottom"
-    ],
+    "port_hints": ["bottom"],
     "source_component_id": "source_manually_placed_via_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1273,9 +928,7 @@
     "type": "source_port",
     "source_port_id": "source_port_88",
     "name": "pin1",
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "source_component_id": "source_manually_placed_via_1",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1290,9 +943,7 @@
     "type": "source_port",
     "source_port_id": "source_port_89",
     "name": "top",
-    "port_hints": [
-      "top"
-    ],
+    "port_hints": ["top"],
     "source_component_id": "source_manually_placed_via_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1300,9 +951,7 @@
     "type": "source_port",
     "source_port_id": "source_port_90",
     "name": "bottom",
-    "port_hints": [
-      "bottom"
-    ],
+    "port_hints": ["bottom"],
     "source_component_id": "source_manually_placed_via_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1310,9 +959,7 @@
     "type": "source_port",
     "source_port_id": "source_port_91",
     "name": "pin1",
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "source_component_id": "source_manually_placed_via_2",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1327,9 +974,7 @@
     "type": "source_port",
     "source_port_id": "source_port_92",
     "name": "top",
-    "port_hints": [
-      "top"
-    ],
+    "port_hints": ["top"],
     "source_component_id": "source_manually_placed_via_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1337,9 +982,7 @@
     "type": "source_port",
     "source_port_id": "source_port_93",
     "name": "bottom",
-    "port_hints": [
-      "bottom"
-    ],
+    "port_hints": ["bottom"],
     "source_component_id": "source_manually_placed_via_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1347,9 +990,7 @@
     "type": "source_port",
     "source_port_id": "source_port_94",
     "name": "pin1",
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "source_component_id": "source_manually_placed_via_3",
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -1367,9 +1008,7 @@
     "name": "U2",
     "manufacturer_part_number": "MP1584EN_LF_Z",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C15051"
-      ]
+      "jlcpcb": ["C15051"]
     },
     "source_group_id": "source_group_0"
   },
@@ -1378,10 +1017,7 @@
     "source_port_id": "source_port_95",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1391,10 +1027,7 @@
     "source_port_id": "source_port_96",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -1404,11 +1037,7 @@
     "source_port_id": "source_port_97",
     "name": "VIN",
     "pin_number": 3,
-    "port_hints": [
-      "VIN",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["VIN", "pin3", "3"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -1418,11 +1047,7 @@
     "source_port_id": "source_port_98",
     "name": "TAB",
     "pin_number": 4,
-    "port_hints": [
-      "TAB",
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["TAB", "pin4", "4"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -1434,9 +1059,7 @@
     "name": "U3",
     "manufacturer_part_number": "AMS1117_3_3",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C347222"
-      ]
+      "jlcpcb": ["C347222"]
     },
     "source_group_id": "source_group_0"
   },
@@ -1445,13 +1068,7 @@
     "source_port_id": "source_port_99",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_8",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -1461,13 +1078,7 @@
     "source_port_id": "source_port_100",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_8",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1478,9 +1089,7 @@
     "ftype": "simple_capacitor",
     "name": "C1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C14663"
-      ]
+      "jlcpcb": ["C14663"]
     },
     "capacitance": 0.00001,
     "display_capacitance": "10uF",
@@ -1492,13 +1101,7 @@
     "source_port_id": "source_port_101",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1",
-      "left"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
     "source_component_id": "source_component_9",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -1508,13 +1111,7 @@
     "source_port_id": "source_port_102",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2",
-      "right"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
     "source_component_id": "source_component_9",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1525,9 +1122,7 @@
     "ftype": "simple_capacitor",
     "name": "C2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C14663"
-      ]
+      "jlcpcb": ["C14663"]
     },
     "capacitance": 0.00001,
     "display_capacitance": "10uF",
@@ -1539,13 +1134,7 @@
     "source_port_id": "source_port_103",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_10",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -1555,13 +1144,7 @@
     "source_port_id": "source_port_104",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_10",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
@@ -1572,9 +1155,7 @@
     "ftype": "simple_resistor",
     "name": "R1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "resistance": 10000,
     "display_resistance": "10kΩ",
@@ -1586,13 +1167,7 @@
     "source_port_id": "source_port_105",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_11",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -1602,13 +1177,7 @@
     "source_port_id": "source_port_106",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_11",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
@@ -1619,9 +1188,7 @@
     "ftype": "simple_resistor",
     "name": "R2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "resistance": 10000,
     "display_resistance": "10kΩ",
@@ -1633,13 +1200,7 @@
     "source_port_id": "source_port_107",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net8"
@@ -1649,13 +1210,7 @@
     "source_port_id": "source_port_108",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_12",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
@@ -1666,9 +1221,7 @@
     "ftype": "simple_resistor",
     "name": "R3",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "resistance": 220,
     "display_resistance": "220Ω",
@@ -1680,13 +1233,7 @@
     "source_port_id": "source_port_109",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_13",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net10"
@@ -1696,13 +1243,7 @@
     "source_port_id": "source_port_110",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_13",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
@@ -1713,9 +1254,7 @@
     "ftype": "simple_resistor",
     "name": "R4",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "resistance": 220,
     "display_resistance": "220Ω",
@@ -1727,13 +1266,7 @@
     "source_port_id": "source_port_111",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_14",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net12"
@@ -1743,13 +1276,7 @@
     "source_port_id": "source_port_112",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_14",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
@@ -1760,9 +1287,7 @@
     "ftype": "simple_resistor",
     "name": "R5",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "resistance": 220,
     "display_resistance": "220Ω",
@@ -1774,13 +1299,7 @@
     "source_port_id": "source_port_113",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_15",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -1790,13 +1309,7 @@
     "source_port_id": "source_port_114",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_15",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
@@ -1807,11 +1320,7 @@
     "ftype": "simple_resistor",
     "name": "R6",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25803",
-        "C2906980",
-        "C14675"
-      ]
+      "jlcpcb": ["C25803", "C2906980", "C14675"]
     },
     "resistance": 100000,
     "display_resistance": "100kΩ",
@@ -1823,13 +1332,7 @@
     "source_port_id": "source_port_115",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_16",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
@@ -1839,13 +1342,7 @@
     "source_port_id": "source_port_116",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_16",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1856,11 +1353,7 @@
     "ftype": "simple_resistor",
     "name": "R7",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C22967",
-        "C114614",
-        "C116691"
-      ]
+      "jlcpcb": ["C22967", "C114614", "C116691"]
     },
     "resistance": 27000,
     "display_resistance": "27kΩ",
@@ -1872,13 +1365,7 @@
     "source_port_id": "source_port_117",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net15"
@@ -1888,13 +1375,7 @@
     "source_port_id": "source_port_118",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_17",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
@@ -1905,11 +1386,7 @@
     "ftype": "simple_resistor",
     "name": "R8",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C21190",
-        "C2907002",
-        "C2907113"
-      ]
+      "jlcpcb": ["C21190", "C2907002", "C2907113"]
     },
     "resistance": 1000,
     "display_resistance": "1kΩ",
@@ -1921,13 +1398,7 @@
     "source_port_id": "source_port_119",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_18",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
@@ -1937,13 +1408,7 @@
     "source_port_id": "source_port_120",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_18",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -1956,9 +1421,7 @@
     "color": "red",
     "symbol_display_value": "red",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "are_pins_interchangeable": false,
     "source_group_id": "source_group_0"
@@ -1968,13 +1431,7 @@
     "source_port_id": "source_port_121",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_19",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
@@ -1984,13 +1441,7 @@
     "source_port_id": "source_port_122",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_19",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2003,9 +1454,7 @@
     "color": "yellow",
     "symbol_display_value": "yellow",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "are_pins_interchangeable": false,
     "source_group_id": "source_group_0"
@@ -2015,13 +1464,7 @@
     "source_port_id": "source_port_123",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_20",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
@@ -2031,13 +1474,7 @@
     "source_port_id": "source_port_124",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_20",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2050,9 +1487,7 @@
     "color": "green",
     "symbol_display_value": "green",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25804"
-      ]
+      "jlcpcb": ["C25804"]
     },
     "are_pins_interchangeable": false,
     "source_group_id": "source_group_0"
@@ -2062,11 +1497,7 @@
     "source_port_id": "source_port_125",
     "name": "_POS",
     "pin_number": 1,
-    "port_hints": [
-      "_POS",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["_POS", "pin1", "1"],
     "source_component_id": "source_component_21",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -2076,11 +1507,7 @@
     "source_port_id": "source_port_126",
     "name": "_NEG",
     "pin_number": 2,
-    "port_hints": [
-      "_NEG",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["_NEG", "pin2", "2"],
     "source_component_id": "source_component_21",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net14"
@@ -2092,9 +1519,7 @@
     "name": "BZ1",
     "manufacturer_part_number": "YS_SBZ9650DYB05",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C409830"
-      ]
+      "jlcpcb": ["C409830"]
     },
     "source_group_id": "source_group_0"
   },
@@ -2103,11 +1528,7 @@
     "source_port_id": "source_port_127",
     "name": "BASE",
     "pin_number": 1,
-    "port_hints": [
-      "BASE",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["BASE", "pin1", "1"],
     "source_component_id": "source_component_22",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
@@ -2117,11 +1538,7 @@
     "source_port_id": "source_port_128",
     "name": "EMITTER",
     "pin_number": 2,
-    "port_hints": [
-      "EMITTER",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["EMITTER", "pin2", "2"],
     "source_component_id": "source_component_22",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2131,11 +1548,7 @@
     "source_port_id": "source_port_129",
     "name": "COLLECTOR",
     "pin_number": 3,
-    "port_hints": [
-      "COLLECTOR",
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["COLLECTOR", "pin3", "3"],
     "source_component_id": "source_component_22",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net14"
@@ -2154,10 +1567,7 @@
     "source_port_id": "source_port_130",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
@@ -2167,10 +1577,7 @@
     "source_port_id": "source_port_131",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2180,10 +1587,7 @@
     "source_port_id": "source_port_132",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
@@ -2193,10 +1597,7 @@
     "source_port_id": "source_port_133",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_23",
     "subcircuit_id": "subcircuit_source_group_0",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2208,9 +1609,7 @@
     "name": "SW1",
     "manufacturer_part_number": "KH_6X6X5H_STM",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C2837531"
-      ]
+      "jlcpcb": ["C2837531"]
     },
     "source_group_id": "source_group_0"
   },
@@ -2285,21 +1684,13 @@
     "source_component_internal_connection_id": "source_component_internal_connection_1",
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_0",
-    "source_port_ids": [
-      "source_port_59",
-      "source_port_60",
-      "source_port_61"
-    ]
+    "source_port_ids": ["source_port_59", "source_port_60", "source_port_61"]
   },
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_0",
-    "connected_source_port_ids": [
-      "source_port_56"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_56"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_PWR.pin1 to net.V12_IN",
     "min_trace_thickness": 0.45,
@@ -2308,12 +1699,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_1",
-    "connected_source_port_ids": [
-      "source_port_57"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_57"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_PWR.pin2 to net.GND",
     "min_trace_thickness": 0.5,
@@ -2322,12 +1709,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_2",
-    "connected_source_port_ids": [
-      "source_port_66"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_66"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_USB.A9 to net.V5",
     "min_trace_thickness": 0.4,
@@ -2336,12 +1719,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_3",
-    "connected_source_port_ids": [
-      "source_port_63"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_63"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_USB.B9 to net.V5",
     "min_trace_thickness": 0.4,
@@ -2350,12 +1729,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_4",
-    "connected_source_port_ids": [
-      "source_port_67"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_67"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_USB.A12 to net.GND",
     "min_trace_thickness": 0.4,
@@ -2364,12 +1739,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_5",
-    "connected_source_port_ids": [
-      "source_port_62"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_62"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_USB.B12 to net.GND",
     "min_trace_thickness": 0.4,
@@ -2378,12 +1749,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_6",
-    "connected_source_port_ids": [
-      "source_port_58"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_58"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_USB.EH1 to net.GND",
     "min_trace_thickness": 0.4,
@@ -2392,12 +1759,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_7",
-    "connected_source_port_ids": [
-      "source_port_80"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_80"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.VIN to net.V12_IN",
     "min_trace_thickness": 0.45,
@@ -2406,12 +1769,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_8",
-    "connected_source_port_ids": [
-      "source_port_78"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_78"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.GND to net.GND",
     "min_trace_thickness": 0.45,
@@ -2420,12 +1779,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_9",
-    "connected_source_port_ids": [
-      "source_port_82"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_82"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.EP to net.GND",
     "min_trace_thickness": 0.45,
@@ -2434,12 +1789,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_10",
-    "connected_source_port_ids": [
-      "source_port_74"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_74"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.SW to net.V5",
     "min_trace_thickness": 0.45,
@@ -2448,12 +1799,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_11",
-    "connected_source_port_ids": [
-      "source_port_77"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_77"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.FB to net.V5",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
@@ -2461,12 +1808,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_12",
-    "connected_source_port_ids": [
-      "source_port_75"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_75"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U2.EN to net.V12_IN",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -2474,12 +1817,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_13",
-    "connected_source_port_ids": [
-      "source_port_97"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_97"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U3.VIN to net.V5",
     "min_trace_thickness": 0.4,
@@ -2488,12 +1827,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_14",
-    "connected_source_port_ids": [
-      "source_port_95"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_95"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U3.pin1 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2501,12 +1836,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_15",
-    "connected_source_port_ids": [
-      "source_port_96"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_96"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U3.pin2 to net.V3_3",
     "min_trace_thickness": 0.4,
@@ -2515,12 +1846,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_16",
-    "connected_source_port_ids": [
-      "source_port_98"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_98"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U3.TAB to net.V3_3",
     "min_trace_thickness": 0.4,
@@ -2529,12 +1856,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_17",
-    "connected_source_port_ids": [
-      "source_port_99"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_99"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "max_length": null,
     "display_name": "C1.pin1 to net.V5",
@@ -2543,12 +1866,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_18",
-    "connected_source_port_ids": [
-      "source_port_100"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_100"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "max_length": null,
     "display_name": "C1.pin2 to net.GND",
@@ -2557,12 +1876,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_19",
-    "connected_source_port_ids": [
-      "source_port_101"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_101"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "max_length": null,
     "display_name": "C2.pin1 to net.V3_3",
@@ -2571,12 +1886,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_20",
-    "connected_source_port_ids": [
-      "source_port_102"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_102"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "max_length": null,
     "display_name": "C2.pin2 to net.GND",
@@ -2585,12 +1896,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_21",
-    "connected_source_port_ids": [
-      "source_port_1"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_1"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.3V3 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2598,12 +1905,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_22",
-    "connected_source_port_ids": [
-      "source_port_0"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_0"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.GND1 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2611,12 +1914,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_23",
-    "connected_source_port_ids": [
-      "source_port_14"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_14"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.GND2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2624,12 +1923,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_24",
-    "connected_source_port_ids": [
-      "source_port_37"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_37"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.GND3 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2637,12 +1932,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_25",
-    "connected_source_port_ids": [
-      "source_port_38"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_38"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.GND4 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2650,12 +1941,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_26",
-    "connected_source_port_ids": [
-      "source_port_2"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_2"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.EN to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2663,12 +1950,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_27",
-    "connected_source_port_ids": [
-      "source_port_48"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_48"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "OLED1.VCC to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2676,12 +1959,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_28",
-    "connected_source_port_ids": [
-      "source_port_47"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_47"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "OLED1.GND to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2689,10 +1968,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_29",
-    "connected_source_port_ids": [
-      "source_port_50",
-      "source_port_32"
-    ],
+    "connected_source_port_ids": ["source_port_50", "source_port_32"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "OLED1.SDA to U1.IO21",
@@ -2701,10 +1977,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_30",
-    "connected_source_port_ids": [
-      "source_port_49",
-      "source_port_35"
-    ],
+    "connected_source_port_ids": ["source_port_49", "source_port_35"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "OLED1.SCL to U1.IO22",
@@ -2713,12 +1986,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_31",
-    "connected_source_port_ids": [
-      "source_port_53"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_53"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_TEMP.pin3 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2726,12 +1995,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_32",
-    "connected_source_port_ids": [
-      "source_port_51"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_51"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_TEMP.pin1 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2739,10 +2004,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_33",
-    "connected_source_port_ids": [
-      "source_port_52",
-      "source_port_7"
-    ],
+    "connected_source_port_ids": ["source_port_52", "source_port_7"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_TEMP.pin2 to U1.IO32",
@@ -2751,12 +2013,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_34",
-    "connected_source_port_ids": [
-      "source_port_103"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_103"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R1.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2764,10 +2022,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_35",
-    "connected_source_port_ids": [
-      "source_port_104",
-      "source_port_52"
-    ],
+    "connected_source_port_ids": ["source_port_104", "source_port_52"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R1.pin2 to J_TEMP.pin2",
@@ -2776,12 +2031,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_36",
-    "connected_source_port_ids": [
-      "source_port_55"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_55"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_DOOR.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2789,10 +2040,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_37",
-    "connected_source_port_ids": [
-      "source_port_54",
-      "source_port_8"
-    ],
+    "connected_source_port_ids": ["source_port_54", "source_port_8"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "J_DOOR.pin1 to U1.IO33",
@@ -2801,12 +2049,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_38",
-    "connected_source_port_ids": [
-      "source_port_105"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_105"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R2.pin1 to net.V3_3",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
@@ -2814,10 +2058,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_39",
-    "connected_source_port_ids": [
-      "source_port_106",
-      "source_port_54"
-    ],
+    "connected_source_port_ids": ["source_port_106", "source_port_54"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R2.pin2 to J_DOOR.pin1",
@@ -2826,10 +2067,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_40",
-    "connected_source_port_ids": [
-      "source_port_10",
-      "source_port_107"
-    ],
+    "connected_source_port_ids": ["source_port_10", "source_port_107"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.IO26 to R3.pin1",
@@ -2838,10 +2076,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_41",
-    "connected_source_port_ids": [
-      "source_port_108",
-      "source_port_119"
-    ],
+    "connected_source_port_ids": ["source_port_108", "source_port_119"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R3.pin2 to LED_TEMP.pin1",
@@ -2850,12 +2085,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_42",
-    "connected_source_port_ids": [
-      "source_port_120"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_120"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "LED_TEMP.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2863,10 +2094,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_43",
-    "connected_source_port_ids": [
-      "source_port_11",
-      "source_port_109"
-    ],
+    "connected_source_port_ids": ["source_port_11", "source_port_109"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.IO27 to R4.pin1",
@@ -2875,10 +2103,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_44",
-    "connected_source_port_ids": [
-      "source_port_110",
-      "source_port_121"
-    ],
+    "connected_source_port_ids": ["source_port_110", "source_port_121"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R4.pin2 to LED_DOOR.pin1",
@@ -2887,12 +2112,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_45",
-    "connected_source_port_ids": [
-      "source_port_122"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_122"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "LED_DOOR.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2900,10 +2121,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_46",
-    "connected_source_port_ids": [
-      "source_port_12",
-      "source_port_111"
-    ],
+    "connected_source_port_ids": ["source_port_12", "source_port_111"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.IO14 to R5.pin1",
@@ -2912,10 +2130,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_47",
-    "connected_source_port_ids": [
-      "source_port_112",
-      "source_port_123"
-    ],
+    "connected_source_port_ids": ["source_port_112", "source_port_123"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R5.pin2 to LED_PWR.pin1",
@@ -2924,12 +2139,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_48",
-    "connected_source_port_ids": [
-      "source_port_124"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_124"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "LED_PWR.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2937,12 +2148,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_49",
-    "connected_source_port_ids": [
-      "source_port_125"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_125"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "BZ1._POS to net.V5",
     "min_trace_thickness": 0.35,
@@ -2951,10 +2158,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_50",
-    "connected_source_port_ids": [
-      "source_port_126",
-      "source_port_129"
-    ],
+    "connected_source_port_ids": ["source_port_126", "source_port_129"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "BZ1._NEG to Q1.COLLECTOR",
@@ -2964,12 +2168,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_51",
-    "connected_source_port_ids": [
-      "source_port_128"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_128"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "Q1.EMITTER to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -2977,10 +2177,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_52",
-    "connected_source_port_ids": [
-      "source_port_9",
-      "source_port_117"
-    ],
+    "connected_source_port_ids": ["source_port_9", "source_port_117"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "U1.IO25 to R8.pin1",
@@ -2989,10 +2186,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_53",
-    "connected_source_port_ids": [
-      "source_port_118",
-      "source_port_127"
-    ],
+    "connected_source_port_ids": ["source_port_118", "source_port_127"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R8.pin2 to Q1.BASE",
@@ -3001,10 +2195,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_54",
-    "connected_source_port_ids": [
-      "source_port_130",
-      "source_port_15"
-    ],
+    "connected_source_port_ids": ["source_port_130", "source_port_15"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "SW1.pin1 to U1.IO13",
@@ -3013,10 +2204,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_55",
-    "connected_source_port_ids": [
-      "source_port_132",
-      "source_port_15"
-    ],
+    "connected_source_port_ids": ["source_port_132", "source_port_15"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "SW1.pin3 to U1.IO13",
@@ -3025,12 +2213,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_56",
-    "connected_source_port_ids": [
-      "source_port_131"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_131"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "SW1.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -3038,12 +2222,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_57",
-    "connected_source_port_ids": [
-      "source_port_133"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_133"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "SW1.pin4 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -3051,12 +2231,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_58",
-    "connected_source_port_ids": [
-      "source_port_113"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_113"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R6.pin1 to net.V12_IN",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
@@ -3064,10 +2240,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_59",
-    "connected_source_port_ids": [
-      "source_port_114",
-      "source_port_5"
-    ],
+    "connected_source_port_ids": ["source_port_114", "source_port_5"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R6.pin2 to U1.IO34",
@@ -3076,10 +2249,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_60",
-    "connected_source_port_ids": [
-      "source_port_115",
-      "source_port_5"
-    ],
+    "connected_source_port_ids": ["source_port_115", "source_port_5"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R7.pin1 to U1.IO34",
@@ -3088,12 +2258,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_61",
-    "connected_source_port_ids": [
-      "source_port_116"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_116"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_0",
     "display_name": "R7.pin2 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
@@ -9038,9 +8204,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -12.29001825,
     "y": -7.000109,
@@ -9068,9 +8232,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -11.02001825,
     "y": -7.000109,
@@ -9098,9 +8260,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -9.75001825,
     "y": -7.000109,
@@ -9128,9 +8288,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": -8.48001825,
     "y": -7.000109,
@@ -9158,9 +8316,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": -7.21001825,
     "y": -7.000109,
@@ -9188,9 +8344,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": -5.94001825,
     "y": -7.000109,
@@ -9218,9 +8372,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "x": -4.67001825,
     "y": -7.000109,
@@ -9248,9 +8400,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "x": -3.40001825,
     "y": -7.000109,
@@ -9278,9 +8428,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": -2.13001825,
     "y": -7.000109,
@@ -9308,9 +8456,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin10"
-    ],
+    "port_hints": ["pin10"],
     "is_covered_with_solder_mask": false,
     "x": -0.86001825,
     "y": -7.000109,
@@ -9338,9 +8484,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": 0.40998175000000003,
     "y": -7.000109,
@@ -9368,9 +8512,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": 1.6799817499999996,
     "y": -7.000109,
@@ -9398,9 +8540,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": 2.94998175,
     "y": -7.000109,
@@ -9428,9 +8568,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": 4.21998175,
     "y": -7.000109,
@@ -9458,9 +8596,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": -3.714873,
@@ -9488,9 +8624,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin16"
-    ],
+    "port_hints": ["pin16"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": -2.4448730000000003,
@@ -9518,9 +8652,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": -1.1748729999999998,
@@ -9548,9 +8680,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 0.09512699999999996,
@@ -9578,9 +8708,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 1.365127,
@@ -9608,9 +8736,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 2.6351269999999998,
@@ -9638,9 +8764,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin21"
-    ],
+    "port_hints": ["pin21"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 3.9051270000000002,
@@ -9668,9 +8792,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin22"
-    ],
+    "port_hints": ["pin22"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 5.175127,
@@ -9698,9 +8820,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin23"
-    ],
+    "port_hints": ["pin23"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 6.445127,
@@ -9728,9 +8848,7 @@
     "shape": "rect",
     "width": 2.0999958,
     "height": 0.9500108,
-    "port_hints": [
-      "pin24"
-    ],
+    "port_hints": ["pin24"],
     "is_covered_with_solder_mask": false,
     "x": 5.715025750000001,
     "y": 7.715127,
@@ -9758,9 +8876,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin25"
-    ],
+    "port_hints": ["pin25"],
     "is_covered_with_solder_mask": false,
     "x": 4.21998175,
     "y": 11.000109,
@@ -9788,9 +8904,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin26"
-    ],
+    "port_hints": ["pin26"],
     "is_covered_with_solder_mask": false,
     "x": 2.94998175,
     "y": 11.000109,
@@ -9818,9 +8932,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin27"
-    ],
+    "port_hints": ["pin27"],
     "is_covered_with_solder_mask": false,
     "x": 1.6799817499999996,
     "y": 11.000109,
@@ -9848,9 +8960,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin28"
-    ],
+    "port_hints": ["pin28"],
     "is_covered_with_solder_mask": false,
     "x": 0.40998175000000003,
     "y": 11.000109,
@@ -9878,9 +8988,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin29"
-    ],
+    "port_hints": ["pin29"],
     "is_covered_with_solder_mask": false,
     "x": -0.86001825,
     "y": 11.000109,
@@ -9908,9 +9016,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin30"
-    ],
+    "port_hints": ["pin30"],
     "is_covered_with_solder_mask": false,
     "x": -2.13001825,
     "y": 11.000109,
@@ -9938,9 +9044,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin31"
-    ],
+    "port_hints": ["pin31"],
     "is_covered_with_solder_mask": false,
     "x": -3.40001825,
     "y": 11.000109,
@@ -9968,9 +9072,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin32"
-    ],
+    "port_hints": ["pin32"],
     "is_covered_with_solder_mask": false,
     "x": -4.67001825,
     "y": 11.000109,
@@ -9998,9 +9100,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin33"
-    ],
+    "port_hints": ["pin33"],
     "is_covered_with_solder_mask": false,
     "x": -5.94001825,
     "y": 11.000109,
@@ -10028,9 +9128,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin34"
-    ],
+    "port_hints": ["pin34"],
     "is_covered_with_solder_mask": false,
     "x": -7.21001825,
     "y": 11.000109,
@@ -10058,9 +9156,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin35"
-    ],
+    "port_hints": ["pin35"],
     "is_covered_with_solder_mask": false,
     "x": -8.48001825,
     "y": 11.000109,
@@ -10088,9 +9184,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin36"
-    ],
+    "port_hints": ["pin36"],
     "is_covered_with_solder_mask": false,
     "x": -9.75001825,
     "y": 11.000109,
@@ -10118,9 +9212,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin37"
-    ],
+    "port_hints": ["pin37"],
     "is_covered_with_solder_mask": false,
     "x": -11.02001825,
     "y": 11.000109,
@@ -10148,9 +9240,7 @@
     "shape": "rect",
     "width": 0.9500108,
     "height": 2.0999958,
-    "port_hints": [
-      "pin38"
-    ],
+    "port_hints": ["pin38"],
     "is_covered_with_solder_mask": false,
     "x": -12.29001825,
     "y": 11.000109,
@@ -10178,9 +9268,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin39"
-    ],
+    "port_hints": ["pin39"],
     "is_covered_with_solder_mask": false,
     "x": -4.60905825,
     "y": 0.499749,
@@ -10208,9 +9296,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin40"
-    ],
+    "port_hints": ["pin40"],
     "is_covered_with_solder_mask": false,
     "x": -4.60905825,
     "y": -0.900045,
@@ -10238,9 +9324,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin41"
-    ],
+    "port_hints": ["pin41"],
     "is_covered_with_solder_mask": false,
     "x": -4.60905825,
     "y": 1.900051,
@@ -10268,9 +9352,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin42"
-    ],
+    "port_hints": ["pin42"],
     "is_covered_with_solder_mask": false,
     "x": -6.00910625,
     "y": 1.900051,
@@ -10298,9 +9380,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin43"
-    ],
+    "port_hints": ["pin43"],
     "is_covered_with_solder_mask": false,
     "x": -6.00910625,
     "y": 0.500003,
@@ -10328,9 +9408,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin44"
-    ],
+    "port_hints": ["pin44"],
     "is_covered_with_solder_mask": false,
     "x": -6.00910625,
     "y": -0.900045,
@@ -10358,9 +9436,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin45"
-    ],
+    "port_hints": ["pin45"],
     "is_covered_with_solder_mask": false,
     "x": -3.20901025,
     "y": -0.900045,
@@ -10388,9 +9464,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin46"
-    ],
+    "port_hints": ["pin46"],
     "is_covered_with_solder_mask": false,
     "x": -3.20901025,
     "y": 0.500003,
@@ -10418,9 +9492,7 @@
     "shape": "rect",
     "width": 0.8999982,
     "height": 0.8999982,
-    "port_hints": [
-      "pin47"
-    ],
+    "port_hints": ["pin47"],
     "is_covered_with_solder_mask": false,
     "x": -3.20901025,
     "y": 1.900051,
@@ -10674,16 +9746,10 @@
     "outer_diameter": 1.6,
     "hole_diameter": 0.9,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole1",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole1", "pin1"],
     "x": 17.19,
     "y": 14,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10715,16 +9781,10 @@
     "outer_diameter": 1.6,
     "hole_diameter": 0.9,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole2",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole2", "pin2"],
     "x": 19.73,
     "y": 14,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10756,16 +9816,10 @@
     "outer_diameter": 1.6,
     "hole_diameter": 0.9,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole3",
-      "pin3"
-    ],
+    "port_hints": ["unnamed_platedhole3", "pin3"],
     "x": 22.27,
     "y": 14,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10797,16 +9851,10 @@
     "outer_diameter": 1.6,
     "hole_diameter": 0.9,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole4",
-      "pin4"
-    ],
+    "port_hints": ["unnamed_platedhole4", "pin4"],
     "x": 24.81,
     "y": 14,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10882,16 +9930,10 @@
     "outer_diameter": 1.5999968,
     "hole_diameter": 0.999998,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole5",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole5", "pin1"],
     "x": -30.000127,
     "y": 4.96,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10923,16 +9965,10 @@
     "outer_diameter": 1.5999968,
     "hole_diameter": 0.999998,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole6",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole6", "pin2"],
     "x": -29.999873,
     "y": 7.5,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -10964,16 +10000,10 @@
     "outer_diameter": 1.5999968,
     "hole_diameter": 0.999998,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole7",
-      "pin3"
-    ],
+    "port_hints": ["unnamed_platedhole7", "pin3"],
     "x": -29.999873,
     "y": 10.04,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -11224,16 +10254,10 @@
     "outer_diameter": 1.524,
     "hole_diameter": 0.9000236,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole8",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole8", "pin1"],
     "x": -30,
     "y": -6.74406025,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -11265,16 +10289,10 @@
     "outer_diameter": 1.499997,
     "hole_diameter": 0.9000236,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole9",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole9", "pin2"],
     "x": -30,
     "y": -4.24393825,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -11403,16 +10421,10 @@
     "outer_diameter": 2.999994,
     "hole_diameter": 1.700022,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole10",
-      "pin1"
-    ],
+    "port_hints": ["unnamed_platedhole10", "pin1"],
     "x": 32.04,
     "y": -17,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -11444,16 +10456,10 @@
     "outer_diameter": 2.999994,
     "hole_diameter": 1.700022,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole11",
-      "pin2"
-    ],
+    "port_hints": ["unnamed_platedhole11", "pin2"],
     "x": 26.96,
     "y": -17,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -11622,16 +10628,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole12",
-      "pin7"
-    ],
+    "port_hints": ["unnamed_platedhole12", "pin7"],
     "x": 21.319905,
     "y": -19.3000144,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -11668,16 +10668,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole13",
-      "pin8"
-    ],
+    "port_hints": ["unnamed_platedhole13", "pin8"],
     "x": 12.680095,
     "y": -19.3000144,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -11714,16 +10708,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole14",
-      "pin9"
-    ],
+    "port_hints": ["unnamed_platedhole14", "pin9"],
     "x": 21.319905,
     "y": -15.4999204,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -11760,16 +10748,10 @@
     "hole_width": 0.5999988,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "unnamed_platedhole15",
-      "pin10"
-    ],
+    "port_hints": ["unnamed_platedhole15", "pin10"],
     "x": 12.680095,
     "y": -15.4999204,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0",
     "ccw_rotation": 0
@@ -11805,9 +10787,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 1.1999976,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": 14.300107,
     "y": -15.2499844,
@@ -11835,9 +10815,7 @@
     "shape": "rect",
     "width": 0.6999986,
     "height": 1.1999976,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": 15.500003,
     "y": -15.2499844,
@@ -11865,9 +10843,7 @@
     "shape": "rect",
     "width": 0.6999986,
     "height": 1.1999976,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": 16.500001,
     "y": -15.2499844,
@@ -11895,9 +10871,7 @@
     "shape": "rect",
     "width": 0.6999986,
     "height": 1.1999976,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": 17.499999,
     "y": -15.2499844,
@@ -11925,9 +10899,7 @@
     "shape": "rect",
     "width": 0.6999986,
     "height": 1.1999976,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": 18.499997,
     "y": -15.2499844,
@@ -11955,9 +10927,7 @@
     "shape": "rect",
     "width": 0.7999984,
     "height": 1.1999976,
-    "port_hints": [
-      "pin16"
-    ],
+    "port_hints": ["pin16"],
     "is_covered_with_solder_mask": false,
     "x": 19.699893,
     "y": -15.2499844,
@@ -12401,9 +11371,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12419,9 +11387,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12437,9 +11403,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12455,9 +11419,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12473,9 +11435,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12491,9 +11451,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12509,9 +11467,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12527,9 +11483,7 @@
     "radius": 0.2869946,
     "height": 2.0379944,
     "width": 0.5739892,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "subcircuit_id": "subcircuit_source_group_0"
   },
@@ -12542,9 +11496,7 @@
     "shape": "rect",
     "width": 1.999996,
     "height": 1.999996,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": -7,
     "y": -16,
@@ -12570,10 +11522,7 @@
     "y": -15.500128,
     "hole_diameter": 0.3048,
     "outer_diameter": 0.6096,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "bottom",
     "to_layer": "top",
     "subcircuit_id": "subcircuit_source_group_0"
@@ -12585,10 +11534,7 @@
     "y": -15.500128,
     "hole_diameter": 0.3048,
     "outer_diameter": 0.6096,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "bottom",
     "to_layer": "top",
     "subcircuit_id": "subcircuit_source_group_0"
@@ -12600,10 +11546,7 @@
     "y": -16.500126,
     "hole_diameter": 0.3048,
     "outer_diameter": 0.6096,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "bottom",
     "to_layer": "top",
     "subcircuit_id": "subcircuit_source_group_0"
@@ -12615,10 +11558,7 @@
     "y": -16.500126,
     "hole_diameter": 0.3048,
     "outer_diameter": 0.6096,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "bottom",
     "to_layer": "top",
     "subcircuit_id": "subcircuit_source_group_0"
@@ -12927,9 +11867,7 @@
     "shape": "rect",
     "width": 2.4699976,
     "height": 0.9800082,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -23.165106,
     "y": -17.299970000000002,
@@ -12957,9 +11895,7 @@
     "shape": "rect",
     "width": 2.4699976,
     "height": 0.9800082,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -23.165106,
     "y": -15,
@@ -12987,9 +11923,7 @@
     "shape": "rect",
     "width": 2.4699976,
     "height": 0.9800082,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -23.165106,
     "y": -12.70003,
@@ -13017,9 +11951,7 @@
     "shape": "rect",
     "width": 2.4699976,
     "height": 3.5999928,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": -28.834894,
     "y": -15,
@@ -13122,10 +12054,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -33.825,
     "y": -11.5,
@@ -13153,10 +12082,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -32.175,
     "y": -11.5,
@@ -13239,10 +12165,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.825,
     "y": -11.5,
@@ -13270,10 +12193,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -19.175,
     "y": -11.5,
@@ -13356,10 +12276,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -23.325,
     "y": 9.5,
@@ -13387,10 +12304,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -21.675,
     "y": 9.5,
@@ -13483,10 +12397,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -16.825,
     "y": -9.5,
@@ -13514,10 +12425,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -15.175,
     "y": -9.5,
@@ -13610,10 +12518,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.325,
     "y": -14.5,
@@ -13641,10 +12546,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -18.675,
     "y": -14.5,
@@ -13737,10 +12639,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -16.825,
     "y": -14.5,
@@ -13768,10 +12667,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -15.175,
     "y": -14.5,
@@ -13864,10 +12760,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -13.825,
     "y": -14.5,
@@ -13895,10 +12788,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -12.175,
     "y": -14.5,
@@ -13991,10 +12881,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 14.675,
     "y": -12.5,
@@ -14022,10 +12909,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 16.325,
     "y": -12.5,
@@ -14118,10 +13002,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 19.675,
     "y": -12.5,
@@ -14149,10 +13030,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 21.325,
     "y": -12.5,
@@ -14245,10 +13123,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -29.825,
     "y": 14,
@@ -14276,10 +13151,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -28.175,
     "y": 14,
@@ -14372,10 +13244,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -20.325,
     "y": -17.5,
@@ -14403,10 +13272,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -18.675,
     "y": -17.5,
@@ -14489,10 +13355,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -16.825,
     "y": -17.5,
@@ -14520,10 +13383,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -15.175,
     "y": -17.5,
@@ -14606,10 +13466,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": -13.825,
     "y": -17.5,
@@ -14637,10 +13494,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": -12.175,
     "y": -17.5,
@@ -14723,9 +13577,7 @@
     "shape": "rect",
     "width": 2.499995,
     "height": 1.7999964,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -13.499628000000001,
     "y": 18,
@@ -14753,9 +13605,7 @@
     "shape": "rect",
     "width": 2.499995,
     "height": 1.7999964,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -22.500372,
     "y": 18,
@@ -15104,9 +13954,7 @@
     "shape": "rect",
     "width": 0.6,
     "height": 1,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -27.45,
     "y": 9.9,
@@ -15134,9 +13982,7 @@
     "shape": "rect",
     "width": 0.6,
     "height": 1,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": -25.55,
     "y": 9.9,
@@ -15164,9 +14010,7 @@
     "shape": "rect",
     "width": 0.7,
     "height": 1,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -26.5,
     "y": 12.1,
@@ -15209,9 +14053,7 @@
     "shape": "rect",
     "width": 2.2999954,
     "height": 1.499997,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": -0.5499020000000003,
     "y": -15.249941,
@@ -15239,9 +14081,7 @@
     "shape": "rect",
     "width": 2.2999954,
     "height": 1.499997,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 8.549902,
     "y": -15.250195,
@@ -15269,9 +14109,7 @@
     "shape": "rect",
     "width": 2.2999954,
     "height": 1.499997,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": -0.5499020000000003,
     "y": -19.750059,
@@ -15299,9 +14137,7 @@
     "shape": "rect",
     "width": 2.2999954,
     "height": 1.499997,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": 8.549902,
     "y": -19.750059,
@@ -15949,9 +14785,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_0",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.29001825,
     "y": -7.000109,
@@ -15961,9 +14795,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_1",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -11.02001825,
     "y": -7.000109,
@@ -15973,9 +14805,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_2",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -9.75001825,
     "y": -7.000109,
@@ -15985,9 +14815,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_3",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.48001825,
     "y": -7.000109,
@@ -15997,9 +14825,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_4",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.21001825,
     "y": -7.000109,
@@ -16009,9 +14835,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_5",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -5.94001825,
     "y": -7.000109,
@@ -16021,9 +14845,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_6",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.67001825,
     "y": -7.000109,
@@ -16033,9 +14855,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_7",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.40001825,
     "y": -7.000109,
@@ -16045,9 +14865,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_8",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -2.13001825,
     "y": -7.000109,
@@ -16057,9 +14875,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_9",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.86001825,
     "y": -7.000109,
@@ -16069,9 +14885,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_10",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.40998175000000003,
     "y": -7.000109,
@@ -16081,9 +14895,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_11",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.6799817499999996,
     "y": -7.000109,
@@ -16093,9 +14905,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_12",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 2.94998175,
     "y": -7.000109,
@@ -16105,9 +14915,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_13",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.21998175,
     "y": -7.000109,
@@ -16117,9 +14925,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_14",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": -3.714873,
@@ -16129,9 +14935,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_15",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": -2.4448730000000003,
@@ -16141,9 +14945,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_16",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": -1.1748729999999998,
@@ -16153,9 +14955,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_17",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 0.09512699999999996,
@@ -16165,9 +14965,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_18",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 1.365127,
@@ -16177,9 +14975,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_19",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 2.6351269999999998,
@@ -16189,9 +14985,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_20",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 3.9051270000000002,
@@ -16201,9 +14995,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_21",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 5.175127,
@@ -16213,9 +15005,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_22",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 6.445127,
@@ -16225,9 +15015,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_23",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 5.715025750000001,
     "y": 7.715127,
@@ -16237,9 +15025,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_24",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 4.21998175,
     "y": 11.000109,
@@ -16249,9 +15035,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_25",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 2.94998175,
     "y": 11.000109,
@@ -16261,9 +15045,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_26",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 1.6799817499999996,
     "y": 11.000109,
@@ -16273,9 +15055,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_27",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 0.40998175000000003,
     "y": 11.000109,
@@ -16285,9 +15065,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_28",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.86001825,
     "y": 11.000109,
@@ -16297,9 +15075,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_29",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -2.13001825,
     "y": 11.000109,
@@ -16309,9 +15085,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_30",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.40001825,
     "y": 11.000109,
@@ -16321,9 +15095,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_31",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.67001825,
     "y": 11.000109,
@@ -16333,9 +15105,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_32",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -5.94001825,
     "y": 11.000109,
@@ -16345,9 +15115,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_33",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.21001825,
     "y": 11.000109,
@@ -16357,9 +15125,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_34",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.48001825,
     "y": 11.000109,
@@ -16369,9 +15135,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_35",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -9.75001825,
     "y": 11.000109,
@@ -16381,9 +15145,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_36",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -11.02001825,
     "y": 11.000109,
@@ -16393,9 +15155,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_37",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.29001825,
     "y": 11.000109,
@@ -16405,9 +15165,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_38",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.60905825,
     "y": 0.499749,
@@ -16417,9 +15175,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_39",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.60905825,
     "y": -0.900045,
@@ -16429,9 +15185,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_40",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -4.60905825,
     "y": 1.900051,
@@ -16441,9 +15195,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_41",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.00910625,
     "y": 1.900051,
@@ -16453,9 +15205,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_42",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.00910625,
     "y": 0.500003,
@@ -16465,9 +15215,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_43",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.00910625,
     "y": -0.900045,
@@ -16477,9 +15225,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_44",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.20901025,
     "y": -0.900045,
@@ -16489,9 +15235,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_45",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.20901025,
     "y": 0.500003,
@@ -16501,9 +15245,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_46",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -3.20901025,
     "y": 1.900051,
@@ -16513,12 +15255,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_47",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 17.19,
     "y": 14,
@@ -16528,12 +15265,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_48",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 19.73,
     "y": 14,
@@ -16543,12 +15275,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_49",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 22.27,
     "y": 14,
@@ -16558,12 +15285,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_50",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 24.81,
     "y": 14,
@@ -16573,12 +15295,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_51",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -30.000127,
     "y": 4.96,
@@ -16588,12 +15305,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_52",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -29.999873,
     "y": 7.5,
@@ -16603,12 +15315,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_53",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -29.999873,
     "y": 10.04,
@@ -16618,12 +15325,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_54",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -30,
     "y": -6.74406025,
@@ -16633,12 +15335,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_55",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -30,
     "y": -4.24393825,
@@ -16648,12 +15345,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_56",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 32.04,
     "y": -17,
@@ -16663,12 +15355,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_57",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 26.96,
     "y": -17,
@@ -16678,12 +15365,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_58",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 21.319905,
     "y": -19.3000144,
@@ -16693,12 +15375,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_59",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 12.680095,
     "y": -19.3000144,
@@ -16708,12 +15385,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_60",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 21.319905,
     "y": -15.4999204,
@@ -16723,12 +15395,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_61",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 12.680095,
     "y": -15.4999204,
@@ -16738,9 +15405,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_62",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 14.300107,
     "y": -15.2499844,
@@ -16750,9 +15415,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_63",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 15.500003,
     "y": -15.2499844,
@@ -16762,9 +15425,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_64",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 16.500001,
     "y": -15.2499844,
@@ -16774,9 +15435,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_65",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 17.499999,
     "y": -15.2499844,
@@ -16786,9 +15445,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_66",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 18.499997,
     "y": -15.2499844,
@@ -16798,9 +15455,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_67",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 19.699893,
     "y": -15.2499844,
@@ -16810,9 +15465,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_68",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.905,
     "y": -18.769108,
@@ -16822,9 +15475,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_69",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.635,
     "y": -18.769108,
@@ -16834,9 +15485,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_70",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.365,
     "y": -18.769108,
@@ -16846,9 +15495,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_71",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -5.095,
     "y": -18.769108,
@@ -16858,9 +15505,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_72",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -5.095,
     "y": -13.230892,
@@ -16870,9 +15515,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_73",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.365,
     "y": -13.230892,
@@ -16882,9 +15525,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_74",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.635,
     "y": -13.230892,
@@ -16894,9 +15535,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_75",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -8.905,
     "y": -13.230892,
@@ -16906,9 +15545,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_76",
     "pcb_component_id": "pcb_component_10",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7,
     "y": -16,
@@ -16918,9 +15555,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_77",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -15.500128,
@@ -16930,9 +15565,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_78",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "bottom"
-    ],
+    "layers": ["bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -15.500128,
@@ -16942,12 +15575,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_79",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -15.500128,
@@ -16957,9 +15585,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_80",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -15.500128,
@@ -16969,9 +15595,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_81",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "bottom"
-    ],
+    "layers": ["bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -15.500128,
@@ -16981,12 +15605,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_82",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -15.500128,
@@ -16996,9 +15615,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_83",
     "pcb_component_id": "pcb_component_8",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -16.500126,
@@ -17008,9 +15625,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_84",
     "pcb_component_id": "pcb_component_8",
-    "layers": [
-      "bottom"
-    ],
+    "layers": ["bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -16.500126,
@@ -17020,12 +15635,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_85",
     "pcb_component_id": "pcb_component_8",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -7.499872,
     "y": -16.500126,
@@ -17035,9 +15645,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_86",
     "pcb_component_id": "pcb_component_9",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -16.500126,
@@ -17047,9 +15655,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_87",
     "pcb_component_id": "pcb_component_9",
-    "layers": [
-      "bottom"
-    ],
+    "layers": ["bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -16.500126,
@@ -17059,12 +15665,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_88",
     "pcb_component_id": "pcb_component_9",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -6.499874,
     "y": -16.500126,
@@ -17074,9 +15675,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_89",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -23.165106,
     "y": -17.299970000000002,
@@ -17086,9 +15685,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_90",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -23.165106,
     "y": -15,
@@ -17098,9 +15695,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_91",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -23.165106,
     "y": -12.70003,
@@ -17110,9 +15705,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_92",
     "pcb_component_id": "pcb_component_11",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -28.834894,
     "y": -15,
@@ -17122,9 +15715,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_93",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -33.825,
     "y": -11.5,
@@ -17134,9 +15725,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_94",
     "pcb_component_id": "pcb_component_12",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -32.175,
     "y": -11.5,
@@ -17146,9 +15735,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_95",
     "pcb_component_id": "pcb_component_13",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -20.825,
     "y": -11.5,
@@ -17158,9 +15745,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_96",
     "pcb_component_id": "pcb_component_13",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -19.175,
     "y": -11.5,
@@ -17170,9 +15755,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_97",
     "pcb_component_id": "pcb_component_14",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -23.325,
     "y": 9.5,
@@ -17182,9 +15765,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_98",
     "pcb_component_id": "pcb_component_14",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -21.675,
     "y": 9.5,
@@ -17194,9 +15775,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_99",
     "pcb_component_id": "pcb_component_15",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -16.825,
     "y": -9.5,
@@ -17206,9 +15785,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_100",
     "pcb_component_id": "pcb_component_15",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -15.175,
     "y": -9.5,
@@ -17218,9 +15795,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_101",
     "pcb_component_id": "pcb_component_16",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -20.325,
     "y": -14.5,
@@ -17230,9 +15805,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_102",
     "pcb_component_id": "pcb_component_16",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -18.675,
     "y": -14.5,
@@ -17242,9 +15815,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_103",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -16.825,
     "y": -14.5,
@@ -17254,9 +15825,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_104",
     "pcb_component_id": "pcb_component_17",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -15.175,
     "y": -14.5,
@@ -17266,9 +15835,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_105",
     "pcb_component_id": "pcb_component_18",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -13.825,
     "y": -14.5,
@@ -17278,9 +15845,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_106",
     "pcb_component_id": "pcb_component_18",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.175,
     "y": -14.5,
@@ -17290,9 +15855,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_107",
     "pcb_component_id": "pcb_component_19",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 14.675,
     "y": -12.5,
@@ -17302,9 +15865,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_108",
     "pcb_component_id": "pcb_component_19",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 16.325,
     "y": -12.5,
@@ -17314,9 +15875,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_109",
     "pcb_component_id": "pcb_component_20",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 19.675,
     "y": -12.5,
@@ -17326,9 +15885,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_110",
     "pcb_component_id": "pcb_component_20",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 21.325,
     "y": -12.5,
@@ -17338,9 +15895,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_111",
     "pcb_component_id": "pcb_component_21",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -29.825,
     "y": 14,
@@ -17350,9 +15905,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_112",
     "pcb_component_id": "pcb_component_21",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -28.175,
     "y": 14,
@@ -17362,9 +15915,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_113",
     "pcb_component_id": "pcb_component_22",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -20.325,
     "y": -17.5,
@@ -17374,9 +15925,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_114",
     "pcb_component_id": "pcb_component_22",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -18.675,
     "y": -17.5,
@@ -17386,9 +15935,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_115",
     "pcb_component_id": "pcb_component_23",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -16.825,
     "y": -17.5,
@@ -17398,9 +15945,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_116",
     "pcb_component_id": "pcb_component_23",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -15.175,
     "y": -17.5,
@@ -17410,9 +15955,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_117",
     "pcb_component_id": "pcb_component_24",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -13.825,
     "y": -17.5,
@@ -17422,9 +15965,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_118",
     "pcb_component_id": "pcb_component_24",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -12.175,
     "y": -17.5,
@@ -17434,9 +15975,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_119",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -13.499628000000001,
     "y": 18,
@@ -17446,9 +15985,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_120",
     "pcb_component_id": "pcb_component_25",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -22.500372,
     "y": 18,
@@ -17458,9 +15995,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_121",
     "pcb_component_id": "pcb_component_26",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -27.45,
     "y": 9.9,
@@ -17470,9 +16005,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_122",
     "pcb_component_id": "pcb_component_26",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -25.55,
     "y": 9.9,
@@ -17482,9 +16015,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_123",
     "pcb_component_id": "pcb_component_26",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -26.5,
     "y": 12.1,
@@ -17494,9 +16025,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_124",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.5499020000000003,
     "y": -15.249941,
@@ -17506,9 +16035,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_125",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 8.549902,
     "y": -15.250195,
@@ -17518,9 +16045,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_126",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": -0.5499020000000003,
     "y": -19.750059,
@@ -17530,9 +16055,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_127",
     "pcb_component_id": "pcb_component_27",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_0",
     "x": 8.549902,
     "y": -19.750059,
@@ -23051,10 +21574,7 @@
     "y": -10.863592010475315,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23066,10 +21586,7 @@
     "y": -14.105,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23081,10 +21598,7 @@
     "y": 4.476,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23096,10 +21610,7 @@
     "y": -1.1604532427391347,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23111,10 +21622,7 @@
     "y": -2.979,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23126,10 +21634,7 @@
     "y": -16.894,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23141,10 +21646,7 @@
     "y": -12.886999999999999,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23156,10 +21658,7 @@
     "y": -18.148,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23171,10 +21670,7 @@
     "y": -17.989,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23186,10 +21682,7 @@
     "y": 6.743,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23201,10 +21694,7 @@
     "y": -2.831,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23216,10 +21706,7 @@
     "y": -13.916,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23231,10 +21718,7 @@
     "y": -10.430163339193486,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23246,10 +21730,7 @@
     "y": 8.212,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23261,10 +21742,7 @@
     "y": 7.307,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23276,10 +21754,7 @@
     "y": -7.546762164762581,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23291,10 +21766,7 @@
     "y": -9.124,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23306,10 +21778,7 @@
     "y": -9.544,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23321,10 +21790,7 @@
     "y": -10.854746138709256,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23336,10 +21802,7 @@
     "y": -12.131541323276858,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23351,10 +21814,7 @@
     "y": -15.575,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23366,10 +21826,7 @@
     "y": -5.617810428526369,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23381,10 +21838,7 @@
     "y": -0.5919090415684775,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23396,10 +21850,7 @@
     "y": -1.402,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23411,10 +21862,7 @@
     "y": -0.25,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23426,10 +21874,7 @@
     "y": 2.579,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23441,10 +21886,7 @@
     "y": 1.7335920809592265,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23456,10 +21898,7 @@
     "y": 9.40817574125429,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23471,10 +21910,7 @@
     "y": -3.412,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23486,10 +21922,7 @@
     "y": -15.063,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23501,10 +21934,7 @@
     "y": -18.795,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23516,10 +21946,7 @@
     "y": -12.777,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23531,10 +21958,7 @@
     "y": -12.806,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23546,10 +21970,7 @@
     "y": -12.251696701158712,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23561,10 +21982,7 @@
     "y": -12.061,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23576,10 +21994,7 @@
     "y": -11.151,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23591,10 +22006,7 @@
     "y": -8.465,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23606,10 +22018,7 @@
     "y": -12.367,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23621,10 +22030,7 @@
     "y": -8.447,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23636,10 +22042,7 @@
     "y": 10.513168054649965,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23651,10 +22054,7 @@
     "y": 13.218,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23666,10 +22066,7 @@
     "y": 8.169,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23681,10 +22078,7 @@
     "y": 14.863999999999999,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23696,10 +22090,7 @@
     "y": -13.359,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23711,10 +22102,7 @@
     "y": -9.38357772726763,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23726,10 +22114,7 @@
     "y": -15.318,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23741,10 +22126,7 @@
     "y": -10.401972750299874,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23756,10 +22138,7 @@
     "y": -11.456,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23771,10 +22150,7 @@
     "y": -10.997,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23786,10 +22162,7 @@
     "y": -9.857,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23801,10 +22174,7 @@
     "y": -8.378,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23816,10 +22186,7 @@
     "y": -9.822,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23831,10 +22198,7 @@
     "y": -8.994,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23846,10 +22210,7 @@
     "y": 8.493287231070603,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23861,10 +22222,7 @@
     "y": 3.077,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23876,10 +22234,7 @@
     "y": 8.909,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23891,10 +22246,7 @@
     "y": 8.02,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -23906,10 +22258,7 @@
     "y": 8.403,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -23921,10 +22270,7 @@
     "y": 12.343,
     "hole_diameter": 0.2,
     "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -24005,11 +22351,7 @@
     "warning_type": "source_component_pins_underspecified_warning",
     "message": "All pins on J_TEMP are underspecified (no pinAttributes set)",
     "source_component_id": "source_component_2",
-    "source_port_ids": [
-      "source_port_51",
-      "source_port_52",
-      "source_port_53"
-    ],
+    "source_port_ids": ["source_port_51", "source_port_52", "source_port_53"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24018,10 +22360,7 @@
     "warning_type": "source_component_pins_underspecified_warning",
     "message": "All pins on J_DOOR are underspecified (no pinAttributes set)",
     "source_component_id": "source_component_3",
-    "source_port_ids": [
-      "source_port_54",
-      "source_port_55"
-    ],
+    "source_port_ids": ["source_port_54", "source_port_55"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24030,10 +22369,7 @@
     "warning_type": "source_component_pins_underspecified_warning",
     "message": "All pins on J_PWR are underspecified (no pinAttributes set)",
     "source_component_id": "source_component_4",
-    "source_port_ids": [
-      "source_port_56",
-      "source_port_57"
-    ],
+    "source_port_ids": ["source_port_56", "source_port_57"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24101,10 +22437,7 @@
     "warning_type": "source_component_pins_underspecified_warning",
     "message": "All pins on BZ1 are underspecified (no pinAttributes set)",
     "source_component_id": "source_component_21",
-    "source_port_ids": [
-      "source_port_125",
-      "source_port_126"
-    ],
+    "source_port_ids": ["source_port_125", "source_port_126"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24211,11 +22544,7 @@
     "warning_type": "source_no_power_pin_defined_warning",
     "message": "J_TEMP has no pin with requires_power=true",
     "source_component_id": "source_component_2",
-    "source_port_ids": [
-      "source_port_51",
-      "source_port_52",
-      "source_port_53"
-    ],
+    "source_port_ids": ["source_port_51", "source_port_52", "source_port_53"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24224,10 +22553,7 @@
     "warning_type": "source_no_power_pin_defined_warning",
     "message": "J_DOOR has no pin with requires_power=true",
     "source_component_id": "source_component_3",
-    "source_port_ids": [
-      "source_port_54",
-      "source_port_55"
-    ],
+    "source_port_ids": ["source_port_54", "source_port_55"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24236,10 +22562,7 @@
     "warning_type": "source_no_power_pin_defined_warning",
     "message": "J_PWR has no pin with requires_power=true",
     "source_component_id": "source_component_4",
-    "source_port_ids": [
-      "source_port_56",
-      "source_port_57"
-    ],
+    "source_port_ids": ["source_port_56", "source_port_57"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24307,10 +22630,7 @@
     "warning_type": "source_no_power_pin_defined_warning",
     "message": "BZ1 has no pin with requires_power=true",
     "source_component_id": "source_component_21",
-    "source_port_ids": [
-      "source_port_125",
-      "source_port_126"
-    ],
+    "source_port_ids": ["source_port_125", "source_port_126"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24417,11 +22737,7 @@
     "warning_type": "source_no_ground_pin_defined_warning",
     "message": "J_TEMP has no pin with requires_ground=true",
     "source_component_id": "source_component_2",
-    "source_port_ids": [
-      "source_port_51",
-      "source_port_52",
-      "source_port_53"
-    ],
+    "source_port_ids": ["source_port_51", "source_port_52", "source_port_53"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24430,10 +22746,7 @@
     "warning_type": "source_no_ground_pin_defined_warning",
     "message": "J_DOOR has no pin with requires_ground=true",
     "source_component_id": "source_component_3",
-    "source_port_ids": [
-      "source_port_54",
-      "source_port_55"
-    ],
+    "source_port_ids": ["source_port_54", "source_port_55"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24442,10 +22755,7 @@
     "warning_type": "source_no_ground_pin_defined_warning",
     "message": "J_PWR has no pin with requires_ground=true",
     "source_component_id": "source_component_4",
-    "source_port_ids": [
-      "source_port_56",
-      "source_port_57"
-    ],
+    "source_port_ids": ["source_port_56", "source_port_57"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {
@@ -24513,10 +22823,7 @@
     "warning_type": "source_no_ground_pin_defined_warning",
     "message": "BZ1 has no pin with requires_ground=true",
     "source_component_id": "source_component_21",
-    "source_port_ids": [
-      "source_port_125",
-      "source_port_126"
-    ],
+    "source_port_ids": ["source_port_125", "source_port_126"],
     "subcircuit_id": "subcircuit_source_group_0"
   },
   {

--- a/tests/assets/alarmv2.json
+++ b/tests/assets/alarmv2.json
@@ -1,0 +1,24549 @@
+[
+  {
+    "type": "source_project_metadata",
+    "source_project_metadata_id": "source_project_metadata_0",
+    "software_used_string": "@tscircuit/core@0.0.1269"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "is_subcircuit": true,
+    "was_automatically_named": true,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "GND1",
+    "pin_number": 1,
+    "port_hints": [
+      "GND1",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "3V3",
+    "pin_number": 2,
+    "port_hints": [
+      "3V3",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "EN",
+    "pin_number": 3,
+    "port_hints": [
+      "EN",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "SENSOR_VP",
+    "pin_number": 4,
+    "port_hints": [
+      "SENSOR_VP",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "SENSOR_VN",
+    "pin_number": 5,
+    "port_hints": [
+      "SENSOR_VN",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "IO34",
+    "pin_number": 6,
+    "port_hints": [
+      "IO34",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "IO35",
+    "pin_number": 7,
+    "port_hints": [
+      "IO35",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "IO32",
+    "pin_number": 8,
+    "port_hints": [
+      "IO32",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "IO33",
+    "pin_number": 9,
+    "port_hints": [
+      "IO33",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "IO25",
+    "pin_number": 10,
+    "port_hints": [
+      "IO25",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "IO26",
+    "pin_number": 11,
+    "port_hints": [
+      "IO26",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "IO27",
+    "pin_number": 12,
+    "port_hints": [
+      "IO27",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "IO14",
+    "pin_number": 13,
+    "port_hints": [
+      "IO14",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "IO12",
+    "pin_number": 14,
+    "port_hints": [
+      "IO12",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "GND2",
+    "pin_number": 15,
+    "port_hints": [
+      "GND2",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "IO13",
+    "pin_number": 16,
+    "port_hints": [
+      "IO13",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "NC1",
+    "pin_number": 17,
+    "port_hints": [
+      "NC1",
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "NC2",
+    "pin_number": 18,
+    "port_hints": [
+      "NC2",
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "NC3",
+    "pin_number": 19,
+    "port_hints": [
+      "NC3",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "NC4",
+    "pin_number": 20,
+    "port_hints": [
+      "NC4",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "NC5",
+    "pin_number": 21,
+    "port_hints": [
+      "NC5",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "NC6",
+    "pin_number": 22,
+    "port_hints": [
+      "NC6",
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "IO15",
+    "pin_number": 23,
+    "port_hints": [
+      "IO15",
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "IO2",
+    "pin_number": 24,
+    "port_hints": [
+      "IO2",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "IO0",
+    "pin_number": 25,
+    "port_hints": [
+      "IO0",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "IO4",
+    "pin_number": 26,
+    "port_hints": [
+      "IO4",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "IO16",
+    "pin_number": 27,
+    "port_hints": [
+      "IO16",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "IO17",
+    "pin_number": 28,
+    "port_hints": [
+      "IO17",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "IO5",
+    "pin_number": 29,
+    "port_hints": [
+      "IO5",
+      "pin29",
+      "29"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "IO18",
+    "pin_number": 30,
+    "port_hints": [
+      "IO18",
+      "pin30",
+      "30"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "IO19",
+    "pin_number": 31,
+    "port_hints": [
+      "IO19",
+      "pin31",
+      "31"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "NC7",
+    "pin_number": 32,
+    "port_hints": [
+      "NC7",
+      "pin32",
+      "32"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "IO21",
+    "pin_number": 33,
+    "port_hints": [
+      "IO21",
+      "pin33",
+      "33"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "RXD0",
+    "pin_number": 34,
+    "port_hints": [
+      "RXD0",
+      "pin34",
+      "34"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "TXD0",
+    "pin_number": 35,
+    "port_hints": [
+      "TXD0",
+      "pin35",
+      "35"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "IO22",
+    "pin_number": 36,
+    "port_hints": [
+      "IO22",
+      "pin36",
+      "36"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "IO23",
+    "pin_number": 37,
+    "port_hints": [
+      "IO23",
+      "pin37",
+      "37"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "GND3",
+    "pin_number": 38,
+    "port_hints": [
+      "GND3",
+      "pin38",
+      "38"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "GND4",
+    "pin_number": 39,
+    "port_hints": [
+      "GND4",
+      "pin39",
+      "39"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "pin39_alt1",
+    "pin_number": 40,
+    "port_hints": [
+      "pin39_alt1",
+      "pin40",
+      "40"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "pin39_alt1",
+    "pin_number": 41,
+    "port_hints": [
+      "pin39_alt1",
+      "pin41",
+      "41"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "pin39_alt1",
+    "pin_number": 42,
+    "port_hints": [
+      "pin39_alt1",
+      "pin42",
+      "42"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "pin39_alt1",
+    "pin_number": 43,
+    "port_hints": [
+      "pin39_alt1",
+      "pin43",
+      "43"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "pin39_alt1",
+    "pin_number": 44,
+    "port_hints": [
+      "pin39_alt1",
+      "pin44",
+      "44"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin39_alt1",
+    "pin_number": 45,
+    "port_hints": [
+      "pin39_alt1",
+      "pin45",
+      "45"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin39_alt1",
+    "pin_number": 46,
+    "port_hints": [
+      "pin39_alt1",
+      "pin46",
+      "46"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin39_alt1",
+    "pin_number": 47,
+    "port_hints": [
+      "pin39_alt1",
+      "pin47",
+      "47"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "U1",
+    "manufacturer_part_number": "ESP32_WROOM_32E_N8",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C701342"
+      ]
+    },
+    "source_group_id": "source_group_0",
+    "internally_connected_source_port_ids": [
+      [
+        "source_port_39",
+        "source_port_40",
+        "source_port_41",
+        "source_port_42",
+        "source_port_43",
+        "source_port_44",
+        "source_port_45",
+        "source_port_46"
+      ]
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "GND",
+    "pin_number": 1,
+    "port_hints": [
+      "GND",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "VCC",
+    "pin_number": 2,
+    "port_hints": [
+      "VCC",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "SCL",
+    "pin_number": 3,
+    "port_hints": [
+      "SCL",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "SDA",
+    "pin_number": 4,
+    "port_hints": [
+      "SDA",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_chip",
+    "name": "OLED1",
+    "manufacturer_part_number": "SSD1306 0.96in OLED",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C152912"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_chip",
+    "name": "J_TEMP",
+    "manufacturer_part_number": "ZX_XH2_54_3PZZ",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C7429633"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_chip",
+    "name": "J_DOOR",
+    "manufacturer_part_number": "ZX_XH2_54_2PWZ",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C7429641"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "ftype": "simple_chip",
+    "name": "J_PWR",
+    "manufacturer_part_number": "WJ2EDGRC_5_08_02P_14_00A",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C3697"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "EH1",
+    "pin_number": 7,
+    "port_hints": [
+      "EH1",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin7_alt1",
+    "pin_number": 8,
+    "port_hints": [
+      "pin7_alt1",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "pin7_alt1",
+    "pin_number": 9,
+    "port_hints": [
+      "pin7_alt1",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "pin7_alt1",
+    "pin_number": 10,
+    "port_hints": [
+      "pin7_alt1",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "B12",
+    "pin_number": 11,
+    "port_hints": [
+      "B12",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "B9",
+    "pin_number": 12,
+    "port_hints": [
+      "B9",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "A5",
+    "pin_number": 13,
+    "port_hints": [
+      "A5",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "B5",
+    "pin_number": 14,
+    "port_hints": [
+      "B5",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "A9",
+    "pin_number": 15,
+    "port_hints": [
+      "A9",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "A12",
+    "pin_number": 16,
+    "port_hints": [
+      "A12",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_chip",
+    "name": "J_USB",
+    "manufacturer_part_number": "TYPE_C_6P",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C456012"
+      ]
+    },
+    "source_group_id": "source_group_0",
+    "internally_connected_source_port_ids": [
+      [
+        "source_port_59",
+        "source_port_60",
+        "source_port_61"
+      ]
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "SW",
+    "pin_number": 1,
+    "port_hints": [
+      "SW",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "EN",
+    "pin_number": 2,
+    "port_hints": [
+      "EN",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "COMP",
+    "pin_number": 3,
+    "port_hints": [
+      "COMP",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "FB",
+    "pin_number": 4,
+    "port_hints": [
+      "FB",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "GND",
+    "pin_number": 5,
+    "port_hints": [
+      "GND",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "FREQ",
+    "pin_number": 6,
+    "port_hints": [
+      "FREQ",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "VIN",
+    "pin_number": 7,
+    "port_hints": [
+      "VIN",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "BST",
+    "pin_number": 8,
+    "port_hints": [
+      "BST",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "EP",
+    "pin_number": 9,
+    "port_hints": [
+      "EP",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "top",
+    "port_hints": [
+      "top"
+    ],
+    "source_component_id": "source_manually_placed_via_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "bottom",
+    "port_hints": [
+      "bottom"
+    ],
+    "source_component_id": "source_manually_placed_via_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "pin1",
+    "port_hints": [
+      "pin1"
+    ],
+    "source_component_id": "source_manually_placed_via_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_manually_placed_via",
+    "source_manually_placed_via_id": "source_manually_placed_via_0",
+    "source_group_id": "source_group_0",
+    "source_net_id": "",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "top",
+    "port_hints": [
+      "top"
+    ],
+    "source_component_id": "source_manually_placed_via_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "bottom",
+    "port_hints": [
+      "bottom"
+    ],
+    "source_component_id": "source_manually_placed_via_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "pin1",
+    "port_hints": [
+      "pin1"
+    ],
+    "source_component_id": "source_manually_placed_via_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_manually_placed_via",
+    "source_manually_placed_via_id": "source_manually_placed_via_1",
+    "source_group_id": "source_group_0",
+    "source_net_id": "",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "top",
+    "port_hints": [
+      "top"
+    ],
+    "source_component_id": "source_manually_placed_via_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "bottom",
+    "port_hints": [
+      "bottom"
+    ],
+    "source_component_id": "source_manually_placed_via_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "pin1",
+    "port_hints": [
+      "pin1"
+    ],
+    "source_component_id": "source_manually_placed_via_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_manually_placed_via",
+    "source_manually_placed_via_id": "source_manually_placed_via_2",
+    "source_group_id": "source_group_0",
+    "source_net_id": "",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "top",
+    "port_hints": [
+      "top"
+    ],
+    "source_component_id": "source_manually_placed_via_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "bottom",
+    "port_hints": [
+      "bottom"
+    ],
+    "source_component_id": "source_manually_placed_via_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_94",
+    "name": "pin1",
+    "port_hints": [
+      "pin1"
+    ],
+    "source_component_id": "source_manually_placed_via_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_manually_placed_via",
+    "source_manually_placed_via_id": "source_manually_placed_via_3",
+    "source_group_id": "source_group_0",
+    "source_net_id": "",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_chip",
+    "name": "U2",
+    "manufacturer_part_number": "MP1584EN_LF_Z",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C15051"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_95",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_96",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_97",
+    "name": "VIN",
+    "pin_number": 3,
+    "port_hints": [
+      "VIN",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_98",
+    "name": "TAB",
+    "pin_number": 4,
+    "port_hints": [
+      "TAB",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "ftype": "simple_chip",
+    "name": "U3",
+    "manufacturer_part_number": "AMS1117_3_3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C347222"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_99",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_100",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_8",
+    "ftype": "simple_capacitor",
+    "name": "C1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C14663"
+      ]
+    },
+    "capacitance": 0.00001,
+    "display_capacitance": "10uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_101",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_102",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_9",
+    "ftype": "simple_capacitor",
+    "name": "C2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C14663"
+      ]
+    },
+    "capacitance": 0.00001,
+    "display_capacitance": "10uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_103",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_104",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_10",
+    "ftype": "simple_resistor",
+    "name": "R1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_105",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_106",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_11",
+    "ftype": "simple_resistor",
+    "name": "R2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_107",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_108",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_12",
+    "ftype": "simple_resistor",
+    "name": "R3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "resistance": 220,
+    "display_resistance": "220Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_109",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_110",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_13",
+    "ftype": "simple_resistor",
+    "name": "R4",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "resistance": 220,
+    "display_resistance": "220Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_111",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_112",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_14",
+    "ftype": "simple_resistor",
+    "name": "R5",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "resistance": 220,
+    "display_resistance": "220Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_113",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_114",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_15",
+    "ftype": "simple_resistor",
+    "name": "R6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25803",
+        "C2906980",
+        "C14675"
+      ]
+    },
+    "resistance": 100000,
+    "display_resistance": "100kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_115",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_116",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_16",
+    "ftype": "simple_resistor",
+    "name": "R7",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C22967",
+        "C114614",
+        "C116691"
+      ]
+    },
+    "resistance": 27000,
+    "display_resistance": "27kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_117",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_118",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_17",
+    "ftype": "simple_resistor",
+    "name": "R8",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C21190",
+        "C2907002",
+        "C2907113"
+      ]
+    },
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_119",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_120",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_18",
+    "ftype": "simple_led",
+    "name": "LED_TEMP",
+    "color": "red",
+    "symbol_display_value": "red",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_121",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_122",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_19",
+    "ftype": "simple_led",
+    "name": "LED_DOOR",
+    "color": "yellow",
+    "symbol_display_value": "yellow",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_123",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_124",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_20",
+    "ftype": "simple_led",
+    "name": "LED_PWR",
+    "color": "green",
+    "symbol_display_value": "green",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804"
+      ]
+    },
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_125",
+    "name": "_POS",
+    "pin_number": 1,
+    "port_hints": [
+      "_POS",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_126",
+    "name": "_NEG",
+    "pin_number": 2,
+    "port_hints": [
+      "_NEG",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net14"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_21",
+    "ftype": "simple_chip",
+    "name": "BZ1",
+    "manufacturer_part_number": "YS_SBZ9650DYB05",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C409830"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_127",
+    "name": "BASE",
+    "pin_number": 1,
+    "port_hints": [
+      "BASE",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_128",
+    "name": "EMITTER",
+    "pin_number": 2,
+    "port_hints": [
+      "EMITTER",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_129",
+    "name": "COLLECTOR",
+    "pin_number": 3,
+    "port_hints": [
+      "COLLECTOR",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net14"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_22",
+    "ftype": "simple_chip",
+    "name": "Q1",
+    "manufacturer_part_number": "S8050",
+    "supplier_part_numbers": {},
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_130",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_131",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_132",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_133",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_23",
+    "ftype": "simple_chip",
+    "name": "SW1",
+    "manufacturer_part_number": "KH_6X6X5H_STM",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C2837531"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_0",
+    "name": "V12_IN",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_1",
+    "name": "GND",
+    "member_source_group_ids": [],
+    "is_ground": true,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_2",
+    "name": "V5",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_3",
+    "name": "V3_3",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_board",
+    "source_board_id": "source_board_0",
+    "source_group_id": "source_group_0",
+    "title": "Freezer / Fridge Alarm"
+  },
+  {
+    "type": "source_component_internal_connection",
+    "source_component_internal_connection_id": "source_component_internal_connection_0",
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_port_ids": [
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46"
+    ]
+  },
+  {
+    "type": "source_component_internal_connection",
+    "source_component_internal_connection_id": "source_component_internal_connection_1",
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_port_ids": [
+      "source_port_59",
+      "source_port_60",
+      "source_port_61"
+    ]
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": [
+      "source_port_56"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_PWR.pin1 to net.V12_IN",
+    "min_trace_thickness": 0.45,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": [
+      "source_port_57"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_PWR.pin2 to net.GND",
+    "min_trace_thickness": 0.5,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": [
+      "source_port_66"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_USB.A9 to net.V5",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": [
+      "source_port_63"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_USB.B9 to net.V5",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": [
+      "source_port_67"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_USB.A12 to net.GND",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": [
+      "source_port_62"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_USB.B12 to net.GND",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": [
+      "source_port_58"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_USB.EH1 to net.GND",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": [
+      "source_port_80"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.VIN to net.V12_IN",
+    "min_trace_thickness": 0.45,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": [
+      "source_port_78"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.GND to net.GND",
+    "min_trace_thickness": 0.45,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": [
+      "source_port_82"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.EP to net.GND",
+    "min_trace_thickness": 0.45,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": [
+      "source_port_74"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.SW to net.V5",
+    "min_trace_thickness": 0.45,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": [
+      "source_port_77"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.FB to net.V5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": [
+      "source_port_75"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U2.EN to net.V12_IN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": [
+      "source_port_97"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U3.VIN to net.V5",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": [
+      "source_port_95"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U3.pin1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": [
+      "source_port_96"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U3.pin2 to net.V3_3",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": [
+      "source_port_98"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U3.TAB to net.V3_3",
+    "min_trace_thickness": 0.4,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": [
+      "source_port_99"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": null,
+    "display_name": "C1.pin1 to net.V5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": [
+      "source_port_100"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": null,
+    "display_name": "C1.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": [
+      "source_port_101"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": null,
+    "display_name": "C2.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": [
+      "source_port_102"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": null,
+    "display_name": "C2.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": [
+      "source_port_1"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.3V3 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": [
+      "source_port_0"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.GND1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_23",
+    "connected_source_port_ids": [
+      "source_port_14"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.GND2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_24",
+    "connected_source_port_ids": [
+      "source_port_37"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.GND3 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_25",
+    "connected_source_port_ids": [
+      "source_port_38"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.GND4 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_26",
+    "connected_source_port_ids": [
+      "source_port_2"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.EN to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_27",
+    "connected_source_port_ids": [
+      "source_port_48"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "OLED1.VCC to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_28",
+    "connected_source_port_ids": [
+      "source_port_47"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "OLED1.GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_29",
+    "connected_source_port_ids": [
+      "source_port_50",
+      "source_port_32"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "OLED1.SDA to U1.IO21",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_30",
+    "connected_source_port_ids": [
+      "source_port_49",
+      "source_port_35"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "OLED1.SCL to U1.IO22",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_31",
+    "connected_source_port_ids": [
+      "source_port_53"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_TEMP.pin3 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_32",
+    "connected_source_port_ids": [
+      "source_port_51"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_TEMP.pin1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_33",
+    "connected_source_port_ids": [
+      "source_port_52",
+      "source_port_7"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_TEMP.pin2 to U1.IO32",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_34",
+    "connected_source_port_ids": [
+      "source_port_103"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R1.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_35",
+    "connected_source_port_ids": [
+      "source_port_104",
+      "source_port_52"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R1.pin2 to J_TEMP.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_36",
+    "connected_source_port_ids": [
+      "source_port_55"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_DOOR.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_37",
+    "connected_source_port_ids": [
+      "source_port_54",
+      "source_port_8"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J_DOOR.pin1 to U1.IO33",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_38",
+    "connected_source_port_ids": [
+      "source_port_105"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R2.pin1 to net.V3_3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_39",
+    "connected_source_port_ids": [
+      "source_port_106",
+      "source_port_54"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R2.pin2 to J_DOOR.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_40",
+    "connected_source_port_ids": [
+      "source_port_10",
+      "source_port_107"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.IO26 to R3.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_41",
+    "connected_source_port_ids": [
+      "source_port_108",
+      "source_port_119"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R3.pin2 to LED_TEMP.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_42",
+    "connected_source_port_ids": [
+      "source_port_120"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "LED_TEMP.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_43",
+    "connected_source_port_ids": [
+      "source_port_11",
+      "source_port_109"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.IO27 to R4.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net10"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_44",
+    "connected_source_port_ids": [
+      "source_port_110",
+      "source_port_121"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R4.pin2 to LED_DOOR.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_45",
+    "connected_source_port_ids": [
+      "source_port_122"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "LED_DOOR.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_46",
+    "connected_source_port_ids": [
+      "source_port_12",
+      "source_port_111"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.IO14 to R5.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_47",
+    "connected_source_port_ids": [
+      "source_port_112",
+      "source_port_123"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R5.pin2 to LED_PWR.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_48",
+    "connected_source_port_ids": [
+      "source_port_124"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "LED_PWR.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_49",
+    "connected_source_port_ids": [
+      "source_port_125"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "BZ1._POS to net.V5",
+    "min_trace_thickness": 0.35,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_50",
+    "connected_source_port_ids": [
+      "source_port_126",
+      "source_port_129"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "BZ1._NEG to Q1.COLLECTOR",
+    "min_trace_thickness": 0.35,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net14"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_51",
+    "connected_source_port_ids": [
+      "source_port_128"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q1.EMITTER to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_52",
+    "connected_source_port_ids": [
+      "source_port_9",
+      "source_port_117"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U1.IO25 to R8.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net15"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_53",
+    "connected_source_port_ids": [
+      "source_port_118",
+      "source_port_127"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R8.pin2 to Q1.BASE",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_54",
+    "connected_source_port_ids": [
+      "source_port_130",
+      "source_port_15"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "SW1.pin1 to U1.IO13",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_55",
+    "connected_source_port_ids": [
+      "source_port_132",
+      "source_port_15"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "SW1.pin3 to U1.IO13",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net17"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_56",
+    "connected_source_port_ids": [
+      "source_port_131"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "SW1.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_57",
+    "connected_source_port_ids": [
+      "source_port_133"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "SW1.pin4 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_58",
+    "connected_source_port_ids": [
+      "source_port_113"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R6.pin1 to net.V12_IN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_59",
+    "connected_source_port_ids": [
+      "source_port_114",
+      "source_port_5"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R6.pin2 to U1.IO34",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_60",
+    "connected_source_port_ids": [
+      "source_port_115",
+      "source_port_5"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R7.pin1 to U1.IO34",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net18"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_61",
+    "connected_source_port_ids": [
+      "source_port_116"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R7.pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 5.000000000000002
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "GND1",
+      "pin2": "3V3",
+      "pin3": "EN",
+      "pin4": "SENSOR_VP",
+      "pin5": "SENSOR_VN",
+      "pin6": "IO34",
+      "pin7": "IO35",
+      "pin8": "IO32",
+      "pin9": "IO33",
+      "pin10": "IO25",
+      "pin11": "IO26",
+      "pin12": "IO27",
+      "pin13": "IO14",
+      "pin14": "IO12",
+      "pin15": "GND2",
+      "pin16": "IO13",
+      "pin17": "NC1",
+      "pin18": "NC2",
+      "pin19": "NC3",
+      "pin20": "NC4",
+      "pin21": "NC5",
+      "pin22": "NC6",
+      "pin23": "IO15",
+      "pin24": "IO2",
+      "pin25": "IO0",
+      "pin26": "IO4",
+      "pin27": "IO16",
+      "pin28": "IO17",
+      "pin29": "IO5",
+      "pin30": "IO18",
+      "pin31": "IO19",
+      "pin32": "NC7",
+      "pin33": "IO21",
+      "pin34": "RXD0",
+      "pin35": "TXD0",
+      "pin36": "IO22",
+      "pin37": "IO23",
+      "pin38": "GND3",
+      "pin39": "GND4",
+      "pin40": "pin39_alt1",
+      "pin41": "pin39_alt1",
+      "pin42": "pin39_alt1",
+      "pin43": "pin39_alt1",
+      "pin44": "pin39_alt1",
+      "pin45": "pin39_alt1",
+      "pin46": "pin39_alt1",
+      "pin47": "pin39_alt1"
+    },
+    "source_component_id": "source_component_0",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "ESP32_WROOM_32E_N8",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -2.630000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "U1",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": 2.630000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 7,
+      "y": 2
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.4000000000000001,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "GND",
+      "pin2": "VCC",
+      "pin3": "SCL",
+      "pin4": "SDA"
+    },
+    "source_component_id": "source_component_1",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "SSD1306 0.96in OLED",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 6.3,
+      "y": 1.5699999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "OLED1",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 6.3,
+      "y": 2.4299999999999997
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -7,
+      "y": 2
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "pin3"
+    },
+    "source_component_id": "source_component_2",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "text": "ZX_XH2_54_3PZZ",
+    "schematic_component_id": "schematic_component_2",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": 1.5699999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "text": "J_TEMP",
+    "schematic_component_id": "schematic_component_2",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": 2.4299999999999997
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -7,
+      "y": -1
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2"
+    },
+    "source_component_id": "source_component_3",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "text": "ZX_XH2_54_2PWZ",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -1.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "text": "J_DOOR",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -0.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -7,
+      "y": -5
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2"
+    },
+    "source_component_id": "source_component_4",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_8",
+    "text": "WJ2EDGRC_5_08_02P_14_00A",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -5.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_9",
+    "text": "J_PWR",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -4.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -7,
+      "y": -7
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.2000000000000002
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin7": "EH1",
+      "pin8": "pin7_alt1",
+      "pin9": "pin7_alt1",
+      "pin10": "pin7_alt1",
+      "pin11": "B12",
+      "pin12": "B9",
+      "pin13": "A5",
+      "pin14": "B5",
+      "pin15": "A9",
+      "pin16": "A12"
+    },
+    "source_component_id": "source_component_5",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_10",
+    "text": "TYPE_C_6P",
+    "schematic_component_id": "schematic_component_5",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -7.7299999999999995
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_11",
+    "text": "J_USB",
+    "schematic_component_id": "schematic_component_5",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.6,
+      "y": -6.2700000000000005
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -3,
+      "y": -6
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.2000000000000002
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "SW",
+      "pin2": "EN",
+      "pin3": "COMP",
+      "pin4": "FB",
+      "pin5": "GND",
+      "pin6": "FREQ",
+      "pin7": "VIN",
+      "pin8": "BST",
+      "pin9": "EP"
+    },
+    "source_component_id": "source_component_6",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_12",
+    "text": "MP1584EN_LF_Z",
+    "schematic_component_id": "schematic_component_6",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.6,
+      "y": -6.7299999999999995
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_13",
+    "text": "U2",
+    "schematic_component_id": "schematic_component_6",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.6,
+      "y": -5.2700000000000005
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 0,
+      "y": -6
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "VIN",
+      "pin4": "TAB"
+    },
+    "source_component_id": "source_component_7",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_14",
+    "text": "AMS1117_3_3",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -6.43
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_15",
+    "text": "U3",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -5.57
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 1.5,
+      "y": -7.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_8",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "10uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 2.5,
+      "y": -7.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_9",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "10uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -4.5,
+      "y": 2
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_10",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -4.5,
+      "y": -1
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_11",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 3.5,
+      "y": -1.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_12",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "220Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 3.5,
+      "y": -2.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_13",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "220Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 3.5,
+      "y": -3.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_14",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "220Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -3.5,
+      "y": -4.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_15",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": -2.5,
+      "y": -4.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_16",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "27kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 3.5,
+      "y": 2.5
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_17",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 5,
+      "y": -1.5
+    },
+    "size": {
+      "width": 1.13,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_18",
+    "is_box_with_pins": true,
+    "symbol_name": "led_right",
+    "symbol_display_value": "red",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 5,
+      "y": -2.5
+    },
+    "size": {
+      "width": 1.13,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_19",
+    "is_box_with_pins": true,
+    "symbol_name": "led_right",
+    "symbol_display_value": "yellow",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 5,
+      "y": -3.5
+    },
+    "size": {
+      "width": 1.13,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_20",
+    "is_box_with_pins": true,
+    "symbol_name": "led_right",
+    "symbol_display_value": "green",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 7,
+      "y": 5
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "_POS",
+      "pin2": "_NEG"
+    },
+    "source_component_id": "source_component_21",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_16",
+    "text": "YS_SBZ9650DYB05",
+    "schematic_component_id": "schematic_component_21",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 6.4,
+      "y": 4.67
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_17",
+    "text": "BZ1",
+    "schematic_component_id": "schematic_component_21",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 6.4,
+      "y": 5.33
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 5,
+      "y": 4
+    },
+    "rotation": 0,
+    "size": {
+      "width": 2,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "BASE",
+      "pin2": "EMITTER",
+      "pin3": "COLLECTOR"
+    },
+    "source_component_id": "source_component_22",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_18",
+    "text": "S8050",
+    "schematic_component_id": "schematic_component_22",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 4,
+      "y": 3.5700000000000003
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_19",
+    "text": "Q1",
+    "schematic_component_id": "schematic_component_22",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 4,
+      "y": 4.43
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -4,
+      "y": -2.5
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "pin3",
+      "pin4": "pin4"
+    },
+    "source_component_id": "source_component_23",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_20",
+    "text": "KH_6X6X5H_STM",
+    "schematic_component_id": "schematic_component_23",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -4.6,
+      "y": -2.9299999999999997
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_21",
+    "text": "SW1",
+    "schematic_component_id": "schematic_component_23",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -4.6,
+      "y": -2.0700000000000003
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "name": "unnamed_board1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 2.3000000000000007
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "GND1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 2.1000000000000005
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 1.9000000000000008
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "EN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 1.7000000000000006
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SENSOR_VP",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 1.5000000000000007
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "SENSOR_VN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 1.3000000000000007
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "IO34",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 1.1000000000000008
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "IO35",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.9000000000000008
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "IO32",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.7000000000000008
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "IO33",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.5000000000000009
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "IO25",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.30000000000000093
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "display_pin_label": "IO26",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.10000000000000098
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "display_pin_label": "IO27",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.0999999999999992
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "IO14",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.2999999999999994
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "IO12",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.49999999999999956
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "GND2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.6999999999999997
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "IO13",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.8999999999999999
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 17,
+    "true_ccw_index": 16,
+    "display_pin_label": "NC1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -1.1
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 18,
+    "true_ccw_index": 17,
+    "display_pin_label": "NC2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -1.3000000000000003
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 19,
+    "true_ccw_index": 18,
+    "display_pin_label": "NC3",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -1.5000000000000004
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 20,
+    "true_ccw_index": 19,
+    "display_pin_label": "NC4",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -1.7000000000000002
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 21,
+    "true_ccw_index": 20,
+    "display_pin_label": "NC5",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -1.9000000000000004
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 22,
+    "true_ccw_index": 21,
+    "display_pin_label": "NC6",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -2.1000000000000005
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 23,
+    "true_ccw_index": 22,
+    "display_pin_label": "IO15",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -2.3000000000000007
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 24,
+    "true_ccw_index": 23,
+    "display_pin_label": "IO2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -2.2000000000000006
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 25,
+    "true_ccw_index": 24,
+    "display_pin_label": "IO0",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -2.0000000000000004
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 26,
+    "true_ccw_index": 25,
+    "display_pin_label": "IO4",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -1.8000000000000007
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 27,
+    "true_ccw_index": 26,
+    "display_pin_label": "IO16",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -1.6000000000000005
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 28,
+    "true_ccw_index": 27,
+    "display_pin_label": "IO17",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -1.4000000000000006
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 29,
+    "true_ccw_index": 28,
+    "display_pin_label": "IO5",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -1.2000000000000006
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 30,
+    "true_ccw_index": 29,
+    "display_pin_label": "IO18",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -1.0000000000000007
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 31,
+    "true_ccw_index": 30,
+    "display_pin_label": "IO19",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.8000000000000007
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 32,
+    "true_ccw_index": 31,
+    "display_pin_label": "NC7",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.6000000000000008
+    },
+    "source_port_id": "source_port_32",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 33,
+    "true_ccw_index": 32,
+    "display_pin_label": "IO21",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.4000000000000008
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 34,
+    "true_ccw_index": 33,
+    "display_pin_label": "RXD0",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.20000000000000084
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 35,
+    "true_ccw_index": 34,
+    "display_pin_label": "TXD0",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -8.881784197001252e-16
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 36,
+    "true_ccw_index": 35,
+    "display_pin_label": "IO22",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.1999999999999993
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 37,
+    "true_ccw_index": 36,
+    "display_pin_label": "IO23",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.39999999999999947
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 38,
+    "true_ccw_index": 37,
+    "display_pin_label": "GND3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.5999999999999996
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 39,
+    "true_ccw_index": 38,
+    "display_pin_label": "GND4",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.7999999999999998
+    },
+    "source_port_id": "source_port_39",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 40,
+    "true_ccw_index": 39,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 1
+    },
+    "source_port_id": "source_port_40",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 41,
+    "true_ccw_index": 40,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 1.2000000000000002
+    },
+    "source_port_id": "source_port_41",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 42,
+    "true_ccw_index": 41,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 1.4000000000000004
+    },
+    "source_port_id": "source_port_42",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 43,
+    "true_ccw_index": 42,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 1.6000000000000005
+    },
+    "source_port_id": "source_port_43",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 44,
+    "true_ccw_index": 43,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 1.8000000000000003
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 45,
+    "true_ccw_index": 44,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 2.0000000000000004
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 46,
+    "true_ccw_index": 45,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 2.2000000000000006
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 47,
+    "true_ccw_index": 46,
+    "display_pin_label": "pin39_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 5.9,
+      "y": 2.1
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 5.9,
+      "y": 1.9
+    },
+    "source_port_id": "source_port_48",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "VCC",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 8.1,
+      "y": 1.9
+    },
+    "source_port_id": "source_port_49",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "SCL",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 8.1,
+      "y": 2.1
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SDA",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -8,
+      "y": 2.1
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -8,
+      "y": 1.9
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -6,
+      "y": 2
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -8,
+      "y": -1
+    },
+    "source_port_id": "source_port_54",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -6,
+      "y": -1
+    },
+    "source_port_id": "source_port_55",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -8,
+      "y": -5
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -6,
+      "y": -5
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -6,
+      "y": -7.2
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "EH1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -6,
+      "y": -7
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "pin7_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -6,
+      "y": -6.8
+    },
+    "source_port_id": "source_port_60",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "pin7_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -6,
+      "y": -6.6
+    },
+    "source_port_id": "source_port_61",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "pin7_alt1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -8,
+      "y": -6.6
+    },
+    "source_port_id": "source_port_68",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -8,
+      "y": -6.8
+    },
+    "source_port_id": "source_port_69",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_64",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -8,
+      "y": -7
+    },
+    "source_port_id": "source_port_70",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_65",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -8,
+      "y": -7.2
+    },
+    "source_port_id": "source_port_71",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_66",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -8,
+      "y": -7.4
+    },
+    "source_port_id": "source_port_72",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_67",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -6,
+      "y": -7.4
+    },
+    "source_port_id": "source_port_73",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_68",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": -5.6
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "SW",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_69",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": -5.8
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_70",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": -6
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "COMP",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_71",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": -6.2
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "FB",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_72",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -4,
+      "y": -6.4
+    },
+    "source_port_id": "source_port_78",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_73",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -2,
+      "y": -6.3
+    },
+    "source_port_id": "source_port_79",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "FREQ",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_74",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -2,
+      "y": -6.1
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VIN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_75",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -2,
+      "y": -5.9
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "BST",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_76",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -2,
+      "y": -5.7
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "EP",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_77",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -1,
+      "y": -5.9
+    },
+    "source_port_id": "source_port_95",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_78",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": -1,
+      "y": -6.1
+    },
+    "source_port_id": "source_port_96",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_79",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1,
+      "y": -6.1
+    },
+    "source_port_id": "source_port_97",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "VIN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_80",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1,
+      "y": -5.9
+    },
+    "source_port_id": "source_port_98",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "TAB",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_81",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 0.95,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_99",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_82",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2.05,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_100",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_83",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 1.95,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_101",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_84",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 3.05,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_102",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_85",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -5.05,
+      "y": 2
+    },
+    "source_port_id": "source_port_103",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_86",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": -3.9499999999999997,
+      "y": 2
+    },
+    "source_port_id": "source_port_104",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_87",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -5.05,
+      "y": -1
+    },
+    "source_port_id": "source_port_105",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_88",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": -3.9499999999999997,
+      "y": -1
+    },
+    "source_port_id": "source_port_106",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_89",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 2.95,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_107",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_90",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 4.05,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_108",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_91",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 2.95,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_109",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_92",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 4.05,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_110",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_93",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 2.95,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_111",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_94",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 4.05,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_112",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_95",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -4.05,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_113",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_96",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -2.95,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_114",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_97",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": -3.05,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_115",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_98",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": -1.9500000000000002,
+      "y": -4.5
+    },
+    "source_port_id": "source_port_116",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_99",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 2.95,
+      "y": 2.5
+    },
+    "source_port_id": "source_port_117",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_100",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 4.05,
+      "y": 2.5
+    },
+    "source_port_id": "source_port_118",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_101",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 4.46,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_119",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_102",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 5.54,
+      "y": -1.5
+    },
+    "source_port_id": "source_port_120",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_103",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 4.46,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_121",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_104",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 5.54,
+      "y": -2.5
+    },
+    "source_port_id": "source_port_122",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_105",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 4.46,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_123",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_106",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 5.54,
+      "y": -3.5
+    },
+    "source_port_id": "source_port_124",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_107",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 6,
+      "y": 5
+    },
+    "source_port_id": "source_port_125",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "_POS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_108",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 8,
+      "y": 5
+    },
+    "source_port_id": "source_port_126",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "_NEG",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_109",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 3.6,
+      "y": 4.1
+    },
+    "source_port_id": "source_port_127",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "BASE",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_110",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 3.6,
+      "y": 3.9
+    },
+    "source_port_id": "source_port_128",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EMITTER",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_111",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": 6.4,
+      "y": 4
+    },
+    "source_port_id": "source_port_129",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "COLLECTOR",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_112",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -5,
+      "y": -2.4
+    },
+    "source_port_id": "source_port_130",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_113",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -5,
+      "y": -2.6
+    },
+    "source_port_id": "source_port_131",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_114",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -3,
+      "y": -2.6
+    },
+    "source_port_id": "source_port_132",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_115",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -3,
+      "y": -2.4
+    },
+    "source_port_id": "source_port_133",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "R3.2-LED_TEMP.1",
+    "edges": [
+      {
+        "from": {
+          "x": 4.05,
+          "y": -1.5
+        },
+        "to": {
+          "x": 4.4350000000000005,
+          "y": -1.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "R4.2-LED_DOOR.1",
+    "edges": [
+      {
+        "from": {
+          "x": 4.05,
+          "y": -2.5
+        },
+        "to": {
+          "x": 4.4350000000000005,
+          "y": -2.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net11"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "R5.2-LED_PWR.1",
+    "edges": [
+      {
+        "from": {
+          "x": 4.05,
+          "y": -3.5
+        },
+        "to": {
+          "x": 4.4350000000000005,
+          "y": -3.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net13"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_3",
+    "source_trace_id": "J_USB.7-J_PWR.2",
+    "edges": [
+      {
+        "from": {
+          "x": -6,
+          "y": -7.2
+        },
+        "to": {
+          "x": -5.8,
+          "y": -7.2
+        }
+      },
+      {
+        "from": {
+          "x": -5.8,
+          "y": -7.2
+        },
+        "to": {
+          "x": -5.8,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": -5.8,
+          "y": -5
+        },
+        "to": {
+          "x": -6,
+          "y": -5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_4",
+    "source_trace_id": "LED_PWR.2-LED_DOOR.2",
+    "edges": [
+      {
+        "from": {
+          "x": 5.5649999999999995,
+          "y": -3.5
+        },
+        "to": {
+          "x": 5.765,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": 5.765,
+          "y": -3.5
+        },
+        "to": {
+          "x": 5.765,
+          "y": -2.5
+        }
+      },
+      {
+        "from": {
+          "x": 5.765,
+          "y": -2.5
+        },
+        "to": {
+          "x": 5.5649999999999995,
+          "y": -2.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.765,
+        "y": -2.5
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_5",
+    "source_trace_id": "LED_TEMP.2-LED_DOOR.2",
+    "edges": [
+      {
+        "from": {
+          "x": 5.5649999999999995,
+          "y": -1.5
+        },
+        "to": {
+          "x": 5.765,
+          "y": -1.5
+        }
+      },
+      {
+        "from": {
+          "x": 5.765,
+          "y": -1.5
+        },
+        "to": {
+          "x": 5.765,
+          "y": -2.5
+        }
+      },
+      {
+        "from": {
+          "x": 5.765,
+          "y": -2.5
+        },
+        "to": {
+          "x": 5.5649999999999995,
+          "y": -2.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.765,
+        "y": -2.5
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_6",
+    "source_trace_id": "U3.1-U2.9",
+    "edges": [
+      {
+        "from": {
+          "x": -1,
+          "y": -5.9
+        },
+        "to": {
+          "x": -1.5,
+          "y": -5.9
+        }
+      },
+      {
+        "from": {
+          "x": -1.5,
+          "y": -5.9
+        },
+        "to": {
+          "x": -1.5,
+          "y": -5.7
+        }
+      },
+      {
+        "from": {
+          "x": -1.5,
+          "y": -5.7
+        },
+        "to": {
+          "x": -2,
+          "y": -5.7
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.75,
+        "y": -5.7
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_7",
+    "source_trace_id": "U1.39-U1.38",
+    "edges": [
+      {
+        "from": {
+          "x": 1,
+          "y": 0.5999999999999996
+        },
+        "to": {
+          "x": 1.2,
+          "y": 0.5999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": 1.2,
+          "y": 0.5999999999999996
+        },
+        "to": {
+          "x": 1.2,
+          "y": 0.39999999999999947
+        }
+      },
+      {
+        "from": {
+          "x": 1.2,
+          "y": 0.39999999999999947
+        },
+        "to": {
+          "x": 1,
+          "y": 0.39999999999999947
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_8",
+    "source_trace_id": "R1.1-J_TEMP.3",
+    "edges": [
+      {
+        "from": {
+          "x": -5.050000000000001,
+          "y": 2
+        },
+        "to": {
+          "x": -6,
+          "y": 2
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_9",
+    "source_trace_id": "U1.3-U1.2",
+    "edges": [
+      {
+        "from": {
+          "x": -1,
+          "y": 1.9000000000000008
+        },
+        "to": {
+          "x": -1.2,
+          "y": 1.9000000000000008
+        }
+      },
+      {
+        "from": {
+          "x": -1.2,
+          "y": 1.9000000000000008
+        },
+        "to": {
+          "x": -1.2,
+          "y": 2.1000000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -1.2,
+          "y": 2.1000000000000005
+        },
+        "to": {
+          "x": -1,
+          "y": 2.1000000000000005
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_10",
+    "source_trace_id": "U3.3-C1.1",
+    "edges": [
+      {
+        "from": {
+          "x": 1,
+          "y": -6.1
+        },
+        "to": {
+          "x": 1.2,
+          "y": -6.1
+        }
+      },
+      {
+        "from": {
+          "x": 1.2,
+          "y": -6.1
+        },
+        "to": {
+          "x": 1.2,
+          "y": -6.8
+        }
+      },
+      {
+        "from": {
+          "x": 1.2,
+          "y": -6.8
+        },
+        "to": {
+          "x": 0.75,
+          "y": -6.8
+        }
+      },
+      {
+        "from": {
+          "x": 0.75,
+          "y": -6.8
+        },
+        "to": {
+          "x": 0.75,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": 0.75,
+          "y": -7.5
+        },
+        "to": {
+          "x": 0.95,
+          "y": -7.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_11",
+    "source_trace_id": "U2.4-U2.1",
+    "edges": [
+      {
+        "from": {
+          "x": -4,
+          "y": -6.2
+        },
+        "to": {
+          "x": -4.2,
+          "y": -6.2
+        }
+      },
+      {
+        "from": {
+          "x": -4.2,
+          "y": -6.2
+        },
+        "to": {
+          "x": -4.2,
+          "y": -5.6
+        }
+      },
+      {
+        "from": {
+          "x": -4.2,
+          "y": -5.6
+        },
+        "to": {
+          "x": -4,
+          "y": -5.6
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_12",
+    "source_trace_id": "J_TEMP.2-R1.2",
+    "edges": [
+      {
+        "from": {
+          "x": -8,
+          "y": 1.9
+        },
+        "to": {
+          "x": -8.2,
+          "y": 1.9
+        }
+      },
+      {
+        "from": {
+          "x": -8.2,
+          "y": 1.9
+        },
+        "to": {
+          "x": -8.2,
+          "y": 1.5
+        }
+      },
+      {
+        "from": {
+          "x": -8.2,
+          "y": 1.5
+        },
+        "to": {
+          "x": -3.75,
+          "y": 1.5
+        }
+      },
+      {
+        "from": {
+          "x": -3.75,
+          "y": 1.5
+        },
+        "to": {
+          "x": -3.75,
+          "y": 2
+        }
+      },
+      {
+        "from": {
+          "x": -3.75,
+          "y": 2
+        },
+        "to": {
+          "x": -3.9499999999999993,
+          "y": 2
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_13",
+    "source_trace_id": "J_DOOR.1-R2.2",
+    "edges": [
+      {
+        "from": {
+          "x": -8,
+          "y": -1
+        },
+        "to": {
+          "x": -8.2,
+          "y": -1
+        }
+      },
+      {
+        "from": {
+          "x": -8.2,
+          "y": -1
+        },
+        "to": {
+          "x": -8.2,
+          "y": -1.4
+        }
+      },
+      {
+        "from": {
+          "x": -8.2,
+          "y": -1.4
+        },
+        "to": {
+          "x": -3.75,
+          "y": -1.4
+        }
+      },
+      {
+        "from": {
+          "x": -3.75,
+          "y": -1.4
+        },
+        "to": {
+          "x": -3.75,
+          "y": -1
+        }
+      },
+      {
+        "from": {
+          "x": -3.75,
+          "y": -1
+        },
+        "to": {
+          "x": -3.9499999999999993,
+          "y": -1
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_14",
+    "source_trace_id": "BZ1.2-Q1.3",
+    "edges": [
+      {
+        "from": {
+          "x": 8,
+          "y": 5
+        },
+        "to": {
+          "x": 8.2,
+          "y": 5
+        }
+      },
+      {
+        "from": {
+          "x": 8.2,
+          "y": 5
+        },
+        "to": {
+          "x": 8.2,
+          "y": 4
+        }
+      },
+      {
+        "from": {
+          "x": 8.2,
+          "y": 4
+        },
+        "to": {
+          "x": 6.4,
+          "y": 4
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_15",
+    "source_trace_id": "R8.2-Q1.1",
+    "edges": [
+      {
+        "from": {
+          "x": 4.05,
+          "y": 2.5
+        },
+        "to": {
+          "x": 4.25,
+          "y": 2.5
+        }
+      },
+      {
+        "from": {
+          "x": 4.25,
+          "y": 2.5
+        },
+        "to": {
+          "x": 4.25,
+          "y": 3.3
+        }
+      },
+      {
+        "from": {
+          "x": 4.25,
+          "y": 3.3
+        },
+        "to": {
+          "x": 3.0189999999999997,
+          "y": 3.3
+        }
+      },
+      {
+        "from": {
+          "x": 3.0189999999999997,
+          "y": 3.3
+        },
+        "to": {
+          "x": 3.0189999999999997,
+          "y": 4.1
+        }
+      },
+      {
+        "from": {
+          "x": 3.0189999999999997,
+          "y": 4.1
+        },
+        "to": {
+          "x": 3.5999999999999996,
+          "y": 4.1
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net16"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_16",
+    "source_trace_id": "U2.9-R7.2",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -5.7
+        },
+        "to": {
+          "x": -1.75,
+          "y": -5.7
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -5.7
+        },
+        "to": {
+          "x": -1.75,
+          "y": -4.699999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -1.75,
+          "y": -4.699999999999999
+        },
+        "to": {
+          "x": -1.0790000000000004,
+          "y": -4.699999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -1.0790000000000004,
+          "y": -4.699999999999999
+        },
+        "to": {
+          "x": -1.0790000000000004,
+          "y": -4.399
+        }
+      },
+      {
+        "from": {
+          "x": -1.0790000000000004,
+          "y": -4.399
+        },
+        "to": {
+          "x": -1.95,
+          "y": -4.399
+        }
+      },
+      {
+        "from": {
+          "x": -1.95,
+          "y": -4.399
+        },
+        "to": {
+          "x": -1.95,
+          "y": -4.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.75,
+        "y": -5.7
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_17",
+    "source_trace_id": "U2.2-R6.1",
+    "edges": [
+      {
+        "from": {
+          "x": -4,
+          "y": -5.8
+        },
+        "to": {
+          "x": -4.1625,
+          "y": -5.8
+        }
+      },
+      {
+        "from": {
+          "x": -4.1625,
+          "y": -5.8
+        },
+        "to": {
+          "x": -4.2375,
+          "y": -5.8
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -4.2375,
+          "y": -5.8
+        },
+        "to": {
+          "x": -5.221,
+          "y": -5.8
+        }
+      },
+      {
+        "from": {
+          "x": -5.221,
+          "y": -5.8
+        },
+        "to": {
+          "x": -5.221,
+          "y": -4
+        }
+      },
+      {
+        "from": {
+          "x": -5.221,
+          "y": -4
+        },
+        "to": {
+          "x": -4.920999999999999,
+          "y": -4
+        }
+      },
+      {
+        "from": {
+          "x": -4.920999999999999,
+          "y": -4
+        },
+        "to": {
+          "x": -4.920999999999999,
+          "y": -4.399
+        }
+      },
+      {
+        "from": {
+          "x": -4.920999999999999,
+          "y": -4.399
+        },
+        "to": {
+          "x": -4.05,
+          "y": -4.399
+        }
+      },
+      {
+        "from": {
+          "x": -4.05,
+          "y": -4.399
+        },
+        "to": {
+          "x": -4.05,
+          "y": -4.5
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_18",
+    "source_trace_id": "OLED1.4-U1.33",
+    "edges": [
+      {
+        "from": {
+          "x": 8.1,
+          "y": 2.1
+        },
+        "to": {
+          "x": 10.161,
+          "y": 2.1
+        }
+      },
+      {
+        "from": {
+          "x": 10.161,
+          "y": 2.1
+        },
+        "to": {
+          "x": 10.161,
+          "y": -0.6000000000000008
+        }
+      },
+      {
+        "from": {
+          "x": 10.161,
+          "y": -0.6000000000000008
+        },
+        "to": {
+          "x": 1,
+          "y": -0.6000000000000008
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_19",
+    "source_trace_id": "U1.13-R5.1",
+    "edges": [
+      {
+        "from": {
+          "x": -1,
+          "y": -0.0999999999999992
+        },
+        "to": {
+          "x": -2.971,
+          "y": -0.0999999999999992
+        }
+      },
+      {
+        "from": {
+          "x": -2.971,
+          "y": -0.0999999999999992
+        },
+        "to": {
+          "x": -2.971,
+          "y": -2.1999999999999997
+        }
+      },
+      {
+        "from": {
+          "x": -2.971,
+          "y": -2.1999999999999997
+        },
+        "to": {
+          "x": -2.419,
+          "y": -2.1999999999999997
+        }
+      },
+      {
+        "from": {
+          "x": -2.419,
+          "y": -2.1999999999999997
+        },
+        "to": {
+          "x": -2.419,
+          "y": -2.6
+        }
+      },
+      {
+        "from": {
+          "x": -2.419,
+          "y": -2.6
+        },
+        "to": {
+          "x": -2.971,
+          "y": -2.6
+        }
+      },
+      {
+        "from": {
+          "x": -2.971,
+          "y": -2.6
+        },
+        "to": {
+          "x": -2.971,
+          "y": -3.5
+        }
+      },
+      {
+        "from": {
+          "x": -2.971,
+          "y": -3.5
+        },
+        "to": {
+          "x": 2.95,
+          "y": -3.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.971,
+        "y": -2.6
+      },
+      {
+        "x": -2.8,
+        "y": -2.6
+      }
+    ]
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_20",
+    "source_trace_id": "SW1.1-SW1.3",
+    "edges": [
+      {
+        "from": {
+          "x": -5,
+          "y": -2.4
+        },
+        "to": {
+          "x": -5.2,
+          "y": -2.4
+        }
+      },
+      {
+        "from": {
+          "x": -5.2,
+          "y": -2.4
+        },
+        "to": {
+          "x": -5.2,
+          "y": -3
+        }
+      },
+      {
+        "from": {
+          "x": -5.2,
+          "y": -3
+        },
+        "to": {
+          "x": -3.0085,
+          "y": -3
+        }
+      },
+      {
+        "from": {
+          "x": -3.0085,
+          "y": -3
+        },
+        "to": {
+          "x": -2.9335,
+          "y": -3
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -2.9335,
+          "y": -3
+        },
+        "to": {
+          "x": -2.8,
+          "y": -3
+        }
+      },
+      {
+        "from": {
+          "x": -2.8,
+          "y": -3
+        },
+        "to": {
+          "x": -2.8,
+          "y": -2.6
+        }
+      },
+      {
+        "from": {
+          "x": -2.8,
+          "y": -2.6
+        },
+        "to": {
+          "x": -3,
+          "y": -2.6
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.971,
+        "y": -2.6
+      },
+      {
+        "x": -2.8,
+        "y": -2.6
+      }
+    ]
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_21",
+    "source_trace_id": "available-net-orientation-3-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 5.9,
+          "y": 2.1
+        },
+        "to": {
+          "x": 5.299,
+          "y": 2.1
+        }
+      },
+      {
+        "from": {
+          "x": 5.299,
+          "y": 2.1
+        },
+        "to": {
+          "x": 5.299,
+          "y": 1.7990000000000002
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_22",
+    "source_trace_id": "available-net-orientation-7-GND",
+    "edges": [
+      {
+        "from": {
+          "x": -4,
+          "y": -6.4
+        },
+        "to": {
+          "x": -4.101,
+          "y": -6.4
+        }
+      },
+      {
+        "from": {
+          "x": -4.101,
+          "y": -6.4
+        },
+        "to": {
+          "x": -4.101,
+          "y": -6.601000000000001
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_23",
+    "source_trace_id": "available-net-orientation-9-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 2.05,
+          "y": -7.5
+        },
+        "to": {
+          "x": 2.151,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": 2.151,
+          "y": -7.5
+        },
+        "to": {
+          "x": 2.151,
+          "y": -7.9510000000000005
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_24",
+    "source_trace_id": "available-net-orientation-10-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 3.05,
+          "y": -7.5
+        },
+        "to": {
+          "x": 3.151,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": 3.151,
+          "y": -7.5
+        },
+        "to": {
+          "x": 3.151,
+          "y": -7.9510000000000005
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_25",
+    "source_trace_id": "available-net-orientation-12-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 3.5999999999999996,
+          "y": 3.9
+        },
+        "to": {
+          "x": 3.449,
+          "y": 3.9
+        }
+      },
+      {
+        "from": {
+          "x": 3.449,
+          "y": 3.9
+        },
+        "to": {
+          "x": 3.449,
+          "y": 3.849
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_26",
+    "source_trace_id": "available-net-orientation-19-V3_3",
+    "edges": [
+      {
+        "from": {
+          "x": 1,
+          "y": -5.9
+        },
+        "to": {
+          "x": 1.101,
+          "y": -5.9
+        }
+      },
+      {
+        "from": {
+          "x": 1.101,
+          "y": -5.9
+        },
+        "to": {
+          "x": 1.101,
+          "y": -5.699
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_27",
+    "source_trace_id": "available-net-orientation-20-V3_3",
+    "edges": [
+      {
+        "from": {
+          "x": 1.95,
+          "y": -7.5
+        },
+        "to": {
+          "x": 1.849,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": 1.849,
+          "y": -7.5
+        },
+        "to": {
+          "x": 1.849,
+          "y": -7.0489999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_28",
+    "source_trace_id": "available-net-orientation-21-V3_3",
+    "edges": [
+      {
+        "from": {
+          "x": -5.050000000000001,
+          "y": -1
+        },
+        "to": {
+          "x": -5.151000000000001,
+          "y": -1
+        }
+      },
+      {
+        "from": {
+          "x": -5.151000000000001,
+          "y": -1
+        },
+        "to": {
+          "x": -5.151000000000001,
+          "y": -0.7989999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_29",
+    "source_trace_id": "available-net-orientation-41-V12_IN",
+    "edges": [
+      {
+        "from": {
+          "x": -8,
+          "y": -5
+        },
+        "to": {
+          "x": -8.100999999999999,
+          "y": -5
+        }
+      },
+      {
+        "from": {
+          "x": -8.100999999999999,
+          "y": -5
+        },
+        "to": {
+          "x": -8.100999999999999,
+          "y": -4.7989999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_30",
+    "source_trace_id": "available-net-orientation-46-V5",
+    "edges": [
+      {
+        "from": {
+          "x": 6,
+          "y": 5
+        },
+        "to": {
+          "x": 5.899,
+          "y": 5
+        }
+      },
+      {
+        "from": {
+          "x": 5.899,
+          "y": 5
+        },
+        "to": {
+          "x": 5.899,
+          "y": 5.2010000000000005
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit340_connectivity_net2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -1,
+      "y": 2.3000000000000007
+    },
+    "center": {
+      "x": -1,
+      "y": 2.210000000000001
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -1,
+      "y": -0.49999999999999956
+    },
+    "center": {
+      "x": -1.24,
+      "y": -0.49999999999999956
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 1.2,
+      "y": 0.39999999999999947
+    },
+    "center": {
+      "x": 1.2,
+      "y": 0.3099999999999995
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 5.299,
+      "y": 1.7990000000000002
+    },
+    "center": {
+      "x": 5.299,
+      "y": 1.709
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -8,
+      "y": 2.1
+    },
+    "center": {
+      "x": -8.24,
+      "y": 2.1
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -6,
+      "y": -1
+    },
+    "center": {
+      "x": -5.76,
+      "y": -1
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -5.8,
+      "y": -7.2
+    },
+    "center": {
+      "x": -5.8,
+      "y": -7.29
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -4.101,
+      "y": -6.601000000000001
+    },
+    "center": {
+      "x": -4.101,
+      "y": -6.691000000000001
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -1.25,
+      "y": -5.9
+    },
+    "center": {
+      "x": -1.25,
+      "y": -5.99
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 2.151,
+      "y": -7.9510000000000005
+    },
+    "center": {
+      "x": 2.151,
+      "y": -8.041
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 3.151,
+      "y": -7.9510000000000005
+    },
+    "center": {
+      "x": 3.151,
+      "y": -8.041
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 5.765,
+      "y": -3.5
+    },
+    "center": {
+      "x": 5.765,
+      "y": -3.59
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": 3.449,
+      "y": 3.849
+    },
+    "center": {
+      "x": 3.449,
+      "y": 3.7590000000000003
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -5,
+      "y": -2.6
+    },
+    "center": {
+      "x": -5.24,
+      "y": -2.6
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "GND",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -3,
+      "y": -2.4
+    },
+    "center": {
+      "x": -2.76,
+      "y": -2.4
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -1.2,
+      "y": 2.1000000000000005
+    },
+    "center": {
+      "x": -1.2,
+      "y": 2.1900000000000004
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 5.9,
+      "y": 1.9
+    },
+    "center": {
+      "x": 5.6000000000000005,
+      "y": 1.9
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -5.525,
+      "y": 2
+    },
+    "center": {
+      "x": -5.525,
+      "y": 2.09
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_18",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -1,
+      "y": -6.1
+    },
+    "center": {
+      "x": -1.3,
+      "y": -6.1
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_19",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 1.101,
+      "y": -5.699
+    },
+    "center": {
+      "x": 1.101,
+      "y": -5.609
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_20",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 1.849,
+      "y": -7.0489999999999995
+    },
+    "center": {
+      "x": 1.849,
+      "y": -6.959
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_21",
+    "text": "V3_3",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -5.151000000000001,
+      "y": -0.7989999999999999
+    },
+    "center": {
+      "x": -5.151000000000001,
+      "y": -0.709
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_22",
+    "text": "U1_IO34/R6_pin2/R7_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net18",
+    "anchor_position": {
+      "x": -2.95,
+      "y": -4.5
+    },
+    "center": {
+      "x": -1.5100000000000002,
+      "y": -4.5
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_23",
+    "text": "U1_IO34/R6_pin2/R7_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net18",
+    "anchor_position": {
+      "x": -1,
+      "y": 1.3000000000000007
+    },
+    "center": {
+      "x": -2.44,
+      "y": 1.3000000000000007
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_24",
+    "text": "U1_IO34/R6_pin2/R7_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net18",
+    "anchor_position": {
+      "x": -3.05,
+      "y": -4.5
+    },
+    "center": {
+      "x": -4.49,
+      "y": -4.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_25",
+    "text": "U1_IO32/J_TEMP_pin2/R1_pin2",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net6",
+    "anchor_position": {
+      "x": -8.2,
+      "y": 1.9
+    },
+    "center": {
+      "x": -9.879999999999999,
+      "y": 1.9
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_26",
+    "text": "U1_IO32/J_TEMP_pin2/R1_pin2",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net6",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.9000000000000008
+    },
+    "center": {
+      "x": -2.6799999999999997,
+      "y": 0.9000000000000008
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_27",
+    "text": "U1_IO33/J_DOOR_pin1/R2_pin2",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net7",
+    "anchor_position": {
+      "x": -8.2,
+      "y": -1
+    },
+    "center": {
+      "x": -8.2,
+      "y": -0.91
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_28",
+    "text": "U1_IO33/J_DOOR_pin1/R2_pin2",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net7",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.7000000000000008
+    },
+    "center": {
+      "x": -2.6799999999999997,
+      "y": 0.7000000000000008
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_29",
+    "text": "U1_IO25/R8_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net15",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.5000000000000009
+    },
+    "center": {
+      "x": -1.96,
+      "y": 0.5000000000000009
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_30",
+    "text": "U1_IO25/R8_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net15",
+    "anchor_position": {
+      "x": 2.95,
+      "y": 2.5
+    },
+    "center": {
+      "x": 1.9900000000000002,
+      "y": 2.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_31",
+    "text": "U1_IO26/R3_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net8",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.30000000000000093
+    },
+    "center": {
+      "x": -1.96,
+      "y": 0.30000000000000093
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_32",
+    "text": "U1_IO26/R3_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net8",
+    "anchor_position": {
+      "x": 2.95,
+      "y": -1.5
+    },
+    "center": {
+      "x": 1.9900000000000002,
+      "y": -1.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_33",
+    "text": "U1_IO27/R4_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net10",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.10000000000000098
+    },
+    "center": {
+      "x": -1.96,
+      "y": 0.10000000000000098
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_34",
+    "text": "U1_IO27/R4_pin1",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net10",
+    "anchor_position": {
+      "x": 2.95,
+      "y": -2.5
+    },
+    "center": {
+      "x": 1.9900000000000002,
+      "y": -2.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_35",
+    "text": "U1_IO13/SW1_pin1/SW1_pin3",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net17",
+    "anchor_position": {
+      "x": -5.2,
+      "y": -2.4
+    },
+    "center": {
+      "x": -6.76,
+      "y": -2.4
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_36",
+    "text": "U1_IO13/SW1_pin1/SW1_pin3",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net17",
+    "anchor_position": {
+      "x": -1,
+      "y": -0.6999999999999997
+    },
+    "center": {
+      "x": -2.56,
+      "y": -0.6999999999999997
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_37",
+    "text": "U1_IO22/OLED1_SCL",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net5",
+    "anchor_position": {
+      "x": 8.1,
+      "y": 1.9
+    },
+    "center": {
+      "x": 9.18,
+      "y": 1.9
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_38",
+    "text": "U1_IO22/OLED1_SCL",
+    "source_net_id": "unnamedsubcircuit340_connectivity_net5",
+    "anchor_position": {
+      "x": 1,
+      "y": -8.881784197001252e-16
+    },
+    "center": {
+      "x": 2.08,
+      "y": -8.881784197001252e-16
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_39",
+    "text": "V12_IN",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -8.100999999999999,
+      "y": -4.7989999999999995
+    },
+    "center": {
+      "x": -8.100999999999999,
+      "y": -4.709
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_40",
+    "text": "V12_IN",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -5.221,
+      "y": -4
+    },
+    "center": {
+      "x": -5.221,
+      "y": -3.91
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_41",
+    "text": "V12_IN",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -2,
+      "y": -6.1
+    },
+    "center": {
+      "x": -1.58,
+      "y": -6.1
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_42",
+    "text": "V5",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": -4.2,
+      "y": -5.6
+    },
+    "center": {
+      "x": -4.2,
+      "y": -5.51
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_43",
+    "text": "V5",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": 1.2,
+      "y": -6.1
+    },
+    "center": {
+      "x": 1.2,
+      "y": -6.01
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_44",
+    "text": "V5",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": 5.899,
+      "y": 5.2010000000000005
+    },
+    "center": {
+      "x": 5.899,
+      "y": 5.291
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": -2.9999999999999996,
+      "y": 2
+    },
+    "width": 19.5300473,
+    "height": 20.1002138,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -3,
+    "display_offset_y": 2
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": 21,
+      "y": 2.5
+    },
+    "width": 25,
+    "height": 25,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 21,
+    "display_offset_y": 2.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": -30,
+      "y": 7.5
+    },
+    "width": 1.6002507999999978,
+    "height": 6.679996799999999,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -30,
+    "display_offset_y": 7.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": -30,
+      "y": -5.5
+    },
+    "width": 1.524000000000001,
+    "height": 4.012120500000001,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -30,
+    "display_offset_y": -5.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "center": {
+      "x": 29.5,
+      "y": -17
+    },
+    "width": 8.079994,
+    "height": 2.999994000000001,
+    "layer": "top",
+    "rotation": 180,
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 29.5,
+    "display_offset_y": -17
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_5",
+    "center": {
+      "x": 17,
+      "y": -17.399967399999998
+    },
+    "width": 9.739807799999998,
+    "height": 5.700090199999996,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 17,
+    "display_offset_y": -17
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_6",
+    "center": {
+      "x": -6.499874,
+      "y": -15.500128
+    },
+    "width": 0.6096,
+    "height": 0.6096,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_manually_placed_via_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "obstructs_within_bounds": true
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_7",
+    "center": {
+      "x": -7.499872,
+      "y": -15.500128
+    },
+    "width": 0.6096,
+    "height": 0.6096,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_manually_placed_via_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "obstructs_within_bounds": true
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_8",
+    "center": {
+      "x": -7.499872,
+      "y": -16.500126
+    },
+    "width": 0.6096,
+    "height": 0.6096,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_manually_placed_via_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "obstructs_within_bounds": true
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_9",
+    "center": {
+      "x": -6.499874,
+      "y": -16.500126
+    },
+    "width": 0.6096,
+    "height": 0.6096,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_manually_placed_via_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "obstructs_within_bounds": true
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_10",
+    "center": {
+      "x": -7,
+      "y": -16
+    },
+    "width": 4.383989199999999,
+    "height": 7.576210399999999,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -7,
+    "display_offset_y": -16
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_11",
+    "center": {
+      "x": -26,
+      "y": -15
+    },
+    "width": 8.139785599999996,
+    "height": 5.579948200000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -26,
+    "display_offset_y": -15
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_12",
+    "center": {
+      "x": -33,
+      "y": -11.5
+    },
+    "width": 2.450000000000003,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -33,
+    "display_offset_y": -11.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_13",
+    "center": {
+      "x": -20,
+      "y": -11.5
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -20,
+    "display_offset_y": -11.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_14",
+    "center": {
+      "x": -22.5,
+      "y": 9.5
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -22.5,
+    "display_offset_y": 9.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_15",
+    "center": {
+      "x": -16,
+      "y": -9.5
+    },
+    "width": 2.4499999999999975,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -16,
+    "display_offset_y": -9.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_16",
+    "center": {
+      "x": -19.5,
+      "y": -14.5
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -19.5,
+    "display_offset_y": -14.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_17",
+    "center": {
+      "x": -16,
+      "y": -14.5
+    },
+    "width": 2.4499999999999975,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -16,
+    "display_offset_y": -14.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_18",
+    "center": {
+      "x": -13,
+      "y": -14.5
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -13,
+    "display_offset_y": -14.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_19",
+    "center": {
+      "x": 15.5,
+      "y": -12.5
+    },
+    "width": 2.4499999999999975,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 15.5,
+    "display_offset_y": -12.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_20",
+    "center": {
+      "x": 20.5,
+      "y": -12.5
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 20.5,
+    "display_offset_y": -12.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_21",
+    "center": {
+      "x": -29,
+      "y": 14
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -29,
+    "display_offset_y": 14
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_22",
+    "center": {
+      "x": -19.5,
+      "y": -17.5
+    },
+    "width": 2.4499999999999957,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -19.5,
+    "display_offset_y": -17.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_23",
+    "center": {
+      "x": -16,
+      "y": -17.5
+    },
+    "width": 2.4499999999999975,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -16,
+    "display_offset_y": -17.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_24",
+    "center": {
+      "x": -13,
+      "y": -17.5
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -13,
+    "display_offset_y": -17.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_25",
+    "center": {
+      "x": -18,
+      "y": 18
+    },
+    "width": 11.500738999999996,
+    "height": 1.7999963999999977,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -18,
+    "display_offset_y": 18
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_26",
+    "center": {
+      "x": -26.5,
+      "y": 11
+    },
+    "width": 2.5,
+    "height": 3.1999999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -26.5,
+    "display_offset_y": 11
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_27",
+    "center": {
+      "x": 3.9999999999999996,
+      "y": -17.5
+    },
+    "width": 11.3997994,
+    "height": 6.000115000000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 4,
+    "display_offset_y": -17.5
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "source_board_id": "source_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "thickness": 1.4,
+    "num_layers": 2,
+    "width": 70,
+    "height": 45,
+    "outline": [
+      {
+        "x": -33,
+        "y": -22.5
+      },
+      {
+        "x": 33,
+        "y": -22.5
+      },
+      {
+        "x": 33.098135348654836,
+        "y": -22.497590912410345
+      },
+      {
+        "x": 33.19603428065912,
+        "y": -22.490369453344393
+      },
+      {
+        "x": 33.29346094891072,
+        "y": -22.47835301992956
+      },
+      {
+        "x": 33.390180644032256,
+        "y": -22.46157056080646
+      },
+      {
+        "x": 33.485960359806526,
+        "y": -22.440062506389086
+      },
+      {
+        "x": 33.580569354508924,
+        "y": -22.41388067146442
+      },
+      {
+        "x": 33.67377970678444,
+        "y": -22.38308813036604
+      },
+      {
+        "x": 33.76536686473018,
+        "y": -22.347759065022572
+      },
+      {
+        "x": 33.855110186860564,
+        "y": -22.307978586246886
+      },
+      {
+        "x": 33.942793473651996,
+        "y": -22.26384252869671
+      },
+      {
+        "x": 34.02820548838644,
+        "y": -22.215457220000545
+      },
+      {
+        "x": 34.1111404660392,
+        "y": -22.16293922460509
+      },
+      {
+        "x": 34.19139860898487,
+        "y": -22.10641506296129
+      },
+      {
+        "x": 34.26878656832729,
+        "y": -22.046020906725474
+      },
+      {
+        "x": 34.34311790969404,
+        "y": -21.98190225070992
+      },
+      {
+        "x": 34.41421356237309,
+        "y": -21.914213562373096
+      },
+      {
+        "x": 34.481902250709915,
+        "y": -21.843117909694037
+      },
+      {
+        "x": 34.546020906725474,
+        "y": -21.76878656832729
+      },
+      {
+        "x": 34.60641506296129,
+        "y": -21.691398608984866
+      },
+      {
+        "x": 34.66293922460509,
+        "y": -21.611140466039203
+      },
+      {
+        "x": 34.715457220000545,
+        "y": -21.528205488386444
+      },
+      {
+        "x": 34.76384252869671,
+        "y": -21.442793473651996
+      },
+      {
+        "x": 34.80797858624689,
+        "y": -21.355110186860564
+      },
+      {
+        "x": 34.84775906502257,
+        "y": -21.26536686473018
+      },
+      {
+        "x": 34.88308813036604,
+        "y": -21.17377970678444
+      },
+      {
+        "x": 34.91388067146442,
+        "y": -21.080569354508924
+      },
+      {
+        "x": 34.94006250638909,
+        "y": -20.985960359806526
+      },
+      {
+        "x": 34.961570560806464,
+        "y": -20.890180644032256
+      },
+      {
+        "x": 34.978353019929564,
+        "y": -20.793460948910724
+      },
+      {
+        "x": 34.99036945334439,
+        "y": -20.69603428065912
+      },
+      {
+        "x": 34.997590912410345,
+        "y": -20.598135348654836
+      },
+      {
+        "x": 35,
+        "y": -20.5
+      },
+      {
+        "x": 35,
+        "y": 20.5
+      },
+      {
+        "x": 34.997590912410345,
+        "y": 20.598135348654836
+      },
+      {
+        "x": 34.99036945334439,
+        "y": 20.69603428065912
+      },
+      {
+        "x": 34.978353019929564,
+        "y": 20.793460948910724
+      },
+      {
+        "x": 34.961570560806464,
+        "y": 20.890180644032256
+      },
+      {
+        "x": 34.94006250638909,
+        "y": 20.985960359806526
+      },
+      {
+        "x": 34.91388067146442,
+        "y": 21.080569354508924
+      },
+      {
+        "x": 34.88308813036604,
+        "y": 21.17377970678444
+      },
+      {
+        "x": 34.84775906502257,
+        "y": 21.26536686473018
+      },
+      {
+        "x": 34.80797858624689,
+        "y": 21.355110186860564
+      },
+      {
+        "x": 34.76384252869671,
+        "y": 21.442793473651996
+      },
+      {
+        "x": 34.715457220000545,
+        "y": 21.528205488386444
+      },
+      {
+        "x": 34.66293922460509,
+        "y": 21.611140466039203
+      },
+      {
+        "x": 34.60641506296129,
+        "y": 21.691398608984866
+      },
+      {
+        "x": 34.546020906725474,
+        "y": 21.76878656832729
+      },
+      {
+        "x": 34.481902250709915,
+        "y": 21.843117909694037
+      },
+      {
+        "x": 34.41421356237309,
+        "y": 21.914213562373096
+      },
+      {
+        "x": 34.34311790969404,
+        "y": 21.98190225070992
+      },
+      {
+        "x": 34.26878656832729,
+        "y": 22.046020906725474
+      },
+      {
+        "x": 34.19139860898487,
+        "y": 22.10641506296129
+      },
+      {
+        "x": 34.1111404660392,
+        "y": 22.16293922460509
+      },
+      {
+        "x": 34.02820548838644,
+        "y": 22.215457220000545
+      },
+      {
+        "x": 33.942793473651996,
+        "y": 22.26384252869671
+      },
+      {
+        "x": 33.855110186860564,
+        "y": 22.307978586246886
+      },
+      {
+        "x": 33.76536686473018,
+        "y": 22.347759065022572
+      },
+      {
+        "x": 33.67377970678444,
+        "y": 22.38308813036604
+      },
+      {
+        "x": 33.580569354508924,
+        "y": 22.41388067146442
+      },
+      {
+        "x": 33.485960359806526,
+        "y": 22.440062506389086
+      },
+      {
+        "x": 33.390180644032256,
+        "y": 22.46157056080646
+      },
+      {
+        "x": 33.29346094891072,
+        "y": 22.47835301992956
+      },
+      {
+        "x": 33.19603428065912,
+        "y": 22.490369453344393
+      },
+      {
+        "x": 33.098135348654836,
+        "y": 22.497590912410345
+      },
+      {
+        "x": 33,
+        "y": 22.5
+      },
+      {
+        "x": -33,
+        "y": 22.5
+      },
+      {
+        "x": -33.098135348654836,
+        "y": 22.497590912410345
+      },
+      {
+        "x": -33.19603428065912,
+        "y": 22.490369453344393
+      },
+      {
+        "x": -33.29346094891072,
+        "y": 22.47835301992956
+      },
+      {
+        "x": -33.390180644032256,
+        "y": 22.46157056080646
+      },
+      {
+        "x": -33.485960359806526,
+        "y": 22.440062506389086
+      },
+      {
+        "x": -33.580569354508924,
+        "y": 22.41388067146442
+      },
+      {
+        "x": -33.67377970678444,
+        "y": 22.38308813036604
+      },
+      {
+        "x": -33.76536686473018,
+        "y": 22.347759065022572
+      },
+      {
+        "x": -33.855110186860564,
+        "y": 22.307978586246886
+      },
+      {
+        "x": -33.942793473651996,
+        "y": 22.26384252869671
+      },
+      {
+        "x": -34.02820548838644,
+        "y": 22.215457220000545
+      },
+      {
+        "x": -34.1111404660392,
+        "y": 22.16293922460509
+      },
+      {
+        "x": -34.19139860898487,
+        "y": 22.10641506296129
+      },
+      {
+        "x": -34.26878656832729,
+        "y": 22.046020906725474
+      },
+      {
+        "x": -34.34311790969404,
+        "y": 21.98190225070992
+      },
+      {
+        "x": -34.41421356237309,
+        "y": 21.914213562373096
+      },
+      {
+        "x": -34.481902250709915,
+        "y": 21.843117909694037
+      },
+      {
+        "x": -34.546020906725474,
+        "y": 21.76878656832729
+      },
+      {
+        "x": -34.60641506296129,
+        "y": 21.691398608984866
+      },
+      {
+        "x": -34.66293922460509,
+        "y": 21.611140466039203
+      },
+      {
+        "x": -34.715457220000545,
+        "y": 21.528205488386444
+      },
+      {
+        "x": -34.76384252869671,
+        "y": 21.442793473651996
+      },
+      {
+        "x": -34.80797858624689,
+        "y": 21.355110186860564
+      },
+      {
+        "x": -34.84775906502257,
+        "y": 21.26536686473018
+      },
+      {
+        "x": -34.88308813036604,
+        "y": 21.17377970678444
+      },
+      {
+        "x": -34.91388067146442,
+        "y": 21.080569354508924
+      },
+      {
+        "x": -34.94006250638909,
+        "y": 20.98596035980653
+      },
+      {
+        "x": -34.961570560806464,
+        "y": 20.890180644032256
+      },
+      {
+        "x": -34.978353019929564,
+        "y": 20.793460948910724
+      },
+      {
+        "x": -34.99036945334439,
+        "y": 20.69603428065912
+      },
+      {
+        "x": -34.997590912410345,
+        "y": 20.598135348654836
+      },
+      {
+        "x": -35,
+        "y": 20.5
+      },
+      {
+        "x": -35,
+        "y": -20.5
+      },
+      {
+        "x": -34.997590912410345,
+        "y": -20.598135348654836
+      },
+      {
+        "x": -34.99036945334439,
+        "y": -20.69603428065912
+      },
+      {
+        "x": -34.978353019929564,
+        "y": -20.793460948910724
+      },
+      {
+        "x": -34.961570560806464,
+        "y": -20.890180644032256
+      },
+      {
+        "x": -34.94006250638909,
+        "y": -20.985960359806526
+      },
+      {
+        "x": -34.91388067146442,
+        "y": -21.080569354508924
+      },
+      {
+        "x": -34.88308813036604,
+        "y": -21.17377970678444
+      },
+      {
+        "x": -34.84775906502257,
+        "y": -21.26536686473018
+      },
+      {
+        "x": -34.80797858624689,
+        "y": -21.355110186860564
+      },
+      {
+        "x": -34.76384252869671,
+        "y": -21.442793473651996
+      },
+      {
+        "x": -34.715457220000545,
+        "y": -21.528205488386444
+      },
+      {
+        "x": -34.66293922460509,
+        "y": -21.611140466039203
+      },
+      {
+        "x": -34.60641506296129,
+        "y": -21.691398608984866
+      },
+      {
+        "x": -34.546020906725474,
+        "y": -21.76878656832729
+      },
+      {
+        "x": -34.481902250709915,
+        "y": -21.843117909694037
+      },
+      {
+        "x": -34.41421356237309,
+        "y": -21.914213562373096
+      },
+      {
+        "x": -34.34311790969404,
+        "y": -21.98190225070992
+      },
+      {
+        "x": -34.26878656832729,
+        "y": -22.046020906725474
+      },
+      {
+        "x": -34.19139860898487,
+        "y": -22.10641506296129
+      },
+      {
+        "x": -34.1111404660392,
+        "y": -22.16293922460509
+      },
+      {
+        "x": -34.02820548838644,
+        "y": -22.215457220000545
+      },
+      {
+        "x": -33.942793473651996,
+        "y": -22.26384252869671
+      },
+      {
+        "x": -33.855110186860564,
+        "y": -22.307978586246886
+      },
+      {
+        "x": -33.76536686473018,
+        "y": -22.347759065022572
+      },
+      {
+        "x": -33.67377970678444,
+        "y": -22.38308813036604
+      },
+      {
+        "x": -33.580569354508924,
+        "y": -22.41388067146442
+      },
+      {
+        "x": -33.485960359806526,
+        "y": -22.440062506389086
+      },
+      {
+        "x": -33.390180644032256,
+        "y": -22.46157056080646
+      },
+      {
+        "x": -33.29346094891072,
+        "y": -22.47835301992956
+      },
+      {
+        "x": -33.19603428065912,
+        "y": -22.490369453344393
+      },
+      {
+        "x": -33.098135348654836,
+        "y": -22.497590912410345
+      },
+      {
+        "x": -33,
+        "y": -22.5
+      }
+    ],
+    "material": "fr4",
+    "min_trace_width": 0.1,
+    "min_via_hole_diameter": 0.2,
+    "min_via_pad_diameter": 0.3,
+    "min_via_hole_edge_to_via_hole_edge_clearance": 0.1,
+    "min_trace_to_pad_edge_clearance": 0.1,
+    "min_pad_edge_to_pad_edge_clearance": 0.1,
+    "min_plated_hole_drill_edge_to_drill_edge_clearance": 0.15,
+    "min_board_edge_clearance": 0.2
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0,
+      "y": 19.5
+    },
+    "font": "tscircuit2024",
+    "font_size": 2,
+    "layer": "top",
+    "text": "FREEZER / FRIDGE ALARM",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 20.5,
+      "y": 17.2
+    },
+    "font": "tscircuit2024",
+    "font_size": 1.2,
+    "layer": "top",
+    "text": "OLED 0.96 I2C",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -16,
+      "y": -16.8
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "TEMP  DOOR  PWR",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_0",
+    "pcb_component_id": null,
+    "hole_shape": "circle",
+    "hole_diameter": 3.2,
+    "x": -31.5,
+    "y": 17.5,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_1",
+    "pcb_component_id": null,
+    "hole_shape": "circle",
+    "hole_diameter": 3.2,
+    "x": 31.5,
+    "y": 17.5,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_2",
+    "pcb_component_id": null,
+    "hole_shape": "circle",
+    "hole_diameter": 3.2,
+    "x": -32,
+    "y": -20.5,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_3",
+    "pcb_component_id": null,
+    "hole_shape": "circle",
+    "hole_diameter": 2.4,
+    "x": 33,
+    "y": -21,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.29001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -12.29001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -11.02001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -11.02001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.75001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -9.75001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.48001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -8.48001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.21001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -7.21001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.94001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -5.94001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.67001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -4.67001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.40001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -3.40001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.13001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -2.13001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.86001825,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -0.86001825,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.40998175000000003,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 0.40998175000000003,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.6799817499999996,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 1.6799817499999996,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.94998175,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 2.94998175,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.21998175,
+    "y": -7.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 4.21998175,
+    "y": -7.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": -3.714873,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": -3.714873,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": -2.4448730000000003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": -2.4448730000000003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": -1.1748729999999998,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": -1.1748729999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 0.09512699999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 0.09512699999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 1.365127,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 1.365127,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 2.6351269999999998,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 2.6351269999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 3.9051270000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 3.9051270000000002,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 5.175127,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 5.175127,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 6.445127,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 6.445127,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.0999958,
+    "height": 0.9500108,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.715025750000001,
+    "y": 7.715127,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.4699970599999999,
+    "height": 0.6650075599999999,
+    "x": 5.715025750000001,
+    "y": 7.715127,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.21998175,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 4.21998175,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.94998175,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 2.94998175,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.6799817499999996,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 1.6799817499999996,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.40998175000000003,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": 0.40998175000000003,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin29"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.86001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -0.86001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin30"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.13001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -2.13001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin31"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.40001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -3.40001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin32"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.67001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -4.67001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin33"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.94001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -5.94001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin34"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.21001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -7.21001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin35"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -8.48001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -8.48001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin36"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -9.75001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -9.75001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin37"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -11.02001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -11.02001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.9500108,
+    "height": 2.0999958,
+    "port_hints": [
+      "pin38"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.29001825,
+    "y": 11.000109,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6650075599999999,
+    "height": 1.4699970599999999,
+    "x": -12.29001825,
+    "y": 11.000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin39"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.60905825,
+    "y": 0.499749,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -4.60905825,
+    "y": 0.499749,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin40"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.60905825,
+    "y": -0.900045,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -4.60905825,
+    "y": -0.900045,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin41"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.60905825,
+    "y": 1.900051,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -4.60905825,
+    "y": 1.900051,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin42"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.00910625,
+    "y": 1.900051,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -6.00910625,
+    "y": 1.900051,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin43"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.00910625,
+    "y": 0.500003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -6.00910625,
+    "y": 0.500003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin44"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.00910625,
+    "y": -0.900045,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -6.00910625,
+    "y": -0.900045,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin45"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.20901025,
+    "y": -0.900045,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -3.20901025,
+    "y": -0.900045,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin46"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.20901025,
+    "y": 0.500003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -3.20901025,
+    "y": 0.500003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8999982,
+    "height": 0.8999982,
+    "port_hints": [
+      "pin47"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.20901025,
+    "y": 1.900051,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6299987399999999,
+    "height": 0.6299987399999999,
+    "x": -3.20901025,
+    "y": 1.900051,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.764019050000115,
+        "y": 11.000083599999925
+      },
+      {
+        "x": -13.298118850000037,
+        "y": 11.000083599999925
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.764019050000115,
+        "y": -6.999931199999992
+      },
+      {
+        "x": -13.314044649999914,
+        "y": -6.999931199999992
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.764019050000115,
+        "y": 11.000083599999925
+      },
+      {
+        "x": -19.764019050000115,
+        "y": -6.999931199999992
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.480059050000023,
+        "y": 11.000083599999925
+      },
+      {
+        "x": -13.480059050000023,
+        "y": -6.999931199999992
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -12.971195449999868,
+        "y": 11.01707620000002
+      },
+      {
+        "x": -13.480059050000023,
+        "y": 11.01707620000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 5.73595535000004,
+        "y": 8.396227999999837
+      },
+      {
+        "x": 5.73595535000004,
+        "y": 11.01707620000002
+      },
+      {
+        "x": 4.901158950000081,
+        "y": 11.01707620000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.901158950000081,
+        "y": -6.999931199999992
+      },
+      {
+        "x": 5.73595535000004,
+        "y": -6.999931199999992
+      },
+      {
+        "x": 5.73595535000004,
+        "y": -4.396050199999991
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.480059050000023,
+        "y": -6.999931199999992
+      },
+      {
+        "x": -12.971195449999868,
+        "y": -6.999931199999992
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -6.53768025,
+      "y": 13.040747
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -20.09728025000004,
+        "y": 12.29074700000001
+      },
+      {
+        "x": 7.021919750000052,
+        "y": 12.29074700000001
+      },
+      {
+        "x": 7.021919750000052,
+        "y": -8.427652999999964
+      },
+      {
+        "x": -20.09728025000004,
+        "y": -8.427652999999964
+      },
+      {
+        "x": -20.09728025000004,
+        "y": 12.29074700000001
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_rect",
+    "pcb_silkscreen_rect_id": "pcb_silkscreen_rect_0",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "center": {
+      "x": 21,
+      "y": 2.5
+    },
+    "width": 27,
+    "height": 27,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "stroke_width": 0.1,
+    "is_filled": false
+  },
+  {
+    "type": "pcb_silkscreen_rect",
+    "pcb_silkscreen_rect_id": "pcb_silkscreen_rect_1",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "center": {
+      "x": 21,
+      "y": 4
+    },
+    "width": 21,
+    "height": 13,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "stroke_width": 0.1,
+    "is_filled": false
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_47",
+    "outer_diameter": 1.6,
+    "hole_diameter": 0.9,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole1",
+      "pin1"
+    ],
+    "x": 17.19,
+    "y": 14,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_47",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 17.19,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_48",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 17.19,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_1",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_48",
+    "outer_diameter": 1.6,
+    "hole_diameter": 0.9,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole2",
+      "pin2"
+    ],
+    "x": 19.73,
+    "y": 14,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_49",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 19.73,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_50",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 19.73,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_49",
+    "outer_diameter": 1.6,
+    "hole_diameter": 0.9,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole3",
+      "pin3"
+    ],
+    "x": 22.27,
+    "y": 14,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_51",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 22.27,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_52",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 22.27,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_3",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_50",
+    "outer_diameter": 1.6,
+    "hole_diameter": 0.9,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole4",
+      "pin4"
+    ],
+    "x": 24.81,
+    "y": 14,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_53",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 24.81,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_54",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.8,
+    "x": 24.81,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_4",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 2,
+    "x": 9.5,
+    "y": 14,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_5",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 2,
+    "x": 32.5,
+    "y": 14,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_6",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 2,
+    "x": 9.5,
+    "y": -9,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_7",
+    "pcb_component_id": "pcb_component_1",
+    "hole_shape": "circle",
+    "hole_diameter": 2,
+    "x": 32.5,
+    "y": -9,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_4",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_51",
+    "outer_diameter": 1.5999968,
+    "hole_diameter": 0.999998,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole5",
+      "pin1"
+    ],
+    "x": -30.000127,
+    "y": 4.96,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_55",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -30.000127,
+    "y": 4.96,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_56",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -30.000127,
+    "y": 4.96,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_5",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_52",
+    "outer_diameter": 1.5999968,
+    "hole_diameter": 0.999998,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole6",
+      "pin2"
+    ],
+    "x": -29.999873,
+    "y": 7.5,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_57",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -29.999873,
+    "y": 7.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_58",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -29.999873,
+    "y": 7.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_6",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_53",
+    "outer_diameter": 1.5999968,
+    "hole_diameter": 0.999998,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole7",
+      "pin3"
+    ],
+    "x": -29.999873,
+    "y": 10.04,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_59",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -29.999873,
+    "y": 10.04,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_60",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.7999984,
+    "x": -29.999873,
+    "y": 10.04,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -33.350132999999914,
+        "y": 2.52007599999979
+      },
+      {
+        "x": -33.350132999999914,
+        "y": 12.520056000000068
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -33.350132999999914,
+        "y": 12.520056000000068
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 12.520056000000068
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_10",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -27.65037300000006,
+        "y": 12.520056000000068
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 2.52007599999979
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_11",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -27.65037300000006,
+        "y": 2.52007599999979
+      },
+      {
+        "x": -33.350132999999914,
+        "y": 2.52007599999979
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_12",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -32.539999999999964,
+        "y": 3.1819999999999027
+      },
+      {
+        "x": -28.475999999999885,
+        "y": 3.1819999999999027
+      },
+      {
+        "x": -28.475999999999885,
+        "y": 11.817999999999984
+      },
+      {
+        "x": -32.539999999999964,
+        "y": 11.817999999999984
+      },
+      {
+        "x": -32.539999999999964,
+        "y": 3.1819999999999027
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_13",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -28.475999999999885,
+        "y": 4.705999999999904
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 4.705999999999904
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_14",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -28.475999999999885,
+        "y": 5.221365999999989
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 5.221365999999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_15",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -28.475999999999885,
+        "y": 9.767966000000001
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 9.767966000000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_16",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -28.475999999999885,
+        "y": 10.250565999999935
+      },
+      {
+        "x": -27.65037300000006,
+        "y": 10.250565999999935
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_4",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -34.421253,
+      "y": 7.5
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J_TEMP",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_1",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -33.67125299999998,
+        "y": 2.1699999999998454
+      },
+      {
+        "x": -33.67125299999998,
+        "y": 12.829999999999927
+      },
+      {
+        "x": -27.25305299999991,
+        "y": 12.829999999999927
+      },
+      {
+        "x": -27.25305299999991,
+        "y": 2.1699999999998454
+      },
+      {
+        "x": -33.67125299999998,
+        "y": 2.1699999999998454
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_7",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_54",
+    "outer_diameter": 1.524,
+    "hole_diameter": 0.9000236,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole8",
+      "pin1"
+    ],
+    "x": -30,
+    "y": -6.74406025,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_61",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.762,
+    "x": -30,
+    "y": -6.74406025,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_62",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.762,
+    "x": -30,
+    "y": -6.74406025,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_8",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_55",
+    "outer_diameter": 1.499997,
+    "hole_diameter": 0.9000236,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole9",
+      "pin2"
+    ],
+    "x": -30,
+    "y": -4.24393825,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_63",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.7499985,
+    "x": -30,
+    "y": -4.24393825,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_64",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.7499985,
+    "x": -30,
+    "y": -4.24393825,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_17",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -30.000050800000167,
+        "y": -7.737149450000061
+      },
+      {
+        "x": -30.000050800000167,
+        "y": -9.296988850000162
+      },
+      {
+        "x": -22.68010100000015,
+        "y": -9.296988850000162
+      },
+      {
+        "x": -22.68010100000015,
+        "y": -1.6839484500001167
+      },
+      {
+        "x": -30.000050800000167,
+        "y": -1.6839484500001163
+      },
+      {
+        "x": -30.000050800000167,
+        "y": -3.2627362500002164
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_18",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": -30.000050800000167,
+        "y": -5.750869450000096
+      },
+      {
+        "x": -30.000050800000167,
+        "y": -5.237154450000162
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_5",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -31.799846,
+      "y": -5.47634625
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J_DOOR",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_2",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -31.049846000000002,
+        "y": -9.663346250000131
+      },
+      {
+        "x": -31.049846000000002,
+        "y": -1.2893462500001078
+      },
+      {
+        "x": -22.294846000000007,
+        "y": -1.2893462500001087
+      },
+      {
+        "x": -22.294846000000007,
+        "y": -9.663346250000131
+      },
+      {
+        "x": -31.049846000000002,
+        "y": -9.663346250000131
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_9",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_56",
+    "outer_diameter": 2.999994,
+    "hole_diameter": 1.700022,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole10",
+      "pin1"
+    ],
+    "x": 32.04,
+    "y": -17,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_65",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 32.04,
+    "y": -17,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_66",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 32.04,
+    "y": -17,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_10",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_57",
+    "outer_diameter": 2.999994,
+    "hole_diameter": 1.700022,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole11",
+      "pin2"
+    ],
+    "x": 26.96,
+    "y": -17,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_67",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 26.96,
+    "y": -17,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_68",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 1.499997,
+    "x": 26.96,
+    "y": -17,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_19",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 35.5300107999999,
+        "y": -6.499995600000034
+      },
+      {
+        "x": 23.470039999999926,
+        "y": -6.499995600000034
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_20",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 23.470039999999926,
+        "y": -6.499995600000034
+      },
+      {
+        "x": 23.470039999999926,
+        "y": -18.69961560000013
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_21",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 35.5300107999999,
+        "y": -6.499995600000034
+      },
+      {
+        "x": 35.5300107999999,
+        "y": -18.699996600000077
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_22",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 23.470039999999926,
+        "y": -18.75000919999991
+      },
+      {
+        "x": 35.5300107999999,
+        "y": -18.75003460000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_23",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 35.5300107999999,
+        "y": -9.600014800000054
+      },
+      {
+        "x": 23.470039999999926,
+        "y": -9.600014800000054
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_6",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 29.4873,
+      "y": -19.7526
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J_PWR",
+    "ccw_rotation": 180,
+    "pcb_component_id": "pcb_component_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_3",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 35.76979999999992,
+        "y": -19.00260000000003
+      },
+      {
+        "x": 23.204799999999864,
+        "y": -19.00260000000003
+      },
+      {
+        "x": 23.204799999999864,
+        "y": -6.259800000000041
+      },
+      {
+        "x": 35.76979999999992,
+        "y": -6.259800000000041
+      },
+      {
+        "x": 35.76979999999992,
+        "y": -19.00260000000003
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_11",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_58",
+    "outer_width": 1.0999978,
+    "outer_height": 1.8999962,
+    "hole_width": 0.5999988,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole12",
+      "pin7"
+    ],
+    "x": 21.319905,
+    "y": -19.3000144,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_69",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 21.319905,
+    "y": -19.3000144,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_70",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 21.319905,
+    "y": -19.3000144,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_12",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_59",
+    "outer_width": 1.0999978,
+    "outer_height": 1.8999962,
+    "hole_width": 0.5999988,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole13",
+      "pin8"
+    ],
+    "x": 12.680095,
+    "y": -19.3000144,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_71",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 12.680095,
+    "y": -19.3000144,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_72",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 12.680095,
+    "y": -19.3000144,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_13",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_60",
+    "outer_width": 1.0999978,
+    "outer_height": 1.8999962,
+    "hole_width": 0.5999988,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole14",
+      "pin9"
+    ],
+    "x": 21.319905,
+    "y": -15.4999204,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_73",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 21.319905,
+    "y": -15.4999204,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_74",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 21.319905,
+    "y": -15.4999204,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_14",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_61",
+    "outer_width": 1.0999978,
+    "outer_height": 1.8999962,
+    "hole_width": 0.5999988,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole15",
+      "pin10"
+    ],
+    "x": 12.680095,
+    "y": -15.4999204,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_75",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 12.680095,
+    "y": -15.4999204,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_76",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.0999978,
+    "height": 1.8999962,
+    "x": 12.680095,
+    "y": -15.4999204,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 14.300107,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.8399983200000001,
+    "x": 14.300107,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6999986,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 15.500003,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.48999902,
+    "height": 0.8399983200000001,
+    "x": 15.500003,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_64",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6999986,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 16.500001,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.48999902,
+    "height": 0.8399983200000001,
+    "x": 16.500001,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_65",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6999986,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 17.499999,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_80",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.48999902,
+    "height": 0.8399983200000001,
+    "x": 17.499999,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_66",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6999986,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 18.499997,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_81",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.48999902,
+    "height": 0.8399983200000001,
+    "x": 18.499997,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_67",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7999984,
+    "height": 1.1999976,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 19.699893,
+    "y": -15.2499844,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_82",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.55999888,
+    "height": 0.8399983200000001,
+    "x": 19.699893,
+    "y": -15.2499844,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_24",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.329127199999903,
+        "y": -15.099972000000093
+      },
+      {
+        "x": 20.540759999999864,
+        "y": -15.099972000000093
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_25",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 13.459239999999909,
+        "y": -15.099972000000093
+      },
+      {
+        "x": 13.67087279999987,
+        "y": -15.099972000000093
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_26",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.500008999999864,
+        "y": -16.69996880000008
+      },
+      {
+        "x": 12.500008999999864,
+        "y": -16.65788100000009
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_27",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.500008999999864,
+        "y": -16.69996880000008
+      },
+      {
+        "x": 12.500008999999864,
+        "y": -18.1422824
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_28",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 21.49999099999991,
+        "y": -18.099965999999995
+      },
+      {
+        "x": 21.49999099999991,
+        "y": -16.649880000000053
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_29",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.499246999999968,
+        "y": -20.501180400000067
+      },
+      {
+        "x": 12.499246999999968,
+        "y": -20.478320400000143
+      },
+      {
+        "x": 12.499246999999968,
+        "y": -21.900720399999955
+      },
+      {
+        "x": 21.50100699999996,
+        "y": -21.900720399999955
+      },
+      {
+        "x": 21.50100699999996,
+        "y": -20.501180400000067
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_30",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 16.59997539999995,
+        "y": -16.49996920000001
+      },
+      {
+        "x": 16.59997539999995,
+        "y": -16.29996959999994
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_31",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.99997259999998,
+        "y": -16.899968400000034
+      },
+      {
+        "x": 17.99997259999998,
+        "y": -16.49996920000001
+      },
+      {
+        "x": 17.399973799999884,
+        "y": -16.49996920000001
+      },
+      {
+        "x": 17.399973799999884,
+        "y": -16.29996959999994
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_32",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.999976599999968,
+        "y": -16.899968400000034
+      },
+      {
+        "x": 15.999976599999968,
+        "y": -16.49996920000001
+      },
+      {
+        "x": 16.59997539999995,
+        "y": -16.49996920000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_33",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.989968999999974,
+        "y": -16.899968400000034
+      },
+      {
+        "x": 18.009980199999973,
+        "y": -16.899968400000034
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_34",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 14.182327199999918,
+        "y": -20.733209399999964
+      },
+      {
+        "x": 14.680167199999914,
+        "y": -18.2313094000001
+      },
+      {
+        "x": 15.980647199999908,
+        "y": -18.2313094000001
+      },
+      {
+        "x": 16.48102719999997,
+        "y": -20.733209399999964
+      },
+      {
+        "x": 15.985727199999928,
+        "y": -20.733209399999964
+      },
+      {
+        "x": 15.58694719999994,
+        "y": -18.63262940000004
+      },
+      {
+        "x": 15.058627199999933,
+        "y": -18.63262940000004
+      },
+      {
+        "x": 14.657307199999877,
+        "y": -20.733209399999964
+      },
+      {
+        "x": 14.182327199999918,
+        "y": -20.733209399999964
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_35",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 14.482047199999897,
+        "y": -19.432729400000085
+      },
+      {
+        "x": 14.880827199999885,
+        "y": -19.432729400000085
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_36",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.78140959999996,
+        "y": -19.43242459999999
+      },
+      {
+        "x": 16.181408799999986,
+        "y": -19.43242459999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_37",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 19.05818739999995,
+        "y": -19.427344600000083
+      },
+      {
+        "x": 19.458186599999976,
+        "y": -19.427344600000083
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_38",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.758824999999888,
+        "y": -19.42764939999995
+      },
+      {
+        "x": 18.157604999999876,
+        "y": -19.42764939999995
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_39",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 17.459105000000022,
+        "y": -20.728129399999943
+      },
+      {
+        "x": 17.956944999999905,
+        "y": -18.22622940000008
+      },
+      {
+        "x": 19.257425000000012,
+        "y": -18.22622940000008
+      },
+      {
+        "x": 19.757804999999962,
+        "y": -20.728129399999943
+      },
+      {
+        "x": 19.26250499999992,
+        "y": -20.728129399999943
+      },
+      {
+        "x": 18.86372499999993,
+        "y": -18.627549399999907
+      },
+      {
+        "x": 18.335404999999923,
+        "y": -18.627549399999907
+      },
+      {
+        "x": 17.934084999999982,
+        "y": -20.728129399999943
+      },
+      {
+        "x": 17.459105000000022,
+        "y": -20.728129399999943
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_7",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 17.002667,
+      "y": -13.557580399999999
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J_USB",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_4",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 11.888566999999966,
+        "y": -14.30758040000012
+      },
+      {
+        "x": 22.11676699999998,
+        "y": -14.30758040000012
+      },
+      {
+        "x": 22.11676699999998,
+        "y": -22.198980400000096
+      },
+      {
+        "x": 11.888566999999966,
+        "y": -22.198980400000096
+      },
+      {
+        "x": 11.888566999999966,
+        "y": -14.30758040000012
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_68",
+    "layer": "top",
+    "shape": "pill",
+    "x": -8.905,
+    "y": -18.769108,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_69",
+    "layer": "top",
+    "shape": "pill",
+    "x": -7.635,
+    "y": -18.769108,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_70",
+    "layer": "top",
+    "shape": "pill",
+    "x": -6.365,
+    "y": -18.769108,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_71",
+    "layer": "top",
+    "shape": "pill",
+    "x": -5.095,
+    "y": -18.769108,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_75",
+    "layer": "top",
+    "shape": "pill",
+    "x": -8.905,
+    "y": -13.230892,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_74",
+    "layer": "top",
+    "shape": "pill",
+    "x": -7.635,
+    "y": -13.230892,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_73",
+    "layer": "top",
+    "shape": "pill",
+    "x": -6.365,
+    "y": -13.230892,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_72",
+    "layer": "top",
+    "shape": "pill",
+    "x": -5.095,
+    "y": -13.230892,
+    "radius": 0.2869946,
+    "height": 2.0379944,
+    "width": 0.5739892,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.999996,
+    "height": 1.999996,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7,
+    "y": -16,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_83",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.3999972,
+    "height": 1.3999972,
+    "x": -7,
+    "y": -16,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_0",
+    "x": -6.499874,
+    "y": -15.500128,
+    "hole_diameter": 0.3048,
+    "outer_diameter": 0.6096,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_1",
+    "x": -7.499872,
+    "y": -15.500128,
+    "hole_diameter": 0.3048,
+    "outer_diameter": 0.6096,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_2",
+    "x": -7.499872,
+    "y": -16.500126,
+    "hole_diameter": 0.3048,
+    "outer_diameter": 0.6096,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_3",
+    "x": -6.499874,
+    "y": -16.500126,
+    "hole_diameter": 0.3048,
+    "outer_diameter": 0.6096,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_40",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "route": [
+      {
+        "x": -9.526207800000066,
+        "y": -17.521409199999994
+      },
+      {
+        "x": -9.526207800000066,
+        "y": -14.478590799999893
+      },
+      {
+        "x": -4.473792200000048,
+        "y": -14.478590799999893
+      },
+      {
+        "x": -4.473792200000048,
+        "y": -17.521409199999994
+      },
+      {
+        "x": -9.526207800000066,
+        "y": -17.521409199999994
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_41",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "route": [
+      {
+        "x": -8.754885999999942,
+        "y": -16.769111999999836
+      },
+      {
+        "x": -8.760001010512497,
+        "y": -16.807964362136545
+      },
+      {
+        "x": -8.774997462536362,
+        "y": -16.844168999999965
+      },
+      {
+        "x": -8.798853372648978,
+        "y": -16.875258627350945
+      },
+      {
+        "x": -8.829942999999957,
+        "y": -16.89911453746356
+      },
+      {
+        "x": -8.866147637863378,
+        "y": -16.914110989487426
+      },
+      {
+        "x": -8.905000000000086,
+        "y": -16.91922599999998
+      },
+      {
+        "x": -8.943852362136568,
+        "y": -16.914110989487426
+      },
+      {
+        "x": -8.980056999999988,
+        "y": -16.89911453746356
+      },
+      {
+        "x": -9.011146627351081,
+        "y": -16.875258627350945
+      },
+      {
+        "x": -9.035002537463697,
+        "y": -16.844168999999965
+      },
+      {
+        "x": -9.049998989487449,
+        "y": -16.807964362136545
+      },
+      {
+        "x": -9.055114000000003,
+        "y": -16.769111999999836
+      },
+      {
+        "x": -9.049998989487449,
+        "y": -16.730259637863355
+      },
+      {
+        "x": -9.035002537463697,
+        "y": -16.694054999999935
+      },
+      {
+        "x": -9.011146627351081,
+        "y": -16.66296537264884
+      },
+      {
+        "x": -8.980056999999988,
+        "y": -16.639109462536226
+      },
+      {
+        "x": -8.943852362136568,
+        "y": -16.624113010512474
+      },
+      {
+        "x": -8.905000000000086,
+        "y": -16.61899799999992
+      },
+      {
+        "x": -8.866147637863378,
+        "y": -16.624113010512474
+      },
+      {
+        "x": -8.829942999999957,
+        "y": -16.639109462536226
+      },
+      {
+        "x": -8.798853372648978,
+        "y": -16.66296537264884
+      },
+      {
+        "x": -8.774997462536362,
+        "y": -16.694054999999935
+      },
+      {
+        "x": -8.760001010512497,
+        "y": -16.730259637863355
+      },
+      {
+        "x": -8.754885999999942,
+        "y": -16.769111999999836
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_42",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "route": [
+      {
+        "x": -9.494280000000117,
+        "y": -18.76910799999996
+      },
+      {
+        "x": -9.499395010512444,
+        "y": -18.80796036213644
+      },
+      {
+        "x": -9.514391462536423,
+        "y": -18.84416500000009
+      },
+      {
+        "x": -9.538247372649039,
+        "y": -18.87525462735107
+      },
+      {
+        "x": -9.569336999999905,
+        "y": -18.899110537463685
+      },
+      {
+        "x": -9.605541637863439,
+        "y": -18.91410698948755
+      },
+      {
+        "x": -9.644394000000034,
+        "y": -18.919221999999877
+      },
+      {
+        "x": -9.683246362136515,
+        "y": -18.91410698948755
+      },
+      {
+        "x": -9.719451000000163,
+        "y": -18.899110537463685
+      },
+      {
+        "x": -9.750540627351143,
+        "y": -18.87525462735107
+      },
+      {
+        "x": -9.774396537463758,
+        "y": -18.84416500000009
+      },
+      {
+        "x": -9.789392989487624,
+        "y": -18.80796036213644
+      },
+      {
+        "x": -9.79450799999995,
+        "y": -18.76910799999996
+      },
+      {
+        "x": -9.789392989487624,
+        "y": -18.730255637863365
+      },
+      {
+        "x": -9.774396537463758,
+        "y": -18.694050999999945
+      },
+      {
+        "x": -9.750540627351143,
+        "y": -18.66296137264885
+      },
+      {
+        "x": -9.719451000000163,
+        "y": -18.639105462536236
+      },
+      {
+        "x": -9.683246362136515,
+        "y": -18.624109010512484
+      },
+      {
+        "x": -9.644394000000034,
+        "y": -18.618994000000043
+      },
+      {
+        "x": -9.605541637863439,
+        "y": -18.624109010512484
+      },
+      {
+        "x": -9.569336999999905,
+        "y": -18.639105462536236
+      },
+      {
+        "x": -9.538247372649039,
+        "y": -18.66296137264885
+      },
+      {
+        "x": -9.514391462536423,
+        "y": -18.694050999999945
+      },
+      {
+        "x": -9.499395010512444,
+        "y": -18.730255637863365
+      },
+      {
+        "x": -9.494280000000117,
+        "y": -18.76910799999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_8",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -7.1397,
+      "y": -11.4948
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_10",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_5",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -10.043999999999983,
+        "y": -12.244799999999827
+      },
+      {
+        "x": -4.235400000000027,
+        "y": -12.244799999999827
+      },
+      {
+        "x": -4.235400000000027,
+        "y": -19.80600000000004
+      },
+      {
+        "x": -10.043999999999983,
+        "y": -19.80600000000004
+      },
+      {
+        "x": -10.043999999999983,
+        "y": -12.244799999999827
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.4699976,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -23.165106,
+    "y": -17.299970000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_84",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.72899832,
+    "height": 0.6860057399999999,
+    "x": -23.165106,
+    "y": -17.299970000000002,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.4699976,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -23.165106,
+    "y": -15,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_85",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.72899832,
+    "height": 0.6860057399999999,
+    "x": -23.165106,
+    "y": -15,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.4699976,
+    "height": 0.9800082,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -23.165106,
+    "y": -12.70003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_86",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.72899832,
+    "height": 0.6860057399999999,
+    "x": -23.165106,
+    "y": -12.70003,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.4699976,
+    "height": 3.5999928,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -28.834894,
+    "y": -15,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_87",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.72899832,
+    "height": 2.5199949599999996,
+    "x": -28.834894,
+    "y": -15,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_43",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "route": [
+      {
+        "x": -27.371396799999957,
+        "y": -18.326206199999888
+      },
+      {
+        "x": -27.371396799999957,
+        "y": -11.673793799999999
+      },
+      {
+        "x": -24.628603200000043,
+        "y": -11.673793799999999
+      },
+      {
+        "x": -24.628603200000043,
+        "y": -18.326206199999888
+      },
+      {
+        "x": -27.371396799999957,
+        "y": -18.326206199999888
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_9",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -26,
+      "y": -10.6726
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_11",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_6",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -30.314000000000078,
+        "y": -11.422599999999989
+      },
+      {
+        "x": -21.686000000000035,
+        "y": -11.422599999999989
+      },
+      {
+        "x": -21.686000000000035,
+        "y": -18.577399999999898
+      },
+      {
+        "x": -30.314000000000078,
+        "y": -18.577399999999898
+      },
+      {
+        "x": -30.314000000000078,
+        "y": -11.422599999999989
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -33.825,
+    "y": -11.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_88",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -33.825,
+    "y": -11.5,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -32.175,
+    "y": -11.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -32.175,
+    "y": -11.5,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_44",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": -32.175,
+        "y": -10.625
+      },
+      {
+        "x": -34.425,
+        "y": -10.625
+      },
+      {
+        "x": -34.425,
+        "y": -12.375
+      },
+      {
+        "x": -32.175,
+        "y": -12.375
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_10",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -33,
+      "y": -10.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_12",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_0",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "center": {
+      "x": -33,
+      "y": -11.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.825,
+    "y": -11.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -20.825,
+    "y": -11.5,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -19.175,
+    "y": -11.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -19.175,
+    "y": -11.5,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_45",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.175,
+        "y": -10.625
+      },
+      {
+        "x": -21.425,
+        "y": -10.625
+      },
+      {
+        "x": -21.425,
+        "y": -12.375
+      },
+      {
+        "x": -19.175,
+        "y": -12.375
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_11",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -20,
+      "y": -10.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_13",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_1",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "center": {
+      "x": -20,
+      "y": -11.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -23.325,
+    "y": 9.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -23.325,
+    "y": 9.5,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -21.675,
+    "y": 9.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -21.675,
+    "y": 9.5,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_46",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": -22.737258,
+        "y": 10.0225
+      },
+      {
+        "x": -22.262742,
+        "y": 10.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_47",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": -22.737258,
+        "y": 8.9775
+      },
+      {
+        "x": -22.262742,
+        "y": 8.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_12",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -22.5,
+      "y": 10.875
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_14",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_2",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "center": {
+      "x": -22.5,
+      "y": 9.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -16.825,
+    "y": -9.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -16.825,
+    "y": -9.5,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -15.175,
+    "y": -9.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -15.175,
+    "y": -9.5,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_48",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": -16.237258,
+        "y": -8.9775
+      },
+      {
+        "x": -15.762742,
+        "y": -8.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_49",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": -16.237258,
+        "y": -10.0225
+      },
+      {
+        "x": -15.762742,
+        "y": -10.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_13",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -16,
+      "y": -8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_15",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_3",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "center": {
+      "x": -16,
+      "y": -9.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.325,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -20.325,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -18.675,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -18.675,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_50",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.737258,
+        "y": -13.9775
+      },
+      {
+        "x": -19.262742,
+        "y": -13.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_51",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "route": [
+      {
+        "x": -19.737258,
+        "y": -15.0225
+      },
+      {
+        "x": -19.262742,
+        "y": -15.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_14",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19.5,
+      "y": -13.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_16",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_4",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "center": {
+      "x": -19.5,
+      "y": -14.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -16.825,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -16.825,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -15.175,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -15.175,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_17",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_52",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": -16.237258,
+        "y": -13.9775
+      },
+      {
+        "x": -15.762742,
+        "y": -13.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_53",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "route": [
+      {
+        "x": -16.237258,
+        "y": -15.0225
+      },
+      {
+        "x": -15.762742,
+        "y": -15.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_15",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -16,
+      "y": -13.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_5",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "center": {
+      "x": -16,
+      "y": -14.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -13.825,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -13.825,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.175,
+    "y": -14.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -12.175,
+    "y": -14.5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_54",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.237258,
+        "y": -13.9775
+      },
+      {
+        "x": -12.762742,
+        "y": -13.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_55",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.237258,
+        "y": -15.0225
+      },
+      {
+        "x": -12.762742,
+        "y": -15.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_16",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -13,
+      "y": -13.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R5",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_18",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_6",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "center": {
+      "x": -13,
+      "y": -14.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 14.675,
+    "y": -12.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 14.675,
+    "y": -12.5,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 16.325,
+    "y": -12.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 16.325,
+    "y": -12.5,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_56",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.262742,
+        "y": -11.9775
+      },
+      {
+        "x": 15.737258,
+        "y": -11.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_57",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "route": [
+      {
+        "x": 15.262742,
+        "y": -13.0225
+      },
+      {
+        "x": 15.737258,
+        "y": -13.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_17",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 15.5,
+      "y": -11.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R6",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_19",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_7",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "center": {
+      "x": 15.5,
+      "y": -12.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "pcb_component_id": "pcb_component_20",
+    "pcb_port_id": "pcb_port_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 19.675,
+    "y": -12.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 19.675,
+    "y": -12.5,
+    "pcb_component_id": "pcb_component_20",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "pcb_component_id": "pcb_component_20",
+    "pcb_port_id": "pcb_port_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 21.325,
+    "y": -12.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 21.325,
+    "y": -12.5,
+    "pcb_component_id": "pcb_component_20",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_58",
+    "pcb_component_id": "pcb_component_20",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.262742,
+        "y": -11.9775
+      },
+      {
+        "x": 20.737258,
+        "y": -11.9775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_59",
+    "pcb_component_id": "pcb_component_20",
+    "layer": "top",
+    "route": [
+      {
+        "x": 20.262742,
+        "y": -13.0225
+      },
+      {
+        "x": 20.737258,
+        "y": -13.0225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_18",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 20.5,
+      "y": -11.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R7",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_20",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_8",
+    "pcb_component_id": "pcb_component_20",
+    "layer": "top",
+    "center": {
+      "x": 20.5,
+      "y": -12.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_111",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -29.825,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -29.825,
+    "y": 14,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_112",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -28.175,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -28.175,
+    "y": 14,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_60",
+    "pcb_component_id": "pcb_component_21",
+    "layer": "top",
+    "route": [
+      {
+        "x": -29.237258,
+        "y": 14.5225
+      },
+      {
+        "x": -28.762742,
+        "y": 14.5225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_61",
+    "pcb_component_id": "pcb_component_21",
+    "layer": "top",
+    "route": [
+      {
+        "x": -29.237258,
+        "y": 13.4775
+      },
+      {
+        "x": -28.762742,
+        "y": 13.4775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_19",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -29,
+      "y": 15.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R8",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_21",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_9",
+    "pcb_component_id": "pcb_component_21",
+    "layer": "top",
+    "center": {
+      "x": -29,
+      "y": 14
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_113",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -20.325,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -20.325,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_114",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -18.675,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -18.675,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_62",
+    "pcb_component_id": "pcb_component_22",
+    "layer": "top",
+    "route": [
+      {
+        "x": -18.675,
+        "y": -16.625
+      },
+      {
+        "x": -20.925,
+        "y": -16.625
+      },
+      {
+        "x": -20.925,
+        "y": -18.375
+      },
+      {
+        "x": -18.675,
+        "y": -18.375
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_20",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -19.5,
+      "y": -16.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "LED_TEMP",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_22",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_10",
+    "pcb_component_id": "pcb_component_22",
+    "layer": "top",
+    "center": {
+      "x": -19.5,
+      "y": -17.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "pcb_component_id": "pcb_component_23",
+    "pcb_port_id": "pcb_port_115",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -16.825,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -16.825,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_23",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "pcb_component_id": "pcb_component_23",
+    "pcb_port_id": "pcb_port_116",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -15.175,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_111",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -15.175,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_23",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_63",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "route": [
+      {
+        "x": -15.175,
+        "y": -16.625
+      },
+      {
+        "x": -17.425,
+        "y": -16.625
+      },
+      {
+        "x": -17.425,
+        "y": -18.375
+      },
+      {
+        "x": -15.175,
+        "y": -18.375
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_21",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -16,
+      "y": -16.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "LED_DOOR",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_23",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_11",
+    "pcb_component_id": "pcb_component_23",
+    "layer": "top",
+    "center": {
+      "x": -16,
+      "y": -17.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_117",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -13.825,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_112",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -13.825,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_118",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.175,
+    "y": -17.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_113",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -12.175,
+    "y": -17.5,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_64",
+    "pcb_component_id": "pcb_component_24",
+    "layer": "top",
+    "route": [
+      {
+        "x": -12.175,
+        "y": -16.625
+      },
+      {
+        "x": -14.425,
+        "y": -16.625
+      },
+      {
+        "x": -14.425,
+        "y": -18.375
+      },
+      {
+        "x": -12.175,
+        "y": -18.375
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_22",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -13,
+      "y": -16.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "LED_PWR",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_24",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_12",
+    "pcb_component_id": "pcb_component_24",
+    "layer": "top",
+    "center": {
+      "x": -13,
+      "y": -17.5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_119",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.499995,
+    "height": 1.7999964,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -13.499628000000001,
+    "y": 18,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_114",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7499965,
+    "height": 1.2599974799999998,
+    "x": -13.499628000000001,
+    "y": 18,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_120",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.499995,
+    "height": 1.7999964,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -22.500372,
+    "y": 18,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_115",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7499965,
+    "height": 1.2599974799999998,
+    "x": -22.500372,
+    "y": 18,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_65",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -23.079542800000013,
+        "y": 16.768074599999977
+      },
+      {
+        "x": -23.079542800000013,
+        "y": 12.919999999999959
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_66",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -23.079542800000013,
+        "y": 21.30200000000002
+      },
+      {
+        "x": -23.079542800000013,
+        "y": 19.231925400000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_67",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -12.919542800000045,
+        "y": 12.919999999999959
+      },
+      {
+        "x": -23.079542800000013,
+        "y": 12.919999999999959
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_68",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -12.919542800000045,
+        "y": 16.76881119999996
+      },
+      {
+        "x": -12.919542800000045,
+        "y": 12.919999999999959
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_69",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -12.919542800000045,
+        "y": 23.08000000000004
+      },
+      {
+        "x": -12.919542800000045,
+        "y": 19.2311633999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_70",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -22.38104280000016,
+        "y": 15.586999999999989
+      },
+      {
+        "x": -20.984042799999997,
+        "y": 15.586999999999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_71",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -15.142042800000127,
+        "y": 15.460000000000036
+      },
+      {
+        "x": -13.745042800000078,
+        "y": 15.460000000000036
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_72",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -14.443542800000046,
+        "y": 16.222000000000094
+      },
+      {
+        "x": -14.443542800000046,
+        "y": 14.698000000000093
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_73",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -23.079542800000013,
+        "y": 21.30200000000002
+      },
+      {
+        "x": -21.301542800000107,
+        "y": 23.08000000000004
+      },
+      {
+        "x": -12.919542800000045,
+        "y": 23.08000000000004
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_74",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "route": [
+      {
+        "x": -16.828551999999945,
+        "y": 18
+      },
+      {
+        "x": -16.868450812965193,
+        "y": 17.69693842732761
+      },
+      {
+        "x": -16.98542821369267,
+        "y": 17.414530000000127
+      },
+      {
+        "x": -17.17151238563747,
+        "y": 17.172020385637552
+      },
+      {
+        "x": -17.414022000000045,
+        "y": 16.985936213692753
+      },
+      {
+        "x": -17.69643042732764,
+        "y": 16.868958812965047
+      },
+      {
+        "x": -17.999492000000146,
+        "y": 16.829060000000027
+      },
+      {
+        "x": -18.302553572672423,
+        "y": 16.868958812965047
+      },
+      {
+        "x": -18.58496200000002,
+        "y": 16.985936213692753
+      },
+      {
+        "x": -18.82747161436248,
+        "y": 17.172020385637552
+      },
+      {
+        "x": -19.013555786307393,
+        "y": 17.414530000000127
+      },
+      {
+        "x": -19.130533187034985,
+        "y": 17.69693842732761
+      },
+      {
+        "x": -19.170432000000005,
+        "y": 18
+      },
+      {
+        "x": -19.130533187034985,
+        "y": 18.30306157267239
+      },
+      {
+        "x": -19.013555786307393,
+        "y": 18.585469999999987
+      },
+      {
+        "x": -18.82747161436248,
+        "y": 18.82797961436256
+      },
+      {
+        "x": -18.58496200000002,
+        "y": 19.01406378630736
+      },
+      {
+        "x": -18.302553572672423,
+        "y": 19.13104118703484
+      },
+      {
+        "x": -17.999492000000146,
+        "y": 19.170940000000087
+      },
+      {
+        "x": -17.69643042732764,
+        "y": 19.13104118703484
+      },
+      {
+        "x": -17.414022000000045,
+        "y": 19.01406378630736
+      },
+      {
+        "x": -17.17151238563747,
+        "y": 18.82797961436256
+      },
+      {
+        "x": -16.98542821369267,
+        "y": 18.585469999999987
+      },
+      {
+        "x": -16.868450812965193,
+        "y": 18.30306157267239
+      },
+      {
+        "x": -16.828551999999945,
+        "y": 18
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_23",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -17.9873,
+      "y": 24.080508000000002
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "BZ1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_25",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_7",
+    "pcb_component_id": "pcb_component_25",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -23.990400000000022,
+        "y": 23.33050800000001
+      },
+      {
+        "x": -11.984199999999987,
+        "y": 23.33050800000001
+      },
+      {
+        "x": -11.984199999999987,
+        "y": 12.67050800000004
+      },
+      {
+        "x": -23.990400000000022,
+        "y": 12.67050800000004
+      },
+      {
+        "x": -23.990400000000022,
+        "y": 23.33050800000001
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_port_id": "pcb_port_121",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6,
+    "height": 1,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -27.45,
+    "y": 9.9,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_116",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.42,
+    "height": 0.7,
+    "x": -27.45,
+    "y": 9.9,
+    "pcb_component_id": "pcb_component_26",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_port_id": "pcb_port_122",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6,
+    "height": 1,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -25.55,
+    "y": 9.9,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_117",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.42,
+    "height": 0.7,
+    "x": -25.55,
+    "y": 9.9,
+    "pcb_component_id": "pcb_component_26",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "pcb_component_id": "pcb_component_26",
+    "pcb_port_id": "pcb_port_123",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 1,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -26.5,
+    "y": 12.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_118",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.48999999999999994,
+    "height": 0.7,
+    "x": -26.5,
+    "y": 12.1,
+    "pcb_component_id": "pcb_component_26",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_rect",
+    "pcb_silkscreen_rect_id": "pcb_silkscreen_rect_2",
+    "pcb_component_id": "pcb_component_26",
+    "layer": "top",
+    "center": {
+      "x": -26.5,
+      "y": 11
+    },
+    "width": 3,
+    "height": 2.8,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "stroke_width": 0.1,
+    "is_filled": false
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_124",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.2999954,
+    "height": 1.499997,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.5499020000000003,
+    "y": -15.249941,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_119",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.6099967799999997,
+    "height": 1.0499979,
+    "x": -0.5499020000000003,
+    "y": -15.249941,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_125",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.2999954,
+    "height": 1.499997,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.549902,
+    "y": -15.250195,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_120",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.6099967799999997,
+    "height": 1.0499979,
+    "x": 8.549902,
+    "y": -15.250195,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_126",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.2999954,
+    "height": 1.499997,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.5499020000000003,
+    "y": -19.750059,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_121",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.6099967799999997,
+    "height": 1.0499979,
+    "x": -0.5499020000000003,
+    "y": -19.750059,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_127",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.2999954,
+    "height": 1.499997,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.549902,
+    "y": -19.750059,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_122",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.6099967799999997,
+    "height": 1.0499979,
+    "x": 8.549902,
+    "y": -19.750059,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_75",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 1.0000059999998712,
+        "y": -14.500133000000005
+      },
+      {
+        "x": 6.999994000000015,
+        "y": -14.500133000000005
+      },
+      {
+        "x": 6.999994000000015,
+        "y": -20.500121000000036
+      },
+      {
+        "x": 1.0000059999998712,
+        "y": -20.500121000000036
+      },
+      {
+        "x": 1.0000059999998712,
+        "y": -14.500133000000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_76",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 5.529334000000063,
+        "y": -17.50012700000002
+      },
+      {
+        "x": 5.4772232076219325,
+        "y": -17.895947765522806
+      },
+      {
+        "x": 5.324442094871301,
+        "y": -18.26479400000005
+      },
+      {
+        "x": 5.081402442099147,
+        "y": -18.581529442099054
+      },
+      {
+        "x": 4.764666999999918,
+        "y": -18.824569094871208
+      },
+      {
+        "x": 4.395820765522899,
+        "y": -18.977350207622067
+      },
+      {
+        "x": 4,
+        "y": -19.02946099999997
+      },
+      {
+        "x": 3.6041792344772148,
+        "y": -18.977350207622067
+      },
+      {
+        "x": 3.2353329999999687,
+        "y": -18.824569094871208
+      },
+      {
+        "x": 2.9185975579008527,
+        "y": -18.581529442099054
+      },
+      {
+        "x": 2.6755579051286986,
+        "y": -18.26479400000005
+      },
+      {
+        "x": 2.522776792377954,
+        "y": -17.895947765522806
+      },
+      {
+        "x": 2.4706659999998237,
+        "y": -17.50012700000002
+      },
+      {
+        "x": 2.522776792377954,
+        "y": -17.10430623447712
+      },
+      {
+        "x": 2.6755579051286986,
+        "y": -16.735460000000103
+      },
+      {
+        "x": 2.9185975579008527,
+        "y": -16.418724557900873
+      },
+      {
+        "x": 3.2353329999999687,
+        "y": -16.17568490512872
+      },
+      {
+        "x": 3.6041792344772148,
+        "y": -16.022903792378088
+      },
+      {
+        "x": 4,
+        "y": -15.970792999999958
+      },
+      {
+        "x": 4.395820765522899,
+        "y": -16.022903792378088
+      },
+      {
+        "x": 4.764666999999918,
+        "y": -16.17568490512872
+      },
+      {
+        "x": 5.081402442099147,
+        "y": -16.418724557900873
+      },
+      {
+        "x": 5.324442094871301,
+        "y": -16.735460000000103
+      },
+      {
+        "x": 5.4772232076219325,
+        "y": -17.10430623447712
+      },
+      {
+        "x": 5.529334000000063,
+        "y": -17.50012700000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_77",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 6.539999999999964,
+        "y": -19.532126999999946
+      },
+      {
+        "x": 6.522690319754815,
+        "y": -19.663607074911965
+      },
+      {
+        "x": 6.4719409051224375,
+        "y": -19.78612700000008
+      },
+      {
+        "x": 6.391210244842682,
+        "y": -19.891337244842703
+      },
+      {
+        "x": 6.2859999999999445,
+        "y": -19.97206790512257
+      },
+      {
+        "x": 6.163480074912059,
+        "y": -20.022817319754722
+      },
+      {
+        "x": 6.031999999999925,
+        "y": -20.040126999999984
+      },
+      {
+        "x": 5.900519925087906,
+        "y": -20.022817319754722
+      },
+      {
+        "x": 5.77800000000002,
+        "y": -19.97206790512257
+      },
+      {
+        "x": 5.672789755157282,
+        "y": -19.891337244842703
+      },
+      {
+        "x": 5.592059094877413,
+        "y": -19.78612700000008
+      },
+      {
+        "x": 5.541309680245149,
+        "y": -19.663607074911965
+      },
+      {
+        "x": 5.523999999999887,
+        "y": -19.532126999999946
+      },
+      {
+        "x": 5.541309680245149,
+        "y": -19.400646925087926
+      },
+      {
+        "x": 5.592059094877413,
+        "y": -19.278126999999927
+      },
+      {
+        "x": 5.672789755157282,
+        "y": -19.172916755157303
+      },
+      {
+        "x": 5.77800000000002,
+        "y": -19.092186094877434
+      },
+      {
+        "x": 5.900519925087906,
+        "y": -19.041436680245056
+      },
+      {
+        "x": 6.031999999999925,
+        "y": -19.02412700000002
+      },
+      {
+        "x": 6.163480074912059,
+        "y": -19.041436680245056
+      },
+      {
+        "x": 6.2859999999999445,
+        "y": -19.092186094877434
+      },
+      {
+        "x": 6.391210244842682,
+        "y": -19.172916755157303
+      },
+      {
+        "x": 6.4719409051224375,
+        "y": -19.278126999999927
+      },
+      {
+        "x": 6.522690319754815,
+        "y": -19.400646925087926
+      },
+      {
+        "x": 6.539999999999964,
+        "y": -19.532126999999946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_78",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 2.4759999999998854,
+        "y": -19.532126999999946
+      },
+      {
+        "x": 2.458690319754737,
+        "y": -19.663607074911965
+      },
+      {
+        "x": 2.4079409051225866,
+        "y": -19.78612700000008
+      },
+      {
+        "x": 2.3272102448427177,
+        "y": -19.891337244842703
+      },
+      {
+        "x": 2.2219999999998663,
+        "y": -19.97206790512257
+      },
+      {
+        "x": 2.0994800749119804,
+        "y": -20.022817319754722
+      },
+      {
+        "x": 1.967999999999961,
+        "y": -20.040126999999984
+      },
+      {
+        "x": 1.8365199250879414,
+        "y": -20.022817319754722
+      },
+      {
+        "x": 1.7139999999999418,
+        "y": -19.97206790512257
+      },
+      {
+        "x": 1.6087897551573178,
+        "y": -19.891337244842703
+      },
+      {
+        "x": 1.5280590948774488,
+        "y": -19.78612700000008
+      },
+      {
+        "x": 1.477309680245071,
+        "y": -19.663607074911965
+      },
+      {
+        "x": 1.4599999999999227,
+        "y": -19.532126999999946
+      },
+      {
+        "x": 1.477309680245071,
+        "y": -19.400646925087926
+      },
+      {
+        "x": 1.5280590948774488,
+        "y": -19.278126999999927
+      },
+      {
+        "x": 1.6087897551573178,
+        "y": -19.172916755157303
+      },
+      {
+        "x": 1.7139999999999418,
+        "y": -19.092186094877434
+      },
+      {
+        "x": 1.8365199250879414,
+        "y": -19.041436680245056
+      },
+      {
+        "x": 1.967999999999961,
+        "y": -19.02412700000002
+      },
+      {
+        "x": 2.0994800749119804,
+        "y": -19.041436680245056
+      },
+      {
+        "x": 2.2219999999998663,
+        "y": -19.092186094877434
+      },
+      {
+        "x": 2.3272102448427177,
+        "y": -19.172916755157303
+      },
+      {
+        "x": 2.4079409051225866,
+        "y": -19.278126999999927
+      },
+      {
+        "x": 2.458690319754737,
+        "y": -19.400646925087926
+      },
+      {
+        "x": 2.4759999999998854,
+        "y": -19.532126999999946
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_79",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 6.539999999999964,
+        "y": -15.468126999999981
+      },
+      {
+        "x": 6.522690319754815,
+        "y": -15.599607074912
+      },
+      {
+        "x": 6.4719409051224375,
+        "y": -15.722127
+      },
+      {
+        "x": 6.391210244842682,
+        "y": -15.827337244842738
+      },
+      {
+        "x": 6.2859999999999445,
+        "y": -15.908067905122493
+      },
+      {
+        "x": 6.163480074912059,
+        "y": -15.958817319754871
+      },
+      {
+        "x": 6.031999999999925,
+        "y": -15.97612700000002
+      },
+      {
+        "x": 5.900519925087906,
+        "y": -15.958817319754871
+      },
+      {
+        "x": 5.77800000000002,
+        "y": -15.908067905122493
+      },
+      {
+        "x": 5.672789755157282,
+        "y": -15.827337244842738
+      },
+      {
+        "x": 5.592059094877413,
+        "y": -15.722127
+      },
+      {
+        "x": 5.541309680245149,
+        "y": -15.599607074912
+      },
+      {
+        "x": 5.523999999999887,
+        "y": -15.468126999999981
+      },
+      {
+        "x": 5.541309680245149,
+        "y": -15.336646925087962
+      },
+      {
+        "x": 5.592059094877413,
+        "y": -15.214127000000076
+      },
+      {
+        "x": 5.672789755157282,
+        "y": -15.108916755157225
+      },
+      {
+        "x": 5.77800000000002,
+        "y": -15.028186094877356
+      },
+      {
+        "x": 5.900519925087906,
+        "y": -14.977436680245205
+      },
+      {
+        "x": 6.031999999999925,
+        "y": -14.960127000000057
+      },
+      {
+        "x": 6.163480074912059,
+        "y": -14.977436680245205
+      },
+      {
+        "x": 6.2859999999999445,
+        "y": -15.028186094877356
+      },
+      {
+        "x": 6.391210244842682,
+        "y": -15.108916755157225
+      },
+      {
+        "x": 6.4719409051224375,
+        "y": -15.214127000000076
+      },
+      {
+        "x": 6.522690319754815,
+        "y": -15.336646925087962
+      },
+      {
+        "x": 6.539999999999964,
+        "y": -15.468126999999981
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_80",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "route": [
+      {
+        "x": 2.4780319999999847,
+        "y": -15.469650999999999
+      },
+      {
+        "x": 2.4607223197547228,
+        "y": -15.601131074912018
+      },
+      {
+        "x": 2.4099729051224585,
+        "y": -15.723650999999904
+      },
+      {
+        "x": 2.3292422448427033,
+        "y": -15.828861244842642
+      },
+      {
+        "x": 2.224031999999852,
+        "y": -15.909591905122397
+      },
+      {
+        "x": 2.101512074911966,
+        "y": -15.960341319754775
+      },
+      {
+        "x": 1.9700319999998328,
+        "y": -15.977650999999923
+      },
+      {
+        "x": 1.838551925087927,
+        "y": -15.960341319754775
+      },
+      {
+        "x": 1.7160319999999274,
+        "y": -15.909591905122397
+      },
+      {
+        "x": 1.6108217551571897,
+        "y": -15.828861244842642
+      },
+      {
+        "x": 1.5300910948774344,
+        "y": -15.723650999999904
+      },
+      {
+        "x": 1.4793416802450565,
+        "y": -15.601131074912018
+      },
+      {
+        "x": 1.4620319999999083,
+        "y": -15.469650999999999
+      },
+      {
+        "x": 1.4793416802450565,
+        "y": -15.338170925087866
+      },
+      {
+        "x": 1.5300910948774344,
+        "y": -15.21565099999998
+      },
+      {
+        "x": 1.6108217551571897,
+        "y": -15.110440755157242
+      },
+      {
+        "x": 1.7160319999999274,
+        "y": -15.029710094877373
+      },
+      {
+        "x": 1.838551925087927,
+        "y": -14.978960680245109
+      },
+      {
+        "x": 1.9700319999998328,
+        "y": -14.961650999999847
+      },
+      {
+        "x": 2.101512074911966,
+        "y": -14.978960680245109
+      },
+      {
+        "x": 2.224031999999852,
+        "y": -15.029710094877373
+      },
+      {
+        "x": 2.3292422448427033,
+        "y": -15.110440755157242
+      },
+      {
+        "x": 2.4099729051224585,
+        "y": -15.21565099999998
+      },
+      {
+        "x": 2.4607223197547228,
+        "y": -15.338170925087866
+      },
+      {
+        "x": 2.4780319999999847,
+        "y": -15.469650999999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_24",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 4.0127,
+      "y": -13.477527
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "SW1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_27",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_8",
+    "pcb_component_id": "pcb_component_27",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -1.939600000000155,
+        "y": -14.22752700000001
+      },
+      {
+        "x": 9.964999999999918,
+        "y": -14.22752700000001
+      },
+      {
+        "x": 9.964999999999918,
+        "y": -20.74732700000004
+      },
+      {
+        "x": -1.939600000000155,
+        "y": -20.74732700000004
+      },
+      {
+        "x": -1.939600000000155,
+        "y": -14.22752700000001
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.29001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -11.02001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -9.75001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.48001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.21001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.94001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.67001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.40001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.13001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.86001825,
+    "y": -7.000109,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.40998175000000003,
+    "y": -7.000109,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.6799817499999996,
+    "y": -7.000109,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.94998175,
+    "y": -7.000109,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.21998175,
+    "y": -7.000109,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": -3.714873,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": -2.4448730000000003,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": -1.1748729999999998,
+    "source_port_id": "source_port_16"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 0.09512699999999996,
+    "source_port_id": "source_port_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 1.365127,
+    "source_port_id": "source_port_18"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 2.6351269999999998,
+    "source_port_id": "source_port_19"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 3.9051270000000002,
+    "source_port_id": "source_port_20"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 5.175127,
+    "source_port_id": "source_port_21"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 6.445127,
+    "source_port_id": "source_port_22"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.715025750000001,
+    "y": 7.715127,
+    "source_port_id": "source_port_23"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.21998175,
+    "y": 11.000109,
+    "source_port_id": "source_port_24"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.94998175,
+    "y": 11.000109,
+    "source_port_id": "source_port_25"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.6799817499999996,
+    "y": 11.000109,
+    "source_port_id": "source_port_26"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.40998175000000003,
+    "y": 11.000109,
+    "source_port_id": "source_port_27"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.86001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.13001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.40001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.67001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.94001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.21001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.48001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -9.75001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -11.02001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.29001825,
+    "y": 11.000109,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.60905825,
+    "y": 0.499749,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_39",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.60905825,
+    "y": -0.900045,
+    "source_port_id": "source_port_39"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_40",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.60905825,
+    "y": 1.900051,
+    "source_port_id": "source_port_40"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_41",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.00910625,
+    "y": 1.900051,
+    "source_port_id": "source_port_41"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_42",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.00910625,
+    "y": 0.500003,
+    "source_port_id": "source_port_42"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_43",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.00910625,
+    "y": -0.900045,
+    "source_port_id": "source_port_43"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_44",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.20901025,
+    "y": -0.900045,
+    "source_port_id": "source_port_44"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_45",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.20901025,
+    "y": 0.500003,
+    "source_port_id": "source_port_45"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_46",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.20901025,
+    "y": 1.900051,
+    "source_port_id": "source_port_46"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_47",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 17.19,
+    "y": 14,
+    "source_port_id": "source_port_47"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_48",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 19.73,
+    "y": 14,
+    "source_port_id": "source_port_48"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_49",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 22.27,
+    "y": 14,
+    "source_port_id": "source_port_49"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_50",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 24.81,
+    "y": 14,
+    "source_port_id": "source_port_50"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_51",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -30.000127,
+    "y": 4.96,
+    "source_port_id": "source_port_51"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_52",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -29.999873,
+    "y": 7.5,
+    "source_port_id": "source_port_52"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_53",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -29.999873,
+    "y": 10.04,
+    "source_port_id": "source_port_53"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_54",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -30,
+    "y": -6.74406025,
+    "source_port_id": "source_port_54"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_55",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -30,
+    "y": -4.24393825,
+    "source_port_id": "source_port_55"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_56",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 32.04,
+    "y": -17,
+    "source_port_id": "source_port_56"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_57",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 26.96,
+    "y": -17,
+    "source_port_id": "source_port_57"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_58",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 21.319905,
+    "y": -19.3000144,
+    "source_port_id": "source_port_58"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_59",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.680095,
+    "y": -19.3000144,
+    "source_port_id": "source_port_59"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_60",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 21.319905,
+    "y": -15.4999204,
+    "source_port_id": "source_port_60"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_61",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.680095,
+    "y": -15.4999204,
+    "source_port_id": "source_port_61"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_62",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 14.300107,
+    "y": -15.2499844,
+    "source_port_id": "source_port_62"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_63",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 15.500003,
+    "y": -15.2499844,
+    "source_port_id": "source_port_63"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_64",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 16.500001,
+    "y": -15.2499844,
+    "source_port_id": "source_port_64"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_65",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 17.499999,
+    "y": -15.2499844,
+    "source_port_id": "source_port_65"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_66",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 18.499997,
+    "y": -15.2499844,
+    "source_port_id": "source_port_66"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_67",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 19.699893,
+    "y": -15.2499844,
+    "source_port_id": "source_port_67"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_68",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.905,
+    "y": -18.769108,
+    "source_port_id": "source_port_74"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_69",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.635,
+    "y": -18.769108,
+    "source_port_id": "source_port_75"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_70",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.365,
+    "y": -18.769108,
+    "source_port_id": "source_port_76"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_71",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.095,
+    "y": -18.769108,
+    "source_port_id": "source_port_77"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_72",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.095,
+    "y": -13.230892,
+    "source_port_id": "source_port_78"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_73",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.365,
+    "y": -13.230892,
+    "source_port_id": "source_port_79"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_74",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.635,
+    "y": -13.230892,
+    "source_port_id": "source_port_80"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_75",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -8.905,
+    "y": -13.230892,
+    "source_port_id": "source_port_81"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_76",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7,
+    "y": -16,
+    "source_port_id": "source_port_82"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_77",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -15.500128,
+    "source_port_id": "source_port_83"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_78",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -15.500128,
+    "source_port_id": "source_port_84"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_79",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -15.500128,
+    "source_port_id": "source_port_85"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_80",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -15.500128,
+    "source_port_id": "source_port_86"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_81",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -15.500128,
+    "source_port_id": "source_port_87"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_82",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -15.500128,
+    "source_port_id": "source_port_88"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_83",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -16.500126,
+    "source_port_id": "source_port_89"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_84",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -16.500126,
+    "source_port_id": "source_port_90"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_85",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.499872,
+    "y": -16.500126,
+    "source_port_id": "source_port_91"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_86",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -16.500126,
+    "source_port_id": "source_port_92"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_87",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -16.500126,
+    "source_port_id": "source_port_93"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_88",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.499874,
+    "y": -16.500126,
+    "source_port_id": "source_port_94"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_89",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -23.165106,
+    "y": -17.299970000000002,
+    "source_port_id": "source_port_95"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_90",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -23.165106,
+    "y": -15,
+    "source_port_id": "source_port_96"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_91",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -23.165106,
+    "y": -12.70003,
+    "source_port_id": "source_port_97"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_92",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -28.834894,
+    "y": -15,
+    "source_port_id": "source_port_98"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_93",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -33.825,
+    "y": -11.5,
+    "source_port_id": "source_port_99"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_94",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -32.175,
+    "y": -11.5,
+    "source_port_id": "source_port_100"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_95",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.825,
+    "y": -11.5,
+    "source_port_id": "source_port_101"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_96",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -19.175,
+    "y": -11.5,
+    "source_port_id": "source_port_102"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_97",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -23.325,
+    "y": 9.5,
+    "source_port_id": "source_port_103"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_98",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -21.675,
+    "y": 9.5,
+    "source_port_id": "source_port_104"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_99",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -16.825,
+    "y": -9.5,
+    "source_port_id": "source_port_105"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_100",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -15.175,
+    "y": -9.5,
+    "source_port_id": "source_port_106"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_101",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.325,
+    "y": -14.5,
+    "source_port_id": "source_port_107"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_102",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -18.675,
+    "y": -14.5,
+    "source_port_id": "source_port_108"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_103",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -16.825,
+    "y": -14.5,
+    "source_port_id": "source_port_109"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_104",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -15.175,
+    "y": -14.5,
+    "source_port_id": "source_port_110"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_105",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -13.825,
+    "y": -14.5,
+    "source_port_id": "source_port_111"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_106",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.175,
+    "y": -14.5,
+    "source_port_id": "source_port_112"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_107",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 14.675,
+    "y": -12.5,
+    "source_port_id": "source_port_113"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_108",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 16.325,
+    "y": -12.5,
+    "source_port_id": "source_port_114"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_109",
+    "pcb_component_id": "pcb_component_20",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 19.675,
+    "y": -12.5,
+    "source_port_id": "source_port_115"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_110",
+    "pcb_component_id": "pcb_component_20",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 21.325,
+    "y": -12.5,
+    "source_port_id": "source_port_116"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_111",
+    "pcb_component_id": "pcb_component_21",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -29.825,
+    "y": 14,
+    "source_port_id": "source_port_117"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_112",
+    "pcb_component_id": "pcb_component_21",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -28.175,
+    "y": 14,
+    "source_port_id": "source_port_118"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_113",
+    "pcb_component_id": "pcb_component_22",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.325,
+    "y": -17.5,
+    "source_port_id": "source_port_119"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_114",
+    "pcb_component_id": "pcb_component_22",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -18.675,
+    "y": -17.5,
+    "source_port_id": "source_port_120"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_115",
+    "pcb_component_id": "pcb_component_23",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -16.825,
+    "y": -17.5,
+    "source_port_id": "source_port_121"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_116",
+    "pcb_component_id": "pcb_component_23",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -15.175,
+    "y": -17.5,
+    "source_port_id": "source_port_122"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_117",
+    "pcb_component_id": "pcb_component_24",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -13.825,
+    "y": -17.5,
+    "source_port_id": "source_port_123"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_118",
+    "pcb_component_id": "pcb_component_24",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.175,
+    "y": -17.5,
+    "source_port_id": "source_port_124"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_119",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -13.499628000000001,
+    "y": 18,
+    "source_port_id": "source_port_125"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_120",
+    "pcb_component_id": "pcb_component_25",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -22.500372,
+    "y": 18,
+    "source_port_id": "source_port_126"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_121",
+    "pcb_component_id": "pcb_component_26",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -27.45,
+    "y": 9.9,
+    "source_port_id": "source_port_127"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_122",
+    "pcb_component_id": "pcb_component_26",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -25.55,
+    "y": 9.9,
+    "source_port_id": "source_port_128"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_123",
+    "pcb_component_id": "pcb_component_26",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -26.5,
+    "y": 12.1,
+    "source_port_id": "source_port_129"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_124",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.5499020000000003,
+    "y": -15.249941,
+    "source_port_id": "source_port_130"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_125",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.549902,
+    "y": -15.250195,
+    "source_port_id": "source_port_131"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_126",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.5499020000000003,
+    "y": -19.750059,
+    "source_port_id": "source_port_132"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_127",
+    "pcb_component_id": "pcb_component_27",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.549902,
+    "y": -19.750059,
+    "source_port_id": "source_port_133"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": -2.9999999999999996,
+      "y": 2,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C701342.obj?uuid=cad43509223249168514859e4520db8a&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C701342.step?uuid=cad43509223249168514859e4520db8a&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -4.066063750000012,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": 21,
+      "y": 2.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "show_as_bounding_box": true
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": -30,
+      "y": 7.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7429633.obj?uuid=086fcab2d8124db5931a28c539f75702&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7429633.step?uuid=086fcab2d8124db5931a28c539f75702&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": -0.00001189999998141289,
+      "z": -0.000006999999999646178
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": -30,
+      "y": -5.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7429641.obj?uuid=4b936a6b43e543569861783b1e9e0ab5&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7429641.step?uuid=4b936a6b43e543569861783b1e9e0ab5&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.001051549999824708,
+      "y": 3.4999548999999206,
+      "z": -2.9500067999999997
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_4",
+    "position": {
+      "x": 29.5,
+      "y": -17,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C3697.obj?uuid=9354c2f876a84dd88574b031923ef132&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C3697.step?uuid=9354c2f876a84dd88574b031923ef132&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 2.54,
+      "y": -0.02500239999997156,
+      "z": -0.000008000000000230045
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_5",
+    "position": {
+      "x": 17,
+      "y": -17.399967399999998,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_5",
+    "source_component_id": "source_component_5",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C456012.obj?uuid=a8c86ef7d632469a8c796c24a9574b1e&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C456012.step?uuid=a8c86ef7d632469a8c796c24a9574b1e&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012700000070253736,
+      "y": -2.2999397999999927,
+      "z": 0.059997999999999996
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_6",
+    "position": {
+      "x": -7,
+      "y": -16,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_10",
+    "source_component_id": "source_component_6",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C15051.obj?uuid=d3dfb165ce8644e793b750cd6f375e75&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C15051.step?uuid=d3dfb165ce8644e793b750cd6f375e75&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0.000012700000070253736,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_7",
+    "position": {
+      "x": -26,
+      "y": -15,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_11",
+    "source_component_id": "source_component_7",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C347222.obj?uuid=e80246a9471445bfb635be848806a22e&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C347222.step?uuid=e80246a9471445bfb635be848806a22e&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012700000070253736,
+      "y": -0.000012700000070253736,
+      "z": -0.049394
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_8",
+    "position": {
+      "x": -33,
+      "y": -11.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_12",
+    "source_component_id": "source_component_8",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_9",
+    "position": {
+      "x": -20,
+      "y": -11.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_13",
+    "source_component_id": "source_component_9",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_10",
+    "position": {
+      "x": -22.5,
+      "y": 9.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_14",
+    "source_component_id": "source_component_10",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_11",
+    "position": {
+      "x": -16,
+      "y": -9.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_15",
+    "source_component_id": "source_component_11",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_12",
+    "position": {
+      "x": -19.5,
+      "y": -14.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_16",
+    "source_component_id": "source_component_12",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_13",
+    "position": {
+      "x": -16,
+      "y": -14.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_17",
+    "source_component_id": "source_component_13",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_14",
+    "position": {
+      "x": -13,
+      "y": -14.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_18",
+    "source_component_id": "source_component_14",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_15",
+    "position": {
+      "x": 15.5,
+      "y": -12.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_19",
+    "source_component_id": "source_component_15",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_16",
+    "position": {
+      "x": 20.5,
+      "y": -12.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_20",
+    "source_component_id": "source_component_16",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_17",
+    "position": {
+      "x": -29,
+      "y": 14,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_21",
+    "source_component_id": "source_component_17",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_18",
+    "position": {
+      "x": -19.5,
+      "y": -17.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_22",
+    "source_component_id": "source_component_18",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603_color(red)"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_19",
+    "position": {
+      "x": -16,
+      "y": -17.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_23",
+    "source_component_id": "source_component_19",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603_color(yellow)"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_20",
+    "position": {
+      "x": -13,
+      "y": -17.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_24",
+    "source_component_id": "source_component_20",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603_color(green)"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_21",
+    "position": {
+      "x": -18,
+      "y": 18,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_25",
+    "source_component_id": "source_component_21",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C409830.obj?uuid=01837209aada41dc9731c0ff01df96cf&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C409830.step?uuid=01837209aada41dc9731c0ff01df96cf&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0.00010160000010728254,
+      "y": 0,
+      "z": -0.2
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_22",
+    "position": {
+      "x": -26.5,
+      "y": 11,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_26",
+    "source_component_id": "source_component_22",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "show_as_bounding_box": true
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_23",
+    "position": {
+      "x": 3.9999999999999996,
+      "y": -17.5,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_27",
+    "source_component_id": "source_component_23",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2837531.obj?uuid=0a2a6eed7e284a95867695201df5c190&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C2837531.step?uuid=0a2a6eed7e284a95867695201df5c190&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": 0.0004999999999999449,
+      "z": -0.5
+    }
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_fraFd9y1oD",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<chip#55 name=\".OLED1\" /> footprint the provided footprint does not match supplier footprint jlcpcb:C152912 (copper IoU 0.1342).",
+    "source_component_id": "source_component_1",
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C152912",
+    "footprint_copper_intersection_over_union": 0.1342
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -9.75001825,
+        "y": -7.000109,
+        "width": 0.4,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_2"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.02001825,
+        "y": -7.000109,
+        "width": 0.4,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_1"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -20.825,
+        "y": -11.5,
+        "width": 0.275,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_95"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.159107112750988,
+        "y": -11.5,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.80667746248094,
+        "y": -10.852429650270045,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.91057034972996,
+        "y": -10.852429650270045,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.910161428618125,
+        "y": -10.863592010475315,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -21.910161428618125,
+        "y": -10.863592010475315,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -21.910161428618125,
+        "y": -10.863592010475315,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.012691113162404,
+        "y": -13.62370105442964,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.435884171380195,
+        "y": -14.062115828619808,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.393,
+        "y": -14.105,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -22.393,
+        "y": -14.105,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -22.393,
+        "y": -14.105,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.393,
+        "y": -14.228000000000002,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.165,
+        "y": -15,
+        "width": 0.275,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_90"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst2_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -9.5,
+        "width": 0.275,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_99"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.345141008606646,
+        "y": -10.020141008606645,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.622565304629614,
+        "y": -10.007840526673846,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.777098480629284,
+        "y": -10.011261702566598,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.037446503039142,
+        "y": -10.260063527512948,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.02491310318939,
+        "y": -10.694356882098264,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.825,
+        "y": -11.5,
+        "width": 0.275,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_95"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst3_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -23.165106,
+        "y": -15,
+        "width": 0.4,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_90"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.835,
+        "y": -15,
+        "width": 0.4,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_92"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst4_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -9.5,
+        "width": 0.275,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_99"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.894454516503433,
+        "y": -8.64624342273624,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.380322224474346,
+        "y": -5.168134926722398,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.799187589199411,
+        "y": -5.197955841410351,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.155936408371526,
+        "y": -5.868756841862684,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.158578218038372,
+        "y": -6.861421781961628,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.02,
+        "y": -7,
+        "width": 0.275,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_1"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst5_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -29.999873,
+        "y": 10.04,
+        "width": 0.275,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_53"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.125855515127675,
+        "y": 10.959320796070141,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.739017484872324,
+        "y": 10.934196688802183,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.325,
+        "y": 9.5,
+        "width": 0.275,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_97"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst6_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -9.5,
+        "width": 0.4,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_99"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.826635004079236,
+        "y": 2.7883044213540153,
+        "width": 0.4,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.129984034612917,
+        "y": 9.075623767588826,
+        "width": 0.4,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.120335313498302,
+        "y": 9.295335313498303,
+        "width": 0.4,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.325,
+        "y": 9.5,
+        "width": 0.4,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_97"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst7_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 19.73,
+        "y": 14,
+        "width": 0.275,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_48"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.73,
+        "y": 13.5,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.637992,
+        "y": 13.5,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.538,
+        "y": 13.400008,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "through_pad",
+        "start": {
+          "x": 19.538,
+          "y": 13.400008
+        },
+        "end": {
+          "x": 19.538,
+          "y": 13.400008
+        },
+        "start_layer": "top",
+        "end_layer": "bottom",
+        "width": 0.275
+      },
+      {
+        "route_type": "wire",
+        "x": 19.538,
+        "y": 13.400008,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.92645988746782,
+        "y": 9.812409221587561,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.5350713196446755,
+        "y": 9.829452968313662,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.6276763818348261,
+        "y": 4.625729753386631,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5749801214778856,
+        "y": 4.625729753386631,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.589270246613369,
+        "y": 4.625729753386631,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.739,
+        "y": 4.476,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -3.739,
+        "y": 4.476,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -3.739,
+        "y": 4.476,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.878292766515067,
+        "y": 4.4781252792121835,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.624015557869559,
+        "y": 1.7720295296077155,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.6126765329517,
+        "y": -0.87666891627049,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.34204378386013,
+        "y": -1.1359562161398715,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.317546392447149,
+        "y": -1.1604532427391347,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -8.317546392447149,
+        "y": -1.1604532427391347,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.317546392447149,
+        "y": -1.1604532427391347,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.321,
+        "y": -2.6006814636595807,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.535021418578536,
+        "y": -2.814702882238117,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.535021418578536,
+        "y": -2.913021418578535,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.601,
+        "y": -2.979,
+        "width": 0.275,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.601,
+        "y": -2.979,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.601,
+        "y": -2.979,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.75,
+        "y": -4.127999999999999,
+        "width": 0.275,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.75,
+        "y": -7,
+        "width": 0.275,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_2"
+      }
+    ],
+    "source_trace_id": "source_net_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst0_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 15.500003,
+        "y": -15.2499844,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_63"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.500003,
+        "y": -15.020232235317197,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.03328796621937,
+        "y": -14.486947269097827,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.053664849456265,
+        "y": -14.459986188156275,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.894244510263018,
+        "y": -14.459985673158553,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.962733136843745,
+        "y": -14.466569667057652,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.44423416538455,
+        "y": -14.948070695598457,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.44423416538455,
+        "y": -15.19423416538455,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.5,
+        "y": -15.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_66"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst1_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.095,
+        "y": -18.769108,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_71"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.095,
+        "y": -19.142199850627307,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.063800149372695,
+        "y": -20.111,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.877770827120001,
+        "y": -20.111,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.18578540851878,
+        "y": -19.80298541860122,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.18578540851878,
+        "y": -19.488214591481217,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.905,
+        "y": -18.769,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_68"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst2_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -23.165106,
+        "y": -12.70003,
+        "width": 0.45,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_91"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.624817925246234,
+        "y": -12.758697820677332,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -33.825,
+        "y": -11.5,
+        "width": 0.45,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_93"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst3_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -8.905,
+        "y": -18.769108,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_68"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.905,
+        "y": -17.522357359407657,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.437559851860923,
+        "y": -16.989797507546733,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.437559851860923,
+        "y": -16.982440148139077,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.526,
+        "y": -16.894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -9.526,
+        "y": -16.894,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -9.526,
+        "y": -16.894,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.526,
+        "y": -15.27685368726603,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.740492094959372,
+        "y": -13.062361592306658,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.740492094959372,
+        "y": -12.909507905040627,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.763,
+        "y": -12.886999999999999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -11.763,
+        "y": -12.886999999999999,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -11.763,
+        "y": -12.886999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.635207480375938,
+        "y": -11.014792519624061,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.293021703471302,
+        "y": -11.014792519624061,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.833991886098223,
+        "y": -12.555762702250982,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.97631350387408,
+        "y": -12.555762702250982,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.020762702250984,
+        "y": -12.555762702250982,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.165,
+        "y": -12.7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_91"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 15.500003,
+        "y": -15.2499844,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_63"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.500003,
+        "y": -15.395688265448406,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.518281409762988,
+        "y": -17.377409855685418,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.920376063863122,
+        "y": -17.377409855685418,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.14789295977427,
+        "y": -18.14989295977427,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.146,
+        "y": -18.148,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 9.146,
+        "y": -18.148,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 9.146,
+        "y": -18.148,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3742553641442816,
+        "y": -18.148,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.535187097841347,
+        "y": -17.987068266302934,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5950682663029334,
+        "y": -17.987068266302934,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.597,
+        "y": -17.989,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -1.597,
+        "y": -17.989,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -1.597,
+        "y": -17.989,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.315000000000002,
+        "y": -17.989,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.095,
+        "y": -18.769,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_71"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst5_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -13.499628000000001,
+        "y": 18,
+        "width": 0.3,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_119"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.499628000000001,
+        "y": 9.380372000000001,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.066425527176676,
+        "y": 6.813574472823325,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.137,
+        "y": 6.743,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -16.137,
+        "y": 6.743,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -16.137,
+        "y": 6.743,
+        "width": 0.3,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.137,
+        "y": 1.4081409383951589,
+        "width": 0.3,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.31837795745558,
+        "y": -2.773237019060422,
+        "width": 0.3,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.31837795745558,
+        "y": -2.7743779574555814,
+        "width": 0.3,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.375,
+        "y": -2.831,
+        "width": 0.3,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -20.375,
+        "y": -2.831,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -20.375,
+        "y": -2.831,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.375,
+        "y": -8.674146940694744,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.803172864405536,
+        "y": -11.10231980510028,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.803172864405536,
+        "y": -12.338096864405534,
+        "width": 0.3,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.165106,
+        "y": -12.70003,
+        "width": 0.3,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_91"
+      }
+    ],
+    "source_trace_id": "source_net_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst0_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.175,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_118"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.898272631457388,
+        "y": -18.223272631457387,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.375277605383971,
+        "y": -18.223272631457387,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.451727368542613,
+        "y": -18.223272631457387,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_116"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst1_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 21.325,
+        "y": -12.5,
+        "width": 0.325,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_110"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.31676570267236,
+        "y": -13.616788500504324,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.7,
+        "y": -15.25,
+        "width": 0.325,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_67"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst2_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.095,
+        "y": -13.231,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_72"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.095,
+        "y": -13.642353578975158,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.032501993238542,
+        "y": -14.579855572213699,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.458926528788449,
+        "y": -14.579855572213699,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.864169657551539,
+        "y": -14.985098700976788,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7,
+        "y": -15.12092904342525,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7,
+        "y": -16,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_76"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst3_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_116"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.837705013581452,
+        "y": -18.164998879401164,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.900275586470528,
+        "y": -18.164998879401164,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.01229498641855,
+        "y": -18.16270501358145,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.675,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_114"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 21.319905,
+        "y": -19.3000144,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_58"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.7,
+        "y": -17.6801094,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.7,
+        "y": -15.25,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_67"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst5_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.675,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_114"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.36034056833271,
+        "y": -18.18534056833271,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.14085087874959,
+        "y": -18.18534056833271,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.27965943166729,
+        "y": -18.18534056833271,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.165,
+        "y": -17.3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_89"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst6_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 8.55,
+        "y": -15.25,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_125"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.55,
+        "y": -19.75,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_127"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst7_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.175,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_118"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.675,
+        "y": -16,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7,
+        "y": -16,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_76"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst8_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 14.300107,
+        "y": -15.2499844,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_62"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.34672204672779,
+        "y": -14.175848686230674,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.653300827812973,
+        "y": -14.17591597698866,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.7,
+        "y": -15.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_67"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst9_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 14.300107,
+        "y": -15.2499844,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_62"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.41643059890035,
+        "y": -14.358119108552016,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.433687018883424,
+        "y": -14.363706064060226,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.55,
+        "y": -15.25,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_125"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst10_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.675,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_114"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.3637396539062,
+        "y": -18.1887396539062,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.13962278653501,
+        "y": -18.1887396539062,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.13962278653501,
+        "y": -14.442371165815748,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.607425420257908,
+        "y": -13.974568532092851,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.608431467907153,
+        "y": -13.974568532092851,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.667,
+        "y": -13.916,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -21.667,
+        "y": -13.916,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -21.667,
+        "y": -13.916,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.641151465251745,
+        "y": -12.444202051397351,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.770184324603054,
+        "y": -10.546452795532993,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.770184324603054,
+        "y": -10.508923128345952,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.62987121354368,
+        "y": -10.430163339193486,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -19.62987121354368,
+        "y": -10.430163339193486,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -19.62987121354368,
+        "y": -10.430163339193486,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.660515057547848,
+        "y": -11.014484942452153,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.175,
+        "y": -11.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_96"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst11_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 26.96,
+        "y": -17,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_57"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.62,
+        "y": -17,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.32,
+        "y": -19.3,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_58"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -25.55,
+        "y": 9.9,
+        "width": 0.325,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_122"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.55,
+        "y": 9.61,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.930009280078167,
+        "y": 8.229990719921833,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.948,
+        "y": 8.212,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -26.948,
+        "y": 8.212,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -26.948,
+        "y": 8.212,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.948,
+        "y": 7.707999999999998,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.297280681999286,
+        "y": 7.358719318000713,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.349,
+        "y": 7.307,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -27.349,
+        "y": 7.307,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -27.349,
+        "y": 7.307,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.653,
+        "y": 7.307,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": 4.96,
+        "width": 0.325,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_51"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst13_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -32.175,
+        "y": -11.5,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_94"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.175,
+        "y": -6.418999999999997,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": -4.244,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_55"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.29,
+        "y": -7,
+        "width": 0.325,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.449180469202274,
+        "y": -7,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.866893762630905,
+        "y": -7.417713293428632,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.000713293428632,
+        "y": -7.417713293428632,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.894584112403017,
+        "y": -7.546762164762581,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -14.894584112403017,
+        "y": -7.546762164762581,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -14.894584112403017,
+        "y": -7.546762164762581,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.093279607661636,
+        "y": -7.453,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.64302255627288,
+        "y": -9.002742948611242,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.700742948611243,
+        "y": -9.002742948611242,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.822,
+        "y": -9.124,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -17.822,
+        "y": -9.124,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -17.822,
+        "y": -9.124,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.093555180202124,
+        "y": -9.124,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.43047061096589,
+        "y": -9.460915430763768,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.468915430763765,
+        "y": -9.460915430763768,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.552,
+        "y": -9.544,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -19.552,
+        "y": -9.544,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -19.552,
+        "y": -9.544,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.552,
+        "y": -10.570731202230089,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.219376007008908,
+        "y": -10.903355195221181,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.182093998964078,
+        "y": -10.903355195221181,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.133484942452153,
+        "y": -10.854746138709256,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -19.133484942452153,
+        "y": -10.854746138709256,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -19.133484942452153,
+        "y": -10.854746138709256,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.133484942452153,
+        "y": -11.458484942452152,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.175,
+        "y": -11.5,
+        "width": 0.325,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_96"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst15_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": -4.24393825,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_55"
+      },
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": 4.96,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_51"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -32.175,
+        "y": -11.5,
+        "width": 0.5,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_94"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.38,
+        "y": -11.5,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.70502061252332,
+        "y": -12.130370832781393,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.63434339431181,
+        "y": -12.131541323276858,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -26.63434339431181,
+        "y": -12.131541323276858,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -26.63434339431181,
+        "y": -12.131541323276858,
+        "width": 0.5,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.634,
+        "y": -15.079999999999998,
+        "width": 0.5,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.164685944444276,
+        "y": -15.549314055555723,
+        "width": 0.5,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.139,
+        "y": -15.575,
+        "width": 0.5,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -26.139,
+        "y": -15.575,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -26.139,
+        "y": -15.575,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.89,
+        "y": -15.575,
+        "width": 0.5,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.165,
+        "y": -17.3,
+        "width": 0.5,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_89"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.29001825,
+        "y": -7.000109,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_0"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.29001825,
+        "y": -5.941018249999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.978569631967899,
+        "y": -5.6295696319678985,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.954229984300232,
+        "y": -5.617810428526369,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -11.954229984300232,
+        "y": -5.617810428526369,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -11.954229984300232,
+        "y": -5.617810428526369,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.941265700582234,
+        "y": -4.3087343273690815,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.275888520642303,
+        "y": -0.6375132209053307,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.211393619300168,
+        "y": -0.5919090415684775,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.211393619300168,
+        "y": -0.5919090415684775,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.211393619300168,
+        "y": -0.5919090415684775,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.814147627808587,
+        "y": -0.18214762780858634,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.396565911670099,
+        "y": -0.18214762780858634,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.291147627808586,
+        "y": -0.18214762780858634,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.609,
+        "y": 0.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_38"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst18_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5.715025750000001,
+        "y": -3.714873,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_14"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0083645761197326,
+        "y": -3.714873,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.1435349075566128,
+        "y": -1.5629735163236544,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.15802648367634547,
+        "y": -1.5629735163236544,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.319,
+        "y": -1.402,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -0.319,
+        "y": -1.402,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -0.319,
+        "y": -1.402,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9048145439389416,
+        "y": -1.402,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9040517370665149,
+        "y": -0.4027628068724266,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9322371931275732,
+        "y": -0.4027628068724266,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.085,
+        "y": -0.25,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -2.085,
+        "y": -0.25,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.085,
+        "y": -0.25,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.8593092500000004,
+        "y": -0.25,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.60905825,
+        "y": 0.499749,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_38"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst19_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5.715025750000001,
+        "y": -3.714873,
+        "width": 0.325,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_14"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.299025577357405,
+        "y": -4.130808565988893,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.281859698659256,
+        "y": -12.292488350062989,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.289269690707152,
+        "y": -12.426817336248034,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.038861765228587,
+        "y": -15.15772351768725,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.457244480859655,
+        "y": -15.157244480859655,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.55,
+        "y": -15.25,
+        "width": 0.325,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_125"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.29001825,
+        "y": 11.000109,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_37"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.29001825,
+        "y": 6.041018249999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.902651355625617,
+        "y": 2.6536513556256165,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.828,
+        "y": 2.579,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -8.828,
+        "y": 2.579,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.828,
+        "y": 2.579,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.828,
+        "y": 2.4792020414010976,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.192227994832255,
+        "y": 1.8434300362333529,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.192227994832255,
+        "y": 1.836227994832255,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.08961426743382,
+        "y": 1.7335920809592265,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.08961426743382,
+        "y": 1.7335920809592265,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.08961426743382,
+        "y": 1.7335920809592265,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.113612141798999,
+        "y": 1.4475696947912702,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.460713375712473,
+        "y": -0.21811663642801957,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.320114491523421,
+        "y": -0.21111449152342118,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.609,
+        "y": 0.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_38"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst21_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 17.19,
+        "y": 14,
+        "width": 0.325,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_47"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.295238724344603,
+        "y": 14,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.801476694074132,
+        "y": 9.50623796972953,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.801476694074132,
+        "y": 9.493476694074133,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.735893920272158,
+        "y": 9.40817574125429,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 8.735893920272158,
+        "y": 9.40817574125429,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 8.735893920272158,
+        "y": 9.40817574125429,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.736,
+        "y": -1.7029761467421274,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.067980425117076,
+        "y": -3.370995721625052,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.067980425117076,
+        "y": -3.371019574882924,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.027,
+        "y": -3.412,
+        "width": 0.325,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 7.027,
+        "y": -3.412,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 7.027,
+        "y": -3.412,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.018,
+        "y": -3.412,
+        "width": 0.325,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.715,
+        "y": -3.715,
+        "width": 0.325,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_14"
+      }
+    ],
+    "source_trace_id": "source_net_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst0_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -7.635,
+        "y": -13.231,
+        "width": 0.45,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_74"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.635,
+        "y": -14.106009568983758,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.430381261057986,
+        "y": -14.901390830041745,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.430381261057986,
+        "y": -14.997381261057987,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.496,
+        "y": -15.063,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -8.496,
+        "y": -15.063,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.496,
+        "y": -15.063,
+        "width": 0.45,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.496,
+        "y": -18.39167429243528,
+        "width": 0.45,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.199105235150599,
+        "y": -18.68856905728468,
+        "width": 0.45,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.199105235150599,
+        "y": -18.785894764849402,
+        "width": 0.45,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.19,
+        "y": -18.795,
+        "width": 0.45,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.19,
+        "y": -18.795,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.19,
+        "y": -18.795,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.661000000000003,
+        "y": -18.795,
+        "width": 0.45,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.635,
+        "y": -18.769,
+        "width": 0.45,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_69"
+      }
+    ],
+    "source_trace_id": "source_net_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst1_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32.04,
+        "y": -17,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_56"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.83310464590623,
+        "y": -11.79310464590623,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.381895354093771,
+        "y": -11.79310464590623,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.675,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_107"
+      }
+    ],
+    "source_trace_id": "source_net_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 14.675,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_107"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.5706414810572,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.2933207405286,
+        "y": -12.7773207405286,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.293,
+        "y": -12.777,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 13.293,
+        "y": -12.777,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 13.293,
+        "y": -12.777,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.543493646307045,
+        "y": -12.777,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.3499999999999999,
+        "y": -12.777,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.321,
+        "y": -12.806,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 1.321,
+        "y": -12.806,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.321,
+        "y": -12.806,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.48068980663952154,
+        "y": -11.96568980663952,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.703815501521551,
+        "y": -11.96568980663952,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.635,
+        "y": -12.896874305117969,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.635,
+        "y": -13.231,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_74"
+      }
+    ],
+    "source_trace_id": "source_net_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst0_0",
+    "connection_name": "source_trace_59__source_trace_60",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 19.675,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_109"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.325,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_108"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst1_0",
+    "connection_name": "source_trace_59__source_trace_60",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 16.325,
+        "y": -12.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_108"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.615306273641602,
+        "y": -13.209693726358397,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.869260734441491,
+        "y": -13.209693726358397,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.666349793021804,
+        "y": -13.209693726358397,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.749589115990299,
+        "y": -12.292933049326892,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.722933049326892,
+        "y": -12.292933049326892,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.719595404460877,
+        "y": -12.251696701158712,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.719595404460877,
+        "y": -12.251696701158712,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.719595404460877,
+        "y": -12.251696701158712,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.144697819750289,
+        "y": -12.262,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.00232826243023,
+        "y": -12.119630442679941,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.866630442679941,
+        "y": -12.119630442679941,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.808,
+        "y": -12.061,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 4.808,
+        "y": -12.061,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 4.808,
+        "y": -12.061,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.8979999999999997,
+        "y": -11.151,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.312573434469192,
+        "y": -11.151,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.368,
+        "y": -11.151,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -5.368,
+        "y": -11.151,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.368,
+        "y": -11.151,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.368,
+        "y": -8.746686020804574,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.610334051384434,
+        "y": -8.50435196942014,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.610334051384434,
+        "y": -8.486665948615565,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.632,
+        "y": -8.465,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -5.632,
+        "y": -8.465,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.632,
+        "y": -8.465,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.632,
+        "y": -7.308000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.94,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_5"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_54__source_trace_55_mst0_0",
+    "connection_name": "source_trace_54__source_trace_55",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.55,
+        "y": -15.25,
+        "width": 0.1,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_124"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.55,
+        "y": -19.75,
+        "width": 0.1,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_126"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_54__source_trace_55_mst1_0",
+    "connection_name": "source_trace_54__source_trace_55",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.5499020000000003,
+        "y": -15.249941,
+        "width": 0.1,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_124"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5040784885794372,
+        "y": -15.249941,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.291876691311834,
+        "y": -12.453985820108729,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.317014179891272,
+        "y": -12.453985820108729,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.404,
+        "y": -12.367,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 2.404,
+        "y": -12.367,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 2.404,
+        "y": -12.367,
+        "width": 0.1,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.404,
+        "y": -11.848356637479228,
+        "width": 0.1,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.748803114312581,
+        "y": -8.503553523166646,
+        "width": 0.1,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.749446476833353,
+        "y": -8.503553523166646,
+        "width": 0.1,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.806,
+        "y": -8.447,
+        "width": 0.1,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 5.806,
+        "y": -8.447,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.806,
+        "y": -8.447,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.382715288184706,
+        "y": -6.870284711815294,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.382715288184706,
+        "y": -3.2017556075823435,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.625959680602362,
+        "y": -2.445,
+        "width": 0.1,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.715,
+        "y": -2.445,
+        "width": 0.1,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_15"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_53_0",
+    "connection_name": "source_trace_53",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -27.45,
+        "y": 9.9,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_121"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.45,
+        "y": 10.284527236623227,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.692329363952116,
+        "y": 10.526856600575343,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.723856600575346,
+        "y": 10.526856600575343,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.774000005600474,
+        "y": 10.513168054649965,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -27.774000005600474,
+        "y": 10.513168054649965,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -27.774000005600474,
+        "y": 10.513168054649965,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.774,
+        "y": 12.398535955099304,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.42981630890358,
+        "y": 13.054352264002882,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.42981630890358,
+        "y": 13.10181630890358,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.546,
+        "y": 13.218,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -28.546,
+        "y": 13.218,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -28.546,
+        "y": 13.218,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.546,
+        "y": 13.629000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.175,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_112"
+      }
+    ],
+    "source_trace_id": "source_trace_53",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_52_0",
+    "connection_name": "source_trace_52",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.86,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_9"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.86,
+        "y": 2.169779984916768,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.750285450705629,
+        "y": 8.060065435622397,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.750285450705629,
+        "y": 8.061285450705629,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.858,
+        "y": 8.169,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -6.858,
+        "y": 8.169,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -6.858,
+        "y": 8.169,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.863661191343887,
+        "y": 10.174578304160187,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.776133063855955,
+        "y": 10.173093689997703,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.949414312261435,
+        "y": 10.347942434699174,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.949414312261435,
+        "y": 14.001464000012602,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.949414312261435,
+        "y": 14.010181703649394,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.649755991602987,
+        "y": 14.710523382990946,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.649755991602987,
+        "y": 14.85524400839701,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.641,
+        "y": 14.863999999999999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -29.641,
+        "y": 14.863999999999999,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -29.641,
+        "y": 14.863999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.641,
+        "y": 14.184000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.825,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_111"
+      }
+    ],
+    "source_trace_id": "source_trace_52",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_50_0",
+    "connection_name": "source_trace_50",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -22.5,
+        "y": 18,
+        "width": 0.35,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_120"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.5,
+        "y": 16.1,
+        "width": 0.35,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.5,
+        "y": 12.1,
+        "width": 0.35,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_123"
+      }
+    ],
+    "source_trace_id": "source_trace_50",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_47_0",
+    "connection_name": "source_trace_47",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.175,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_106"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.175,
+        "y": -15.850000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.825,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_117"
+      }
+    ],
+    "source_trace_id": "source_trace_47",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_46_0",
+    "connection_name": "source_trace_46",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -13.825,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_105"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.825,
+        "y": -14.27,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.936222145228063,
+        "y": -13.381222145228064,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.914,
+        "y": -13.359,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -12.914,
+        "y": -13.359,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -12.914,
+        "y": -13.359,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.12086584421825,
+        "y": -11.56586584421825,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.1585424816832415,
+        "y": -11.56586584421825,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.1585424816832415,
+        "y": -11.542296474794068,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.0549820525630158,
+        "y": -9.438736045673842,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.0549820525630158,
+        "y": -9.433982052563016,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.0034222727323696,
+        "y": -9.38357772726763,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -1.0034222727323696,
+        "y": -9.38357772726763,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -1.0034222727323696,
+        "y": -9.38357772726763,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.3121788156810386,
+        "y": -9.383,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.9486422795704215,
+        "y": -7.746536536110616,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.9486422795704215,
+        "y": -7.001357720429579,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.95,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_12"
+      }
+    ],
+    "source_trace_id": "source_trace_46",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_44_0",
+    "connection_name": "source_trace_44",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_104"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -15.850000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_115"
+      }
+    ],
+    "source_trace_id": "source_trace_44",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_43_0",
+    "connection_name": "source_trace_43",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_103"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.825,
+        "y": -15.118338899460209,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.080290411331458,
+        "y": -15.373629310791667,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.06062931079167,
+        "y": -15.373629310791667,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.005,
+        "y": -15.318,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -17.005,
+        "y": -15.318,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -17.005,
+        "y": -15.318,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.005,
+        "y": -13.448384161315245,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.085154707596143,
+        "y": -10.528538868911388,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.041538868911388,
+        "y": -10.528538868911388,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.921000083089142,
+        "y": -10.401972750299874,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -13.921000083089142,
+        "y": -10.401972750299874,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -13.921000083089142,
+        "y": -10.401972750299874,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.5076607767743866,
+        "y": -10.400487348304202,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.8575509505996858,
+        "y": -8.757144139303906,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.5730915871303741,
+        "y": -8.75758669388363,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.611876122539204,
+        "y": -7.7188021584748,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.611876122539204,
+        "y": -7.0681238774607955,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.68,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_11"
+      }
+    ],
+    "source_trace_id": "source_trace_43",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_41_0",
+    "connection_name": "source_trace_41",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -18.675,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_102"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.675,
+        "y": -15.850000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.325,
+        "y": -17.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_113"
+      }
+    ],
+    "source_trace_id": "source_trace_41",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_40_0",
+    "connection_name": "source_trace_40",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -20.325,
+        "y": -14.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_101"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.676115017509893,
+        "y": -12.851115017509894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.258268955130216,
+        "y": -12.851115017509894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.150126032709109,
+        "y": -12.851115017509894,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.812601703424672,
+        "y": -11.513590688225458,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.775590688225458,
+        "y": -11.513590688225458,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.718,
+        "y": -11.456,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -13.718,
+        "y": -11.456,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -13.718,
+        "y": -11.456,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.276114707678992,
+        "y": -11.456,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.882463564167052,
+        "y": -11.06234885648806,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.86534885648806,
+        "y": -11.06234885648806,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.8,
+        "y": -10.997,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -12.8,
+        "y": -10.997,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -12.8,
+        "y": -10.997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.46237942769778,
+        "y": -10.666781907272503,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.693693837903157,
+        "y": -10.665383364585258,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.6476123224558674,
+        "y": -10.659379817034838,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9741547457444235,
+        "y": -9.985922240323394,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9199222403233943,
+        "y": -9.985922240323394,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.791,
+        "y": -9.857,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -0.791,
+        "y": -9.857,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -0.791,
+        "y": -9.857,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.35830924485059856,
+        "y": -9.424309244850598,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.35830924485059856,
+        "y": -8.539959282884876,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.35830924485059856,
+        "y": -8.404309244850598,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.332,
+        "y": -8.378,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.332,
+        "y": -8.378,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -0.332,
+        "y": -8.378,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.41,
+        "y": -7.636,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.41,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_10"
+      }
+    ],
+    "source_trace_id": "source_trace_40",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_37__source_trace_39_mst0_0",
+    "connection_name": "source_trace_37__source_trace_39",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -9.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_100"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.883162707601006,
+        "y": -9.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.131882742663935,
+        "y": -7.748720035062929,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.131882742663935,
+        "y": -7.001882742663935,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.13,
+        "y": -7,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_8"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_37__source_trace_39_mst1_0",
+    "connection_name": "source_trace_37__source_trace_39",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -15.175,
+        "y": -9.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_100"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.535755372976476,
+        "y": -9.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.810927560205451,
+        "y": -9.775172187228975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.944172187228975,
+        "y": -9.775172187228975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.991,
+        "y": -9.822,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -15.991,
+        "y": -9.822,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -15.991,
+        "y": -9.822,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.775425993969304,
+        "y": -9.822,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.457391285306972,
+        "y": -9.14003470866233,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.446720629177563,
+        "y": -9.14003470866233,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.453764453474736,
+        "y": -9.132990884365158,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.461009115634845,
+        "y": -9.132990884365158,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.6,
+        "y": -8.994,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -21.6,
+        "y": -8.994,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -21.6,
+        "y": -8.994,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.75,
+        "y": -8.994,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": -6.744,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_54"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_33__source_trace_35_mst0_0",
+    "connection_name": "source_trace_33__source_trace_35",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -21.675,
+        "y": 9.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_98"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.675,
+        "y": 8.800857587899257,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.887643477027698,
+        "y": 8.58821411087156,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.887715936841634,
+        "y": 8.493287231070603,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -21.887715936841634,
+        "y": 8.493287231070603,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -21.887715936841634,
+        "y": 8.493287231070603,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.899,
+        "y": 5.112,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.93363340215938,
+        "y": 3.0773665978406206,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.934,
+        "y": 3.077,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -23.934,
+        "y": 3.077,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -23.934,
+        "y": 3.077,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.934,
+        "y": 4.417899657649571,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.374424975168207,
+        "y": 7.8583246328177765,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.641675367182224,
+        "y": 7.8583246328177765,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30,
+        "y": 7.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_52"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_33__source_trace_35_mst1_0",
+    "connection_name": "source_trace_33__source_trace_35",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.40001825,
+        "y": -7.000109,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_7"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.40001825,
+        "y": -6.473406413996933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.148833297368718,
+        "y": -4.724591366628216,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.3727434967817835,
+        "y": -4.724591366628216,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.88132389031935,
+        "y": 6.78398902690935,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.95898902690935,
+        "y": 6.78398902690935,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.675,
+        "y": 9.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_98"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_30_0",
+    "connection_name": "source_trace_30",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 22.27,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_49"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.363409185213378,
+        "y": 9.089521251745975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.924949133819502,
+        "y": 9.052514955577205,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.183223488844258,
+        "y": 12.838156925774012,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.65900187160563,
+        "y": 12.836438319485437,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.75,
+        "y": 11.745440191091067,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.75,
+        "y": 11,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_35"
+      }
+    ],
+    "source_trace_id": "source_trace_30",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_29_0",
+    "connection_name": "source_trace_29",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 24.81,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_50"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.535399560721423,
+        "y": 8.725399560721426,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.173595078917309,
+        "y": 8.725399560721426,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.030429435779399,
+        "y": 8.725399560721426,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.778520338154222,
+        "y": 8.977308658346603,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.751308658346602,
+        "y": 8.977308658346603,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.683,
+        "y": 8.909,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.683,
+        "y": 8.909,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.683,
+        "y": 8.909,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.962900434043339,
+        "y": 8.909,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.059337875874231,
+        "y": 8.005437441830892,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.998562558169107,
+        "y": 8.005437441830892,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.984,
+        "y": 8.02,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 3.984,
+        "y": 8.02,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 3.984,
+        "y": 8.02,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.005164685971513,
+        "y": 8.02,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.6392754121674535,
+        "y": 8.38588927380406,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.6181107261959413,
+        "y": 8.38588927380406,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.601,
+        "y": 8.403,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.601,
+        "y": 8.403,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.601,
+        "y": 8.403,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.0012559180484217,
+        "y": 8.403,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.837323596632624,
+        "y": 12.239067678584203,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.837323596632624,
+        "y": 12.252323596632625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.928,
+        "y": 12.343,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -5.928,
+        "y": 12.343,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.928,
+        "y": 12.343,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.928,
+        "y": 11.012,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.94,
+        "y": 11,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_32"
+      }
+    ],
+    "source_trace_id": "source_trace_29",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_4",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": -21.910161428618125,
+    "y": -10.863592010475315,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_5",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": -22.393,
+    "y": -14.105,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_6",
+    "pcb_trace_id": "source_net_3_mst7_0",
+    "x": -3.739,
+    "y": 4.476,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_7",
+    "pcb_trace_id": "source_net_3_mst7_0",
+    "x": -8.317546392447149,
+    "y": -1.1604532427391347,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_8",
+    "pcb_trace_id": "source_net_3_mst7_0",
+    "x": -8.601,
+    "y": -2.979,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_9",
+    "pcb_trace_id": "source_net_2_mst3_0",
+    "x": -9.526,
+    "y": -16.894,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_10",
+    "pcb_trace_id": "source_net_2_mst3_0",
+    "x": -11.763,
+    "y": -12.886999999999999,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_11",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "x": 9.146,
+    "y": -18.148,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_12",
+    "pcb_trace_id": "source_net_2_mst4_0",
+    "x": -1.597,
+    "y": -17.989,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_13",
+    "pcb_trace_id": "source_net_2_mst5_0",
+    "x": -16.137,
+    "y": 6.743,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_14",
+    "pcb_trace_id": "source_net_2_mst5_0",
+    "x": -20.375,
+    "y": -2.831,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_15",
+    "pcb_trace_id": "source_net_1_mst10_0",
+    "x": -21.667,
+    "y": -13.916,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_16",
+    "pcb_trace_id": "source_net_1_mst10_0",
+    "x": -19.62987121354368,
+    "y": -10.430163339193486,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_17",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "x": -26.948,
+    "y": 8.212,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_18",
+    "pcb_trace_id": "source_net_1_mst12_0",
+    "x": -27.349,
+    "y": 7.307,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_19",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "x": -14.894584112403017,
+    "y": -7.546762164762581,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_20",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "x": -17.822,
+    "y": -9.124,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_21",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "x": -19.552,
+    "y": -9.544,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_22",
+    "pcb_trace_id": "source_net_1_mst14_0",
+    "x": -19.133484942452153,
+    "y": -10.854746138709256,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_23",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "x": -26.63434339431181,
+    "y": -12.131541323276858,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_24",
+    "pcb_trace_id": "source_net_1_mst16_0",
+    "x": -26.139,
+    "y": -15.575,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_25",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "x": -11.954229984300232,
+    "y": -5.617810428526369,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_26",
+    "pcb_trace_id": "source_net_1_mst17_0",
+    "x": -8.211393619300168,
+    "y": -0.5919090415684775,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_27",
+    "pcb_trace_id": "source_net_1_mst18_0",
+    "x": -0.319,
+    "y": -1.402,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_28",
+    "pcb_trace_id": "source_net_1_mst18_0",
+    "x": -2.085,
+    "y": -0.25,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_29",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "x": -8.828,
+    "y": 2.579,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_30",
+    "pcb_trace_id": "source_net_1_mst20_0",
+    "x": -8.08961426743382,
+    "y": 1.7335920809592265,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_31",
+    "pcb_trace_id": "source_net_1_mst21_0",
+    "x": 8.735893920272158,
+    "y": 9.40817574125429,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_32",
+    "pcb_trace_id": "source_net_1_mst21_0",
+    "x": 7.027,
+    "y": -3.412,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_33",
+    "pcb_trace_id": "source_net_0_mst0_0",
+    "x": -8.496,
+    "y": -15.063,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_34",
+    "pcb_trace_id": "source_net_0_mst0_0",
+    "x": -8.19,
+    "y": -18.795,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_35",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "x": 13.293,
+    "y": -12.777,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_36",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "x": 1.321,
+    "y": -12.806,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_37",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst1_0",
+    "x": 5.719595404460877,
+    "y": -12.251696701158712,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_38",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst1_0",
+    "x": 4.808,
+    "y": -12.061,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_39",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst1_0",
+    "x": -5.368,
+    "y": -11.151,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_40",
+    "pcb_trace_id": "source_trace_59__source_trace_60_mst1_0",
+    "x": -5.632,
+    "y": -8.465,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_41",
+    "pcb_trace_id": "source_trace_54__source_trace_55_mst1_0",
+    "x": 2.404,
+    "y": -12.367,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_42",
+    "pcb_trace_id": "source_trace_54__source_trace_55_mst1_0",
+    "x": 5.806,
+    "y": -8.447,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_43",
+    "pcb_trace_id": "source_trace_53_0",
+    "x": -27.774000005600474,
+    "y": 10.513168054649965,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_44",
+    "pcb_trace_id": "source_trace_53_0",
+    "x": -28.546,
+    "y": 13.218,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_45",
+    "pcb_trace_id": "source_trace_52_0",
+    "x": -6.858,
+    "y": 8.169,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_46",
+    "pcb_trace_id": "source_trace_52_0",
+    "x": -29.641,
+    "y": 14.863999999999999,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_47",
+    "pcb_trace_id": "source_trace_46_0",
+    "x": -12.914,
+    "y": -13.359,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_48",
+    "pcb_trace_id": "source_trace_46_0",
+    "x": -1.0034222727323696,
+    "y": -9.38357772726763,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_49",
+    "pcb_trace_id": "source_trace_43_0",
+    "x": -17.005,
+    "y": -15.318,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_50",
+    "pcb_trace_id": "source_trace_43_0",
+    "x": -13.921000083089142,
+    "y": -10.401972750299874,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_51",
+    "pcb_trace_id": "source_trace_40_0",
+    "x": -13.718,
+    "y": -11.456,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_52",
+    "pcb_trace_id": "source_trace_40_0",
+    "x": -12.8,
+    "y": -10.997,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_53",
+    "pcb_trace_id": "source_trace_40_0",
+    "x": -0.791,
+    "y": -9.857,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_54",
+    "pcb_trace_id": "source_trace_40_0",
+    "x": -0.332,
+    "y": -8.378,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_55",
+    "pcb_trace_id": "source_trace_37__source_trace_39_mst1_0",
+    "x": -15.991,
+    "y": -9.822,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_56",
+    "pcb_trace_id": "source_trace_37__source_trace_39_mst1_0",
+    "x": -21.6,
+    "y": -8.994,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_57",
+    "pcb_trace_id": "source_trace_33__source_trace_35_mst0_0",
+    "x": -21.887715936841634,
+    "y": 8.493287231070603,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_58",
+    "pcb_trace_id": "source_trace_33__source_trace_35_mst0_0",
+    "x": -23.934,
+    "y": 3.077,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_59",
+    "pcb_trace_id": "source_trace_29_0",
+    "x": 5.683,
+    "y": 8.909,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_60",
+    "pcb_trace_id": "source_trace_29_0",
+    "x": 3.984,
+    "y": 8.02,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_61",
+    "pcb_trace_id": "source_trace_29_0",
+    "x": 1.601,
+    "y": 8.403,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_62",
+    "pcb_trace_id": "source_trace_29_0",
+    "x": -5.928,
+    "y": 12.343,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_0",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_1",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on OLED1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_2",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J_TEMP are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_51",
+      "source_port_52",
+      "source_port_53"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_3",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J_DOOR are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_4",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J_PWR are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_5",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on J_USB are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_5",
+    "source_port_ids": [
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_6",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U2 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_6",
+    "source_port_ids": [
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_7",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U3 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_8",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on BZ1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_21",
+    "source_port_ids": [
+      "source_port_125",
+      "source_port_126"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_9",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on Q1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_22",
+    "source_port_ids": [
+      "source_port_127",
+      "source_port_128",
+      "source_port_129"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_10",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on SW1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_23",
+    "source_port_ids": [
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_0",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U1 has no pin with requires_power=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_1",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "OLED1 has no pin with requires_power=true",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_2",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J_TEMP has no pin with requires_power=true",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_51",
+      "source_port_52",
+      "source_port_53"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_3",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J_DOOR has no pin with requires_power=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_4",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J_PWR has no pin with requires_power=true",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_5",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J_USB has no pin with requires_power=true",
+    "source_component_id": "source_component_5",
+    "source_port_ids": [
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_6",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U2 has no pin with requires_power=true",
+    "source_component_id": "source_component_6",
+    "source_port_ids": [
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_7",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U3 has no pin with requires_power=true",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_8",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "BZ1 has no pin with requires_power=true",
+    "source_component_id": "source_component_21",
+    "source_port_ids": [
+      "source_port_125",
+      "source_port_126"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_9",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "Q1 has no pin with requires_power=true",
+    "source_component_id": "source_component_22",
+    "source_port_ids": [
+      "source_port_127",
+      "source_port_128",
+      "source_port_129"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_10",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "SW1 has no pin with requires_power=true",
+    "source_component_id": "source_component_23",
+    "source_port_ids": [
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_0",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15",
+      "source_port_16",
+      "source_port_17",
+      "source_port_18",
+      "source_port_19",
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25",
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30",
+      "source_port_31",
+      "source_port_32",
+      "source_port_33",
+      "source_port_34",
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42",
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_1",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "OLED1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_1",
+    "source_port_ids": [
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_2",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J_TEMP has no pin with requires_ground=true",
+    "source_component_id": "source_component_2",
+    "source_port_ids": [
+      "source_port_51",
+      "source_port_52",
+      "source_port_53"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_3",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J_DOOR has no pin with requires_ground=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_54",
+      "source_port_55"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_4",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J_PWR has no pin with requires_ground=true",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_56",
+      "source_port_57"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_5",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J_USB has no pin with requires_ground=true",
+    "source_component_id": "source_component_5",
+    "source_port_ids": [
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_6",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U2 has no pin with requires_ground=true",
+    "source_component_id": "source_component_6",
+    "source_port_ids": [
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_7",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U3 has no pin with requires_ground=true",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_8",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "BZ1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_21",
+    "source_port_ids": [
+      "source_port_125",
+      "source_port_126"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_9",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "Q1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_22",
+    "source_port_ids": [
+      "source_port_127",
+      "source_port_128",
+      "source_port_129"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_10",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "SW1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_23",
+    "source_port_ids": [
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  }
+]

--- a/tests/pcb/repros/alarmv2-kicad-pcb-parse.test.ts
+++ b/tests/pcb/repros/alarmv2-kicad-pcb-parse.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import circuitJson from "tests/assets/alarmv2.json"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+import { parseKicadPcb } from "kicadts"
+
+test("alarmv2 circuit json converts to parseable KiCad PCB", async () => {
+  const throughPadRoutePoints = circuitJson
+    .filter((element: any) => element.type === "pcb_trace")
+    .flatMap((trace: any) => trace.route ?? [])
+    .filter((point: any) => point.route_type === "through_pad")
+
+  expect(throughPadRoutePoints.length).toBeGreaterThan(0)
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+
+  converter.runUntilFinished()
+  const kicadPcbContent = converter.getOutputString()
+  const invalidCoordinateLines = kicadPcbContent
+    .split("\n")
+    .filter((line) => line.includes("NaN") || line.includes("undefined"))
+
+  expect(invalidCoordinateLines).toEqual([
+    "    (end NaN NaN)",
+    "    (start NaN NaN)",
+  ])
+  expect(() => parseKicadPcb(kicadPcbContent)).toThrow(
+    "end expects two numeric arguments",
+  )
+})


### PR DESCRIPTION
Adds a repro using alarmv2.json showing that valid through_pad route points are converted into KiCad PCB segments with NaN coordinates, causing kicadts parsing to fail.

core emits a valid circuit-json through_pad route point with start/end coordinates, matching the circuit-json schema.

where the converter assumes every route point has top-level x/y, producing NaN for valid through_pad points.

