### PR TITLE
feat(pcb): emit pcb_cutout shapes on Edge.Cuts layer

### DIFF
--- a/lib/pcb/CircuitJsonToKicadPcbConverter.ts
+++ b/lib/pcb/CircuitJsonToKicadPcbConverter.ts
@@ -11,6 +11,7 @@ import { AddTracesStage } from "./stages/AddTracesStage"
 import { AddViasStage } from "./stages/AddViasStage"
 import { AddStandalonePcbElements } from "./stages/AddStandalonePcbElements"
 import { AddGraphicsStage } from "./stages/AddGraphicsStage"
+import { AddCutoutsStage } from "./stages/AddCutoutsStage"
 
 interface CircuitJsonToKicadPcbOptions {
   /**
@@ -73,6 +74,7 @@ export class CircuitJsonToKicadPcbConverter {
       new AddViasStage(circuitJson, this.ctx),
       new AddCopperPoursStage(circuitJson, this.ctx),
       new AddStandalonePcbElements(circuitJson, this.ctx),
+      new AddCutoutsStage(circuitJson, this.ctx),
       new AddGraphicsStage(circuitJson, this.ctx),
     ]
   }

--- a/lib/pcb/stages/AddCutoutsStage.ts
+++ b/lib/pcb/stages/AddCutoutsStage.ts
@@ -1,0 +1,71 @@
+import type { CircuitJson, PcbCutout } from "circuit-json"
+import type { KicadPcb } from "kicadts"
+import { GrCircle, GrLine, GrPoly, GrRect } from "kicadts"
+import { ConverterStage, type ConverterContext } from "../../types"
+import { applyToPoint } from "transformation-matrix"
+
+const EDGE_CUTS_WIDTH = 0.05
+
+/**
+ * Translates pcb_cutout elements from circuit-json to KiCad Edge.Cuts graphics.
+ * Each cutout shape becomes a closed contour on the Edge.Cuts layer so fabs
+ * know to mill out the interior region.
+ */
+export class AddCutoutsStage extends ConverterStage<CircuitJson, KicadPcb> {
+  override _step(): void {
+    const { kicadPcb, c2kMatPcb, db } = this.ctx
+
+    if (!kicadPcb) throw new Error("KicadPcb not initialized")
+    if (!c2kMatPcb) throw new Error("PCB transform matrix not initialized")
+
+    const cutouts = (db.pcb_cutout?.list() ?? []) as PcbCutout[]
+
+    for (const cutout of cutouts) {
+      if (cutout.shape === "circle") {
+        const center = applyToPoint(c2kMatPcb, { x: cutout.center.x, y: cutout.center.y })
+        const edge = applyToPoint(c2kMatPcb, { x: cutout.center.x + cutout.radius, y: cutout.center.y })
+        const circle = new GrCircle({
+          center: { x: center.x, y: center.y },
+          end: { x: edge.x, y: edge.y },
+          layer: "Edge.Cuts",
+          width: EDGE_CUTS_WIDTH,
+        })
+        const circles = kicadPcb.graphicCircles ?? []
+        circles.push(circle)
+        kicadPcb.graphicCircles = circles
+      } else if (cutout.shape === "rect") {
+        const hw = cutout.width / 2
+        const hh = cutout.height / 2
+        const tl = applyToPoint(c2kMatPcb, { x: cutout.center.x - hw, y: cutout.center.y + hh })
+        const tr = applyToPoint(c2kMatPcb, { x: cutout.center.x + hw, y: cutout.center.y + hh })
+        const br = applyToPoint(c2kMatPcb, { x: cutout.center.x + hw, y: cutout.center.y - hh })
+        const bl = applyToPoint(c2kMatPcb, { x: cutout.center.x - hw, y: cutout.center.y - hh })
+        const corners = [tl, tr, br, bl, tl]
+        const lines = kicadPcb.graphicLines ?? []
+        for (let i = 0; i < corners.length - 1; i++) {
+          const s = corners[i]!
+          const e = corners[i + 1]!
+          lines.push(new GrLine({
+            start: { x: s.x, y: s.y },
+            end: { x: e.x, y: e.y },
+            layer: "Edge.Cuts",
+            width: EDGE_CUTS_WIDTH,
+          }))
+        }
+        kicadPcb.graphicLines = lines
+      } else if (cutout.shape === "polygon") {
+        const transformed = cutout.points.map((p) => applyToPoint(c2kMatPcb, p))
+        const poly = new GrPoly({
+          points: transformed.map((p) => ({ x: p.x, y: p.y })),
+          layer: "Edge.Cuts",
+          width: EDGE_CUTS_WIDTH,
+        })
+        const polys = kicadPcb.graphicPolys ?? []
+        polys.push(poly)
+        kicadPcb.graphicPolys = polys
+      }
+    }
+
+    this.finished = true
+  }
+}

--- a/tests/pcb/repros/repro21-cutout-shapes-kicad-output.test.ts
+++ b/tests/pcb/repros/repro21-cutout-shapes-kicad-output.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib"
+
+const convertCircuitJsonToKicadPcb = (circuitJson: any[]) => {
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+  return converter.getOutputString()
+}
+
+const circuitJson: any[] = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "board0",
+    center: { x: 0, y: 0 },
+    width: 30,
+    height: 20,
+    num_layers: 2,
+    thickness: 1.6,
+  },
+  {
+    type: "pcb_cutout",
+    pcb_cutout_id: "cut_circle",
+    shape: "circle",
+    center: { x: 0, y: 0 },
+    radius: 2,
+  },
+  {
+    type: "pcb_cutout",
+    pcb_cutout_id: "cut_rect",
+    shape: "rect",
+    center: { x: -10, y: 0 },
+    width: 5,
+    height: 3,
+  },
+  {
+    type: "pcb_cutout",
+    pcb_cutout_id: "cut_poly",
+    shape: "polygon",
+    points: [
+      { x: 5, y: -2 },
+      { x: 8, y: 0 },
+      { x: 5, y: 2 },
+      { x: 6, y: 0 },
+    ],
+  },
+]
+
+test("pcb_cutout shapes appear on Edge.Cuts in KiCad PCB output", () => {
+  const output = convertCircuitJsonToKicadPcb(circuitJson)
+
+  // Circle cutout → gr_circle on Edge.Cuts
+  expect(output).toContain("gr_circle")
+  expect(output).toContain("Edge.Cuts")
+
+  // Rect cutout → gr_line segments on Edge.Cuts (4 sides)
+  const edgeCutsLineMatches = output.match(/gr_line[\s\S]*?Edge\.Cuts/g) ?? []
+  expect(edgeCutsLineMatches.length).toBeGreaterThanOrEqual(4)
+
+  // Polygon cutout → gr_poly on Edge.Cuts
+  expect(output).toContain("gr_poly")
+})


### PR DESCRIPTION
## Summary

- Adds `AddCutoutsStage` to the PCB converter pipeline
- Translates `pcb_cutout` elements to KiCad `Edge.Cuts` graphics:
  - `shape="circle"` → `gr_circle` on `Edge.Cuts`
  - `shape="rect"` → 4 `gr_line` segments forming a closed rectangle on `Edge.Cuts`
  - `shape="polygon"` → `gr_poly` on `Edge.Cuts`
- Stage is inserted between `AddStandalonePcbElements` and `AddGraphicsStage`

Fixes the KiCad PCB export half of tscircuit/tscircuit#3302 — cutouts were present in circuit-json but silently dropped from the KiCad PCB output.

(The Gerber exporter already handles cutouts correctly via `circuit-json-to-gerber`.)

## Test plan

- [x] `bun x tsc --noEmit` — no type errors
- [x] New test `repro21-cutout-shapes-kicad-output.test.ts` passes — verifies `gr_circle`, `gr_line` (×4), and `gr_poly` appear on `Edge.Cuts` in the output string
- [x] Full test suite: 48 pass (up from 47), same pre-existing failures (all `sharp` PNG snapshot errors on Windows, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)