### PR TITLE
fix: use generic connector lib ids

### DIFF
--- a/lib/schematic/getLibraryId.ts
+++ b/lib/schematic/getLibraryId.ts
@@ -1,20 +1,24 @@
 import type {
-  SourceComponentBase,
-  SchematicComponent,
   CadComponent,
+  SchematicComponent,
+  SourceComponentBase,
   SourceSimplePinHeader,
 } from "circuit-json"
+import { symbols } from "schematic-symbols"
 import {
   getKicadCompatibleComponentName,
   getReferencePrefixForComponent,
 } from "../utils/getKicadCompatibleComponentName"
-import { symbols } from "schematic-symbols"
 
 /**
  * Checks if a symbol name is a known builtin symbol from schematic-symbols package.
  */
 function isBuiltinSymbol(symbolName: string): boolean {
   return symbolName in symbols
+}
+
+function getConnectorGenericLibraryId(pinCount: number): string {
+  return `Connector_Generic:Conn_01x${String(pinCount).padStart(2, "0")}`
 }
 
 /**
@@ -24,6 +28,7 @@ function isBuiltinSymbol(symbolName: string): boolean {
  * @param schematicComp - The schematic component
  * @param cadComponent - Optional CAD component for footprinter_string
  * @param schematicSymbolName - Optional name from schematic_symbol element (highest priority)
+ * @param connectorPinCount - Optional rendered schematic pin count for simple connectors
  * @returns Library ID string like "Device:resistor" or "Custom:my_symbol"
  */
 export function getLibraryId(
@@ -31,6 +36,7 @@ export function getLibraryId(
   schematicComp: SchematicComponent,
   cadComponent?: CadComponent | null,
   schematicSymbolName?: string,
+  connectorPinCount?: number,
 ): string {
   // Highest priority: schematic_symbol.name (for custom symbols)
   if (schematicSymbolName) {
@@ -59,7 +65,15 @@ export function getLibraryId(
   }
   if (sourceComp.ftype === "simple_pin_header") {
     const pinCount = (sourceComp as SourceSimplePinHeader).pin_count
-    return `Connector_Generic:Conn_01x${pinCount}`
+    return getConnectorGenericLibraryId(pinCount)
+  }
+
+  if (
+    sourceComp.ftype === "simple_connector" &&
+    connectorPinCount &&
+    connectorPinCount > 0
+  ) {
+    return getConnectorGenericLibraryId(connectorPinCount)
   }
 
   // Generate ergonomic name using manufacturer part number or footprint string

--- a/lib/schematic/stages/AddLibrarySymbolsStage.ts
+++ b/lib/schematic/stages/AddLibrarySymbolsStage.ts
@@ -1,8 +1,7 @@
 import type {
   CircuitJson,
-  SchematicNetLabel,
   SchematicComponent,
-  SchematicPort,
+  SchematicNetLabel,
   SourceComponentBase,
 } from "circuit-json"
 import type { KicadSch } from "kicadts"
@@ -13,13 +12,13 @@ import {
   SymbolPinNames,
   SymbolPinNumbers,
 } from "kicadts"
-import { ConverterStage } from "../../types"
 import { symbols } from "schematic-symbols"
-import { getLibraryId } from "../getLibraryId"
+import { ConverterStage } from "../../types"
 import {
   getKicadCompatibleComponentName,
   getReferencePrefixForComponent,
 } from "../../utils/getKicadCompatibleComponentName"
+import { getLibraryId } from "../getLibraryId"
 import { buildSymbolDataFromSchematicPrimitives } from "./symbols-stage-converters/buildSymbolDataFromSchematicPrimitives"
 import { createDrawingSubsymbol } from "./symbols-stage-converters/createDrawingSubsymbol"
 import { createGenericChipSymbolData } from "./symbols-stage-converters/createGenericChipSymbolData"
@@ -183,7 +182,13 @@ export class AddLibrarySymbolsStage extends ConverterStage<
           texts: [],
         }
 
-        const libId = getLibraryId(sourceComp, schematicComponent, cadComponent)
+        const libId = getLibraryId(
+          sourceComp,
+          schematicComponent,
+          cadComponent,
+          undefined,
+          this.getSchematicPortCount(schematicComponent),
+        )
         const footprintName = getKicadCompatibleComponentName(
           sourceComp,
           cadComponent,
@@ -220,7 +225,13 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     const symbolData = this.getSymbolData(symbolName, schematicComponent)
     if (!symbolData) return null
 
-    const libId = getLibraryId(sourceComp, schematicComponent, cadComponent)
+    const libId = getLibraryId(
+      sourceComp,
+      schematicComponent,
+      cadComponent,
+      undefined,
+      this.getSchematicPortCount(schematicComponent),
+    )
     const isChip =
       sourceComp.ftype === "simple_chip" ||
       sourceComp.ftype === "simple_pin_header" ||
@@ -262,8 +273,6 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     cadComponent: any,
     schematicSymbolId: string,
   ): SchematicSymbol | null {
-    const { db } = this.ctx
-
     // Look up the schematic_symbol element
     // Since this is a new type, access it via the raw circuitJson
     const schematicSymbol = this.ctx.circuitJson.find(
@@ -495,6 +504,18 @@ export class AddLibrarySymbolsStage extends ConverterStage<
     if (sourceComp?.ftype === "simple_chip") return "*"
     if (sourceComp?.ftype === "simple_connector") return "*"
     return "*"
+  }
+
+  private getSchematicPortCount(
+    schematicComponent: SchematicComponent,
+  ): number {
+    return this.ctx.db.schematic_port
+      .list()
+      .filter(
+        (port: any) =>
+          port.schematic_component_id ===
+          schematicComponent.schematic_component_id,
+      ).length
   }
 
   private hasComponentLevelSymbolPrimitives(

--- a/lib/schematic/stages/AddSchematicSymbolsStage.ts
+++ b/lib/schematic/stages/AddSchematicSymbolsStage.ts
@@ -1,30 +1,29 @@
+import type { KicadSymbolMetadata } from "@tscircuit/props"
 import type { CircuitJson, SchematicComponent } from "circuit-json"
 import type { KicadSch } from "kicadts"
 import {
+  EmbeddedFonts,
   SchematicSymbol,
-  SymbolLibId,
-  SymbolProperty,
-  SymbolPin,
+  SymbolInstancePath,
   SymbolInstances,
   SymbolInstancesProject,
-  SymbolInstancePath,
-  Uuid,
+  SymbolLibId,
+  SymbolPin,
+  SymbolPinNames,
+  SymbolPinNumbers,
+  SymbolProperty,
   TextEffects,
   TextEffectsFont,
   TextEffectsJustify,
-  EmbeddedFonts,
-  SymbolPinNames,
-  SymbolPinNumbers,
 } from "kicadts"
-import { applyToPoint } from "transformation-matrix"
-import { ConverterStage, type ConverterContext } from "../../types"
 import { symbols } from "schematic-symbols"
-import { getLibraryId } from "../getLibraryId"
+import { applyToPoint } from "transformation-matrix"
+import { ConverterStage } from "../../types"
 import {
-  getReferenceDesignator,
   getKicadCompatibleComponentName,
+  getReferenceDesignator,
 } from "../../utils/getKicadCompatibleComponentName"
-import type { KicadSymbolMetadata } from "@tscircuit/props"
+import { getLibraryId } from "../getLibraryId"
 
 /**
  * Adds schematic symbol instances (placed components) to the schematic
@@ -82,6 +81,14 @@ export class AddSchematicSymbolsStage extends ConverterStage<
             cad.source_component_id === sourceComponent.source_component_id,
         )
 
+      const componentSchematicPorts = db.schematic_port
+        .list()
+        .filter(
+          (p: any) =>
+            p.schematic_component_id ===
+            schematicComponent.schematic_component_id,
+        )
+
       // Check for custom symbol via schematic_symbol_id
       let schematicSymbolName: string | undefined
       let schematicSymbolId = (schematicComponent as any).schematic_symbol_id
@@ -132,6 +139,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
         schematicComponent,
         cadComponent,
         schematicSymbolName,
+        componentSchematicPorts.length,
       )
       const symLibId = new SymbolLibId(libId)
       ;(symbol as any)._sxLibId = symLibId
@@ -305,13 +313,7 @@ export class AddSchematicSymbolsStage extends ConverterStage<
       // Add pin instances with UUIDs based on schematic ports
       // For custom symbols, use only ports with display_pin_label
       // For regular components, use all ports
-      let schematicPorts = db.schematic_port
-        .list()
-        .filter(
-          (p: any) =>
-            p.schematic_component_id ===
-            schematicComponent.schematic_component_id,
-        )
+      let schematicPorts = [...componentSchematicPorts]
 
       // If this is a custom symbol, filter to only ports with display_pin_label
       if (schematicSymbolId) {

--- a/tests/sch/repros/repro14-connector-library-id.test.ts
+++ b/tests/sch/repros/repro14-connector-library-id.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { getLibraryId } from "lib/schematic/getLibraryId"
+
+const schematicComponent = {
+  type: "schematic_component",
+  schematic_component_id: "schematic_component_0",
+  center: { x: 0, y: 0 },
+  size: { width: 1, height: 1 },
+  is_box_with_pins: true,
+} as any
+
+test("connector library ids use KiCad Connector_Generic names", () => {
+  expect(
+    getLibraryId(
+      {
+        type: "source_component",
+        source_component_id: "source_component_0",
+        name: "J1",
+        ftype: "simple_pin_header",
+        pin_count: 8,
+        gender: "male",
+      } as any,
+      schematicComponent,
+    ),
+  ).toBe("Connector_Generic:Conn_01x08")
+
+  expect(
+    getLibraryId(
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "PWR_USB",
+        ftype: "simple_connector",
+        standard: "usb_c",
+      } as any,
+      schematicComponent,
+      null,
+      undefined,
+      24,
+    ),
+  ).toBe("Connector_Generic:Conn_01x24")
+})


### PR DESCRIPTION
Fixes #257

## Summary
- Use KiCad `Connector_Generic:Conn_01xNN` library IDs for simple pin headers and simple connectors.
- Pass the rendered schematic port count through connector symbol generation so generic connector symbols match their pin count.
- Add a regression test for zero-padded pin header and connector library IDs.

## Verification
- `bun test tests\sch\repros\repro14-connector-library-id.test.ts`
- `bun x @biomejs/biome check lib\schematic\getLibraryId.ts lib\schematic\stages\AddLibrarySymbolsStage.ts lib\schematic\stages\AddSchematicSymbolsStage.ts tests\sch\repros\repro14-connector-library-id.test.ts`
- `bun x tsc --noEmit`
- `bun run build`