### PR TITLE
fix(pcb): flip bottom footprint silkscreen to B.SilkS (#362)

### DIFF
--- a/lib/pcb/stages/AddFootprintsStage.ts
+++ b/lib/pcb/stages/AddFootprintsStage.ts
@@ -38,6 +38,7 @@ import { create3DModelsFromCadComponent } from "./footprints-stage-converters/cr
 import { convertSmdPads } from "./footprints-stage-converters/convertSmdPads"
 import { convertPlatedHoles } from "./footprints-stage-converters/convertPlatedHoles"
 import { convertNpthHoles } from "./footprints-stage-converters/convertNpthHoles"
+import { flipFootprintToBack } from "../utils/flipFootprintToBack"
 
 /**
  * Adds footprints to the PCB from circuit JSON components
@@ -144,7 +145,6 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         silkscreenTexts: pcbSilkscreenTexts,
         componentCenter: component.center,
         componentRotation: component.rotation || 0,
-        sourceComponentName: sourceComponent?.name,
       }),
     )
 
@@ -400,6 +400,10 @@ export class AddFootprintsStage extends ConverterStage<CircuitJson, KicadPcb> {
         metadata: footprintMetadata,
         componentProperty: kicadComponentProperty,
       })
+    }
+
+    if (component.layer === "bottom") {
+      flipFootprintToBack(footprint)
     }
 
     const footprints = kicadPcb.footprints

--- a/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSilkscreenTexts.ts
@@ -6,14 +6,8 @@ export function convertSilkscreenTexts(params: {
   silkscreenTexts: PcbSilkscreenText[]
   componentCenter: { x: number; y: number }
   componentRotation: number
-  sourceComponentName?: string
 }): FpText[] {
-  const {
-    silkscreenTexts,
-    componentCenter,
-    componentRotation,
-    sourceComponentName,
-  } = params
+  const { silkscreenTexts, componentCenter, componentRotation } = params
   const fpTexts: FpText[] = []
 
   for (const textElement of silkscreenTexts) {
@@ -23,9 +17,6 @@ export function convertSilkscreenTexts(params: {
       componentRotation,
     })
     if (fpText) {
-      if (sourceComponentName && textElement.text === sourceComponentName) {
-        fpText.type = "reference"
-      }
       fpTexts.push(fpText)
     }
   }

--- a/lib/pcb/utils/flipFootprintToBack.ts/flipFootprintToBack.ts
+++ b/lib/pcb/utils/flipFootprintToBack.ts/flipFootprintToBack.ts
@@ -1,0 +1,64 @@
+import type { Footprint } from "kicadts"
+
+const FRONT_TO_BACK: Record<string, string> = {
+  "F.Cu": "B.Cu",
+  "F.SilkS": "B.SilkS",
+  "F.Fab": "B.Fab",
+  "F.CrtYd": "B.CrtYd",
+  "F.Mask": "B.Mask",
+  "F.Paste": "B.Paste",
+  "F.Adhes": "B.Adhes",
+}
+
+const layerName = (layer: unknown): string | undefined => {
+  if (typeof layer === "string") return layer
+  if (Array.isArray(layer))
+    return layer[0] != null ? String(layer[0]) : undefined
+  if (layer && typeof layer === "object") {
+    const l = layer as { names?: string[]; getString?: () => string }
+    if (Array.isArray(l.names) && l.names.length) return l.names[0]
+    if (typeof l.getString === "function") return l.getString()
+  }
+  return undefined
+}
+
+const toBack = (layer: unknown): string | undefined => {
+  const name = layerName(layer)
+  if (!name) return undefined
+  return FRONT_TO_BACK[name] ?? name
+}
+
+const rotate180 = (pos: unknown): void => {
+  const at = pos as { angle?: number } | undefined
+  if (at && typeof at === "object" && "angle" in at) {
+    at.angle = ((at.angle ?? 0) + 180) % 360
+  }
+}
+
+const flipItems = <T extends { layer?: unknown }>(
+  items: T[] | undefined,
+  positionOf?: (item: T) => unknown,
+): T[] => {
+  const out = items ?? []
+  for (const item of out) {
+    const back = toBack(item.layer)
+    if (back) item.layer = back as never
+    if (positionOf) rotate180(positionOf(item))
+  }
+  return out
+}
+
+/**
+ * Move a bottom-side footprint and its graphics/text to back layers (B.*),
+ * rotating text 180° for readability. Pads already carry B.Cu from pcbPad.layer.
+ */
+export function flipFootprintToBack(footprint: Footprint): void {
+  footprint.layer = "B.Cu" as never
+  footprint.properties = flipItems(footprint.properties, (p) => p.position)
+  footprint.fpTexts = flipItems(footprint.fpTexts, (t) => t.position)
+  footprint.fpLines = flipItems(footprint.fpLines)
+  footprint.fpCircles = flipItems(footprint.fpCircles)
+  footprint.fpRects = flipItems(footprint.fpRects)
+  footprint.fpPolys = flipItems(footprint.fpPolys)
+  footprint.fpArcs = flipItems(footprint.fpArcs)
+}

--- a/tests/pcb/repros/repro26-bottom-footprint-silkscreen.test.tsx/repro26-bottom-footprint-silkscreen.test.tsx
+++ b/tests/pcb/repros/repro26-bottom-footprint-silkscreen.test.tsx/repro26-bottom-footprint-silkscreen.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+// https://github.com/tscircuit/circuit-json-to-kicad/issues/362
+test("bottom-side footprint silkscreen text is on B.SilkS and not dropped", async () => {
+  const circuit = new Circuit()
+  const FP = (
+    <footprint>
+      <smtpad
+        portHints={["pin1"]}
+        pcbX="-2mm"
+        pcbY="0mm"
+        width="1.6mm"
+        height="2.6mm"
+        shape="rect"
+      />
+      <smtpad
+        portHints={["pin2"]}
+        pcbX="2mm"
+        pcbY="0mm"
+        width="1.6mm"
+        height="2.6mm"
+        shape="rect"
+      />
+      <silkscreentext text="+" pcbX="-3.9mm" pcbY="0mm" fontSize="1mm" />
+      <silkscreentext text="BT1" pcbX="0mm" pcbY="-2.3mm" fontSize="0.8mm" />
+    </footprint>
+  )
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip name="BT1" footprint={FP} layer="bottom" pcbX={0} pcbY={0} />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuit.getCircuitJson())
+  converter.runUntilFinished()
+  const pcb = converter.getOutputString()
+
+  const blocks = pcb.split("(footprint").slice(1)
+  const bt1Block = blocks.find((b) => /"Reference"\s+"BT1"/.test(b))
+  expect(bt1Block).toBeDefined()
+
+  expect(bt1Block).toMatch(/\(layer B\.Cu\)/)
+  expect(bt1Block).not.toMatch(/\(layer F\.SilkS\)/)
+
+  const plusText = bt1Block!.match(
+    /\(fp_text user "\+"[\s\S]*?\(layer ([^)]+)\)/,
+  )
+  expect(plusText).toBeDefined()
+  expect(plusText![1]).toBe("B.SilkS")
+
+  const labelText = bt1Block!.match(
+    /\(fp_text user "BT1"[\s\S]*?\(layer ([^)]+)\)/,
+  )
+  expect(labelText).toBeDefined()
+  expect(labelText![1]).toBe("B.SilkS")
+})


### PR DESCRIPTION
Fixes #362

Bottom-side components now flip footprint silk/fab/courtyard graphics to B.* layers via `flipFootprintToBack` (same family as #361).

Also fixes footprint silkscreen text being dropped when it matched the component name (e.g. decorative "BT1" label was coerced to `reference` type).

Test: `repro26-bottom-footprint-silkscreen` asserts both `+` and `BT1` fp_text appear on `B.SilkS`.