### PR TITLE
refactor: Apply two-parameter rule to PCB footprint converter functions

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -140,12 +140,12 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         ) || []
 
     fpTexts.push(
-      ...convertSilkscreenTexts(
-        pcbSilkscreenTexts,
-        component.center,
-        component.rotation || 0,
-        sourceComponent?.name,
-      ),
+      ...convertSilkscreenTexts({
+        silkscreenTexts: pcbSilkscreenTexts,
+        componentCenter: component.center,
+        componentRotation: component.rotation || 0,
+        sourceComponentName: sourceComponent?.name,
+      }),
     )
 
     const pcbNoteTexts =
@@ -156,11 +156,11 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         ) || []
 
     fpTexts.push(
-      ...convertNoteTexts(
-        pcbNoteTexts,
-        component.center,
-        component.rotation || 0,
-      ),
+      ...convertNoteTexts({
+        noteTexts: pcbNoteTexts,
+        componentCenter: component.center,
+        componentRotation: component.rotation || 0,
+      }),
     )
 
     footprint.fpTexts = fpTexts
@@ -235,11 +235,11 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
             hole.pcb_component_id === component.pcb_component_id,
         ) || []
 
-    const npthPads = convertNpthHoles(
+    const npthPads = convertNpthHoles({
       pcbHoles,
-      component.center,
-      component.rotation || 0,
-    )
+      componentCenter: component.center,
+      componentRotation: component.rotation || 0,
+    })
     fpPads.push(...npthPads)
 
     footprint.fpPads = fpPads
@@ -309,11 +309,11 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
             outline.pcb_component_id === component.pcb_component_id,
         ) || []
 
-    const fpPolys = convertCourtyardOutlines(
-      pcbCourtyardOutlines,
-      component.center,
-      component.rotation || 0,
-    )
+    const fpPolys = convertCourtyardOutlines({
+      courtyardOutlines: pcbCourtyardOutlines,
+      componentCenter: component.center,
+      componentRotation: component.rotation || 0,
+    })
 
     if (fpPolys.length > 0) {
       footprint.fpPolys = fpPolys

--- a/lib/pcb/stages/AddStandalonePcbElements.ts
+++ b/lib/pcb/stages/AddStandalonePcbElements.ts
@@ -94,11 +94,11 @@ export class AddStandalonePcbElements extends ConverterStage<
       })
 
       const ccwRotationDegrees = 0
-      const npthPads = convertNpthHoles(
-        [hole],
-        { x: hole.x, y: hole.y }, // Use hole center for negative offset
-        ccwRotationDegrees,
-      )
+      const npthPads = convertNpthHoles({
+        pcbHoles: [hole],
+        componentCenter: { x: hole.x, y: hole.y }, // Use hole center for negative offset
+        componentRotation: ccwRotationDegrees,
+      })
 
       if (npthPads.length > 0) {
         footprint.fpPads = npthPads

--- a/lib/pcb/stages/footprints-stage-converters/convertCourtyardOutlines.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertCourtyardOutlines.ts
@@ -9,18 +9,12 @@ import {
 } from "transformation-matrix"
 import { generateDeterministicUuid } from "../utils/generateDeterministicUuid"
 
-export function convertCourtyardOutlines(
-  params: {
-    courtyardOutlines: PcbCourtyardOutline[]
-    componentCenter: { x: number; y: number }
-    componentRotation?: number
-  },
-): FpPoly[] {
-  const {
-    courtyardOutlines,
-    componentCenter,
-    componentRotation = 0,
-  } = params
+export function convertCourtyardOutlines(params: {
+  courtyardOutlines: PcbCourtyardOutline[]
+  componentCenter: { x: number; y: number }
+  componentRotation?: number
+}): FpPoly[] {
+  const { courtyardOutlines, componentCenter, componentRotation = 0 } = params
   const fpPolys: FpPoly[] = []
 
   const cj2kicadMatrix = compose(

--- a/lib/pcb/stages/footprints-stage-converters/convertCourtyardOutlines.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertCourtyardOutlines.ts
@@ -10,10 +10,17 @@ import {
 import { generateDeterministicUuid } from "../utils/generateDeterministicUuid"
 
 export function convertCourtyardOutlines(
-  courtyardOutlines: PcbCourtyardOutline[],
-  componentCenter: { x: number; y: number },
-  componentRotation = 0,
+  params: {
+    courtyardOutlines: PcbCourtyardOutline[]
+    componentCenter: { x: number; y: number }
+    componentRotation?: number
+  },
 ): FpPoly[] {
+  const {
+    courtyardOutlines,
+    componentCenter,
+    componentRotation = 0,
+  } = params
   const fpPolys: FpPoly[] = []
 
   const cj2kicadMatrix = compose(

--- a/lib/pcb/stages/footprints-stage-converters/convertNoteTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertNoteTexts.ts
@@ -3,10 +3,13 @@ import { FpText, TextEffects, TextEffectsFont } from "kicadts"
 import { applyToPoint, rotate, identity } from "transformation-matrix"
 
 export function convertNoteTexts(
-  noteTexts: PcbNoteText[],
-  componentCenter: { x: number; y: number },
-  componentRotation: number,
+  params: {
+    noteTexts: PcbNoteText[]
+    componentCenter: { x: number; y: number }
+    componentRotation: number
+  },
 ): FpText[] {
+  const { noteTexts, componentCenter, componentRotation } = params
   const fpTexts: FpText[] = []
 
   for (const textElement of noteTexts) {

--- a/lib/pcb/stages/footprints-stage-converters/convertNoteTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertNoteTexts.ts
@@ -2,13 +2,11 @@ import type { PcbNoteText } from "circuit-json"
 import { FpText, TextEffects, TextEffectsFont } from "kicadts"
 import { applyToPoint, rotate, identity } from "transformation-matrix"
 
-export function convertNoteTexts(
-  params: {
-    noteTexts: PcbNoteText[]
-    componentCenter: { x: number; y: number }
-    componentRotation: number
-  },
-): FpText[] {
+export function convertNoteTexts(params: {
+  noteTexts: PcbNoteText[]
+  componentCenter: { x: number; y: number }
+  componentRotation: number
+}): FpText[] {
   const { noteTexts, componentCenter, componentRotation } = params
   const fpTexts: FpText[] = []
 

--- a/lib/pcb/stages/footprints-stage-converters/convertNpthHoles.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertNpthHoles.ts
@@ -3,10 +3,13 @@ import type { FootprintPad } from "kicadts"
 import { createNpthPadFromCircuitJson } from "../utils/CreateNpthPadFromCircuitJson"
 
 export function convertNpthHoles(
-  pcbHoles: PcbHole[],
-  componentCenter: { x: number; y: number },
-  componentRotation: number,
+  params: {
+    pcbHoles: PcbHole[]
+    componentCenter: { x: number; y: number }
+    componentRotation: number
+  },
 ): FootprintPad[] {
+  const { pcbHoles, componentCenter, componentRotation } = params
   const pads: FootprintPad[] = []
 
   for (const pcbHole of pcbHoles) {

--- a/lib/pcb/stages/footprints-stage-converters/convertNpthHoles.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertNpthHoles.ts
@@ -2,13 +2,11 @@ import type { PcbHole } from "circuit-json"
 import type { FootprintPad } from "kicadts"
 import { createNpthPadFromCircuitJson } from "../utils/CreateNpthPadFromCircuitJson"
 
-export function convertNpthHoles(
-  params: {
-    pcbHoles: PcbHole[]
-    componentCenter: { x: number; y: number }
-    componentRotation: number
-  },
-): FootprintPad[] {
+export function convertNpthHoles(params: {
+  pcbHoles: PcbHole[]
+  componentCenter: { x: number; y: number }
+  componentRotation: number
+}): FootprintPad[] {
   const { pcbHoles, componentCenter, componentRotation } = params
   const pads: FootprintPad[] = []
 

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
@@ -3,11 +3,19 @@ import { FpText } from "kicadts"
 import { createFpTextFromCircuitJson } from "../utils/CreateFpTextFromCircuitJson"
 
 export function convertSilkscreenTexts(
-  silkscreenTexts: PcbSilkscreenText[],
-  componentCenter: { x: number; y: number },
-  componentRotation: number,
-  sourceComponentName?: string,
+  params: {
+    silkscreenTexts: PcbSilkscreenText[]
+    componentCenter: { x: number; y: number }
+    componentRotation: number
+    sourceComponentName?: string
+  },
 ): FpText[] {
+  const {
+    silkscreenTexts,
+    componentCenter,
+    componentRotation,
+    sourceComponentName,
+  } = params
   const fpTexts: FpText[] = []
 
   for (const textElement of silkscreenTexts) {

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
@@ -2,14 +2,12 @@ import type { PcbSilkscreenText } from "circuit-json"
 import { FpText } from "kicadts"
 import { createFpTextFromCircuitJson } from "../utils/CreateFpTextFromCircuitJson"
 
-export function convertSilkscreenTexts(
-  params: {
-    silkscreenTexts: PcbSilkscreenText[]
-    componentCenter: { x: number; y: number }
-    componentRotation: number
-    sourceComponentName?: string
-  },
-): FpText[] {
+export function convertSilkscreenTexts(params: {
+  silkscreenTexts: PcbSilkscreenText[]
+  componentCenter: { x: number; y: number }
+  componentRotation: number
+  sourceComponentName?: string
+}): FpText[] {
   const {
     silkscreenTexts,
     componentCenter,


### PR DESCRIPTION
This pull request refactors several converter functions and their usage to use a single parameter object instead of multiple positional arguments. This improves code readability and maintainability, making it less error-prone when passing many related parameters. No functional logic is changed; only the function signatures and their call sites are updated.

**Refactoring to parameter objects:**

* Updated `convertSilkscreenTexts`, `convertNoteTexts`, `convertNpthHoles`, and `convertCourtyardOutlines` to accept a single parameter object instead of multiple positional arguments. [[1]](diffhunk://#diff-d2b50d50c7e733be9b3bf5cd86f45f7e35c58c4a24ec8bec9b4bd6e0673eccf2L6-R18) [[2]](diffhunk://#diff-501a6cdc5eef208ae01dc1b8a963829eeb28f3b867943810560ea8ae0e88e55fL6-R12) [[3]](diffhunk://#diff-a880b1731584386e0b959f434a5f0883ff99ae4164c473d26d31df1010c6246bL6-R12) [[4]](diffhunk://#diff-cdea65ad2ed39bd2cbec0455d66c1e7d1a111f8bdbf978c8527c3250b3ff9bb3L13-R23)
* Refactored all call sites in `AddFootprintsStage` and `AddStandalonePcbElements` to use the new parameter object syntax when calling these converter functions. [[1]](diffhunk://#diff-f061d089a2592ca77a52ca1f40d810d7519493bc40fca1602ca4382d3f82c7acL143-R148) [[2]](diffhunk://#diff-f061d089a2592ca77a52ca1f40d810d7519493bc40fca1602ca4382d3f82c7acL159-R163) [[3]](diffhunk://#diff-f061d089a2592ca77a52ca1f40d810d7519493bc40fca1602ca4382d3f82c7acL238-R242) [[4]](diffhunk://#diff-f061d089a2592ca77a52ca1f40d810d7519493bc40fca1602ca4382d3f82c7acL312-R316) [[5]](diffhunk://#diff-aaab02dbd48c678bfb4454fa569ba0774000b4d83b6c27ccd5fa672deb09c64eL97-R101)