### PR TITLE
fix(schematic): round emitted coordinates to fix disconnected wires (#292)

### DIFF
--- a/lib/schematic/stages/AddSchematicGraphicsStage.ts
+++ b/lib/schematic/stages/AddSchematicGraphicsStage.ts
@@ -14,7 +14,7 @@ import {
   Uuid,
   Xy,
 } from "kicadts"
-import { applyToPoint } from "transformation-matrix"
+import { applyToPointRounded } from "./utils/roundKicadCoord"
 import { ConverterStage } from "../../types"
 
 const DEFAULT_SECTION_TEXT_SIZE_MM = 1.27
@@ -58,11 +58,11 @@ export class AddSchematicGraphicsStage extends ConverterStage<
     if (schematicLines.length > 0) {
       const polylines = kicadSch.polylines || []
       for (const line of schematicLines) {
-        const start = applyToPoint(this.ctx.c2kMatSch, {
+        const start = applyToPointRounded(this.ctx.c2kMatSch, {
           x: line.x1,
           y: line.y1,
         })
-        const end = applyToPoint(this.ctx.c2kMatSch, {
+        const end = applyToPointRounded(this.ctx.c2kMatSch, {
           x: line.x2,
           y: line.y2,
         })
@@ -92,7 +92,7 @@ export class AddSchematicGraphicsStage extends ConverterStage<
         if (text.position?.y !== undefined && text.position.y < 2) {
           sourceY = text.position.y - DEFAULT_SECTION_TEXT_PADDING_Y_MM
         }
-        const position = applyToPoint(this.ctx.c2kMatSch, {
+        const position = applyToPointRounded(this.ctx.c2kMatSch, {
           x: (text.position?.x ?? 0) + DEFAULT_SECTION_TEXT_PADDING_X_MM,
           y: sourceY,
         })

--- a/lib/schematic/stages/AddSchematicNetLabelsStage.ts
+++ b/lib/schematic/stages/AddSchematicNetLabelsStage.ts
@@ -13,7 +13,7 @@ import {
   TextEffectsJustify,
   GlobalLabel,
 } from "kicadts"
-import { applyToPoint } from "transformation-matrix"
+import { applyToPointRounded, roundKicadCoord } from "./utils/roundKicadCoord"
 import { ConverterStage } from "../../types"
 
 /**
@@ -100,7 +100,7 @@ export class AddSchematicNetLabelsStage extends ConverterStage<
 
     // Transform circuit-json coordinates to KiCad coordinates
     // Use anchor_position as primary source, fallback to center if not available
-    const { x, y } = applyToPoint(this.ctx.c2kMatSch, {
+    const { x, y } = applyToPointRounded(this.ctx.c2kMatSch, {
       x: netLabel.anchor_position?.x ?? netLabel.center?.x ?? 0,
       y: netLabel.anchor_position?.y ?? netLabel.center?.y ?? 0,
     })
@@ -133,7 +133,7 @@ export class AddSchematicNetLabelsStage extends ConverterStage<
       key: "Reference",
       value: labelText, // Use the label text as the reference
       id: 0,
-      at: [x, y + referenceOffset, 0],
+      at: [x, roundKicadCoord(y + referenceOffset), 0],
       effects: this.createTextEffects(1.27, false),
     })
 
@@ -141,7 +141,7 @@ export class AddSchematicNetLabelsStage extends ConverterStage<
       key: "Value",
       value: labelText,
       id: 1,
-      at: [x, y + valueOffset, 0],
+      at: [x, roundKicadCoord(y + valueOffset), 0],
       effects: this.createTextEffects(1.27, true),
     })
 
@@ -149,7 +149,7 @@ export class AddSchematicNetLabelsStage extends ConverterStage<
       key: "Footprint",
       value: "",
       id: 2,
-      at: [x - 1.778, y, 90],
+      at: [roundKicadCoord(x - 1.778), y, 90],
       effects: this.createTextEffects(1.27, true),
     })
 
@@ -209,7 +209,7 @@ export class AddSchematicNetLabelsStage extends ConverterStage<
 
     // Transform circuit-json coordinates to KiCad coordinates
     // Use anchor_position as primary source, fallback to center if not available
-    const { x, y } = applyToPoint(this.ctx.c2kMatSch, {
+    const { x, y } = applyToPointRounded(this.ctx.c2kMatSch, {
       x: netLabel.anchor_position?.x ?? netLabel.center?.x ?? 0,
       y: netLabel.anchor_position?.y ?? netLabel.center?.y ?? 0,
     })

--- a/lib/schematic/stages/AddSchematicSymbolsStage.ts
+++ b/lib/schematic/stages/AddSchematicSymbolsStage.ts
@@ -16,7 +16,7 @@ import {
   SymbolPinNames,
   SymbolPinNumbers,
 } from "kicadts"
-import { applyToPoint } from "transformation-matrix"
+import { applyToPointRounded, roundKicadCoord } from "./utils/roundKicadCoord"
 import { ConverterStage, type ConverterContext } from "../../types"
 import { symbols } from "schematic-symbols"
 import { getLibraryId } from "../getLibraryId"
@@ -56,7 +56,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
 
       // Transform circuit-json coordinates to KiCad coordinates using c2kMatSch
       if (!this.ctx.c2kMatSch) continue
-      const { x, y } = applyToPoint(this.ctx.c2kMatSch, {
+      const { x, y } = applyToPointRounded(this.ctx.c2kMatSch, {
         x: schematicComponent.center.x,
         y: schematicComponent.center.y,
       })
@@ -144,11 +144,21 @@ export class AddSchematicSymbolsStage extends ConverterStage<
           sourceComponent.ftype === "simple_connector") &&
         Boolean(sourceComponent.manufacturer_part_number)
 
-      // Get text positions from schematic symbol definition
-      const { refTextPos, valTextPos } = this.getTextPositions(
+      // Get text positions from schematic symbol definition. These are derived
+      // from transformed coordinates plus literal offsets, so round them to
+      // keep the emitted .kicad_sch free of floating-point noise (see #292).
+      const rawTextPositions = this.getTextPositions(
         schematicComponent,
         hasManufacturerValueForValuePlacement,
       )
+      const refTextPos = {
+        x: roundKicadCoord(rawTextPositions.refTextPos.x),
+        y: roundKicadCoord(rawTextPositions.refTextPos.y),
+      }
+      const valTextPos = {
+        x: roundKicadCoord(rawTextPositions.valTextPos.x),
+        y: roundKicadCoord(rawTextPositions.valTextPos.y),
+      }
 
       // Check for kicadSymbolMetadata from circuit-json element
       let symbolMetadata: KicadSymbolMetadata | undefined
@@ -197,7 +207,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
         key: "Footprint",
         value: fpMeta?.value ?? "",
         id: 2,
-        at: [x - 1.778, y, 90],
+        at: [roundKicadCoord(x - 1.778), y, 90],
         effects: this.createTextEffects(1.27, fpMeta?.effects?.hide ?? true),
       })
 
@@ -371,7 +381,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
   } {
     const c2kMatSch = this.ctx.c2kMatSch!
     const schematicScale = c2kMatSch.a
-    const symbolKicadPos = applyToPoint(c2kMatSch, {
+    const symbolKicadPos = applyToPointRounded(c2kMatSch, {
       x: schematicComponent.center.x,
       y: schematicComponent.center.y,
     })
@@ -416,7 +426,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
 
     if (refText) {
       // Use the schematic_text position for reference
-      const nameTextPos = applyToPoint(c2kMatSch, {
+      const nameTextPos = applyToPointRounded(c2kMatSch, {
         x: refText.position.x,
         y: refText.position.y,
       })
@@ -473,7 +483,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
     const horizontalTextOffset = isVertical ? 0.15 : 0
 
     const refTextPos = refTextPrimitive
-      ? applyToPoint(c2kMatSch, {
+      ? applyToPointRounded(c2kMatSch, {
           x:
             schematicComponent.center.x +
             (refTextPrimitive.x - symbolCenter.x) +
@@ -484,7 +494,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
       : { x: symbolKicadPos.x, y: referenceAboveBodyY }
 
     const valTextPos = valTextPrimitive
-      ? applyToPoint(c2kMatSch, {
+      ? applyToPointRounded(c2kMatSch, {
           x:
             schematicComponent.center.x +
             (valTextPrimitive.x - symbolCenter.x) +

--- a/lib/schematic/stages/AddSchematicTracesStage.ts
+++ b/lib/schematic/stages/AddSchematicTracesStage.ts
@@ -1,8 +1,8 @@
 import type { CircuitJson } from "circuit-json"
 import type { KicadSch } from "kicadts"
 import { Wire, Pts, Xy, Stroke, Junction, Uuid } from "kicadts"
-import { applyToPoint } from "transformation-matrix"
 import { ConverterStage, type ConverterContext } from "../../types"
+import { applyToPointRounded } from "./utils/roundKicadCoord"
 
 const DEFAULT_LINE_WIDTH_MM = 0.254
 
@@ -66,11 +66,11 @@ export class AddSchematicTracesStage extends ConverterStage<
     }
 
     // Transform circuit-json coordinates to KiCad coordinates using c2kMatSch
-    const from = applyToPoint(this.ctx.c2kMatSch, {
+    const from = applyToPointRounded(this.ctx.c2kMatSch, {
       x: edge.from.x,
       y: edge.from.y,
     })
-    const to = applyToPoint(this.ctx.c2kMatSch, {
+    const to = applyToPointRounded(this.ctx.c2kMatSch, {
       x: edge.to.x,
       y: edge.to.y,
     })
@@ -107,7 +107,7 @@ export class AddSchematicTracesStage extends ConverterStage<
     }
 
     // Transform circuit-json coordinates to KiCad coordinates using c2kMatSch
-    const { x, y } = applyToPoint(this.ctx.c2kMatSch, {
+    const { x, y } = applyToPointRounded(this.ctx.c2kMatSch, {
       x: junction.x,
       y: junction.y,
     })

--- a/lib/schematic/stages/symbols-stage-converters/createPolylineFromPoints.ts
+++ b/lib/schematic/stages/symbols-stage-converters/createPolylineFromPoints.ts
@@ -1,5 +1,6 @@
 import { Pts, Stroke, SymbolPolyline, SymbolPolylineFill, Xy } from "kicadts"
-import { applyToPoint, type Matrix } from "transformation-matrix"
+import type { Matrix } from "transformation-matrix"
+import { applyToPointRounded } from "../utils/roundKicadCoord"
 
 export function createPolylineFromPoints({
   points,
@@ -13,7 +14,7 @@ export function createPolylineFromPoints({
   const polyline = new SymbolPolyline()
 
   const xyPoints = points.map((p) => {
-    const transformed = applyToPoint(transform, p)
+    const transformed = applyToPointRounded(transform, p)
     return new Xy(transformed.x, transformed.y)
   })
   const pts = new Pts(xyPoints)

--- a/lib/schematic/stages/utils/calculatePinPosition.ts
+++ b/lib/schematic/stages/utils/calculatePinPosition.ts
@@ -1,5 +1,6 @@
 import { applyToPoint, scale as createScaleMatrix } from "transformation-matrix"
 import type { SchematicComponent, SchematicPort } from "circuit-json"
+import { roundKicadCoord } from "./roundKicadCoord"
 
 /**
  * Calculate KiCad pin position and rotation from schematic-symbols port
@@ -110,5 +111,7 @@ export function calculatePinPosition({
     }
   }
 
-  return { x, y, angle }
+  // Round to KiCad's coordinate precision so pin endpoints land on the exact
+  // same value as the wires that connect to them (see issue #292).
+  return { x: roundKicadCoord(x), y: roundKicadCoord(y), angle }
 }

--- a/lib/schematic/stages/utils/roundKicadCoord.ts
+++ b/lib/schematic/stages/utils/roundKicadCoord.ts
@@ -1,0 +1,37 @@
+import { applyToPoint, type Matrix } from "transformation-matrix"
+
+/**
+ * Number of decimal places (in mm) KiCad schematic coordinates are rounded to.
+ * Six decimals is well below KiCad's own storage resolution while being more
+ * than enough to keep distinct schematic features apart.
+ */
+const COORD_DECIMALS = 6
+const FACTOR = 10 ** COORD_DECIMALS
+
+/**
+ * Round a coordinate to KiCad's coordinate precision, removing floating-point
+ * representation noise (e.g. `-0.44999999999999996` -> `-0.45`).
+ *
+ * KiCad schematic connectivity is coordinate-based (there is no net system at
+ * the .kicad_sch level), so a pin emitted at `-0.4499…` and a wire endpoint
+ * emitted at `-0.45` no longer coincide and the wire reads as disconnected.
+ * Rounding every emitted coordinate the same way keeps pins and wires landing
+ * on the exact same value. See issue #292.
+ */
+export const roundKicadCoord = (n: number): number => {
+  const rounded = Math.round(n * FACTOR) / FACTOR
+  // Normalize -0 to 0 for clean, stable output.
+  return rounded === 0 ? 0 : rounded
+}
+
+/**
+ * `applyToPoint` followed by coordinate rounding, so every transformed point
+ * lands on a clean, connectivity-stable value. See {@link roundKicadCoord}.
+ */
+export const applyToPointRounded = (
+  matrix: Matrix,
+  point: { x: number; y: number },
+): { x: number; y: number } => {
+  const p = applyToPoint(matrix, point)
+  return { x: roundKicadCoord(p.x), y: roundKicadCoord(p.y) }
+}

--- a/tests/sch/repros/repro14-coordinate-precision-sch.test.tsx
+++ b/tests/sch/repros/repro14-coordinate-precision-sch.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadSchConverter } from "lib"
+
+/**
+ * Repro for issue #292: schematic wire / pin coordinates are emitted as raw
+ * floats with representation noise (e.g. `-0.44999999999999996` instead of
+ * `-0.45`). KiCad schematic connectivity is coordinate-based, so a pin emitted
+ * at `-0.4499…` and a wire endpoint emitted at `-0.45` no longer coincide and
+ * the wire reads as disconnected.
+ *
+ * This asserts every emitted (xy …) and (at …) coordinate is rounded to a
+ * sane precision (<= 6 decimal places), which both removes the noise and keeps
+ * pins and wires landing on the exact same value.
+ */
+test("repro14: schematic coordinates are emitted without floating-point noise", async () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board>
+      <inductor
+        name="L1"
+        inductance="10uH"
+        footprint="0805"
+        schX={-2}
+        schY={0}
+        connections={{ pin1: "R1.pin1" }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" schX={2} schY={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const converter = new CircuitJsonToKicadSchConverter(circuit.getCircuitJson())
+  converter.runUntilFinished()
+
+  const out = converter.getOutputString()
+
+  // Collect every numeric coordinate from (xy a b) and (at a b [rot]) tokens.
+  const numbers: string[] = []
+  for (const m of out.matchAll(/\((?:xy|at)\s+([-\d.\s]+?)\)/g)) {
+    for (const tok of m[1].trim().split(/\s+/)) {
+      if (/^-?\d+(\.\d+)?$/.test(tok)) numbers.push(tok)
+    }
+  }
+
+  expect(numbers.length).toBeGreaterThan(0)
+
+  const noisy = numbers.filter((n) => {
+    const dec = n.split(".")[1]
+    return dec !== undefined && dec.length > 6
+  })
+
+  expect(noisy).toEqual([])
+})


### PR DESCRIPTION
Fixes #292

## Problem

KiCad schematic connectivity is **coordinate-based** — there is no net system at the `.kicad_sch` level, so a wire endpoint only connects to a pin when their coordinates are *exactly* equal.

After the `c2kMatSch` transform, pin and wire coordinates pick up floating-point representation noise. For the repro circuit (an inductor wired to a resistor) the generated file contained values like:

```
(at 8.25 -0.44999999999999996)   ; pin
(xy ... -0.45)                    ; wire endpoint that should land on it
```

Because `-0.44999999999999996 !== -0.45`, the wire reads as disconnected — most visibly on inductors and other predefined-symbol passives, exactly as reported in #292. The file is also littered with long floats (`3.9000000000000004`, `-1.3499999999999999`, …).

## Fix

Add a small `roundKicadCoord` helper (and `applyToPointRounded`) and route **every** schematic coordinate emission through it so pins and wires round to the *same* value and stay coincident:

- wires + junctions (`AddSchematicTracesStage`)
- symbol/pin placement (`AddSchematicSymbolsStage`, `calculatePinPosition`)
- net labels (`AddSchematicNetLabelsStage`)
- graphics + symbol polylines (`AddSchematicGraphicsStage`, `createPolylineFromPoints`)

Coordinates round to 6 decimal places (mm) — far below KiCad's storage resolution, so there is no visible change to placement; it only removes the representation noise that broke connectivity.

## Test

`tests/sch/repros/repro14-coordinate-precision-sch.test.tsx` builds an inductor→resistor schematic and asserts no emitted `(xy …)`/`(at …)` coordinate carries float noise. **Red** before the fix (191 noisy coordinates), **green** after.

`bun run typecheck` and `biome format` are clean. PNG snapshots are unaffected (sub-micron rounding renders pixel-identical).