### PR TITLE
Add schematic file output API

### DIFF
--- a/lib/schematic/CircuitJsonToKicadSchConverter.ts
+++ b/lib/schematic/CircuitJsonToKicadSchConverter.ts
@@ -15,6 +15,15 @@ import { InitializeSchematicStage } from "./stages/InitializeSchematicStage"
 
 const DEFAULT_SCHEMATIC_SCALE_FACTOR = 15
 
+export interface KicadSchFile {
+  filename: string
+  content: string
+}
+
+export interface KicadSchFileOutputOptions {
+  schematicFilename: string
+}
+
 export class CircuitJsonToKicadSchConverter {
   ctx: ConverterContext
 
@@ -102,5 +111,21 @@ export class CircuitJsonToKicadSchConverter {
    */
   getOutputString(): string {
     return this.ctx.kicadSch!.getString()
+  }
+
+  /**
+   * Returns every KiCad schematic file produced by this converter.
+   *
+   * Today this is a single root schematic file. This API is intentionally a
+   * file list so hierarchical schematic sheets can add child .kicad_sch files
+   * without changing callers.
+   */
+  getOutputFiles(options: KicadSchFileOutputOptions): KicadSchFile[] {
+    return [
+      {
+        filename: options.schematicFilename,
+        content: this.getOutputString(),
+      },
+    ]
   }
 }

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -118,7 +118,11 @@ convertBtn.addEventListener("click", async () => {
     proConverter.runUntilFinished()
 
     const zip = new JSZip()
-    zip.file(schematicFileName, schConverter.getOutputString())
+    for (const { filename, content } of schConverter.getOutputFiles({
+      schematicFilename: schematicFileName,
+    })) {
+      zip.file(filename, content)
+    }
     zip.file(boardFileName, pcbConverter.getOutputString())
     zip.file(projectFileName, proConverter.getOutputString())
 

--- a/tests/project/full-project-export.test.tsx
+++ b/tests/project/full-project-export.test.tsx
@@ -47,8 +47,13 @@ test("exports full KiCad project with .kicad_pro, .kicad_sch, and .kicad_pcb fil
   // Generate .kicad_sch file
   const schConverter = new CircuitJsonToKicadSchConverter(circuitJson)
   schConverter.runUntilFinished()
-  const schContent = schConverter.getOutputString()
-  writeFileSync(join(OUTPUT_DIR, `${PROJECT_NAME}.kicad_sch`), schContent)
+  const schematicFiles = schConverter.getOutputFiles({
+    schematicFilename: `${PROJECT_NAME}.kicad_sch`,
+  })
+  const schContent = schematicFiles[0]!.content
+  for (const { filename, content } of schematicFiles) {
+    writeFileSync(join(OUTPUT_DIR, filename), content)
+  }
 
   // Generate .kicad_pcb file
   const pcbConverter = new CircuitJsonToKicadPcbConverter(circuitJson)


### PR DESCRIPTION
### Proposal
This sets up `CircuitJsonToKicadSchConverter` to return schematic files as a list instead of assuming there is always only one `.kicad_sch` file.

For now, it still returns one file, so behavior stays the same.

Later, this API can support schematic sheets by returning multiple files, for example:

- `circuit.kicad_sch`
- `Sheet_1.kicad_sch`
- `Sheet_2.kicad_sch`

The site export now uses this file-list API, so it will not need another structure change when multi-sheet schematic export is implemented.