### PR TITLE
Fix .kicad_mod metadata parity for custom library footprints

### DIFF
--- a/lib/kicad-library/kicad-library-converter-utils/applyKicadFootprintMetadata.ts
+++ b/lib/kicad-library/kicad-library-converter-utils/applyKicadFootprintMetadata.ts
@@ -4,6 +4,9 @@ import {
   Property,
   TextEffects,
   TextEffectsFont,
+  EmbeddedFonts,
+  FootprintAttr,
+  FootprintModel,
 } from "kicadts"
 import type { KicadFootprintMetadata, KicadEffects } from "@tscircuit/props"
 import { generateDeterministicUuid } from "../../pcb/stages/utils/generateDeterministicUuid"
@@ -57,11 +60,6 @@ export function applyKicadFootprintMetadata(
     }
     if (metadata.generatorVersion !== undefined) {
       footprint.generatorVersion = String(metadata.generatorVersion)
-    }
-
-    // Apply embedded fonts setting
-    if (metadata.embeddedFonts !== undefined) {
-      // The footprint already has embeddedFonts set, we just update the value
     }
 
     // Apply properties if provided
@@ -160,7 +158,11 @@ export function applyKicadFootprintMetadata(
     }
 
     // Apply attributes if provided
-    if (metadata.attributes && footprint.attr) {
+    if (metadata.attributes) {
+      if (!footprint.attr) {
+        footprint.attr = new FootprintAttr()
+      }
+
       if (metadata.attributes.through_hole) {
         footprint.attr.type = "through_hole"
       } else if (metadata.attributes.smd) {
@@ -173,6 +175,50 @@ export function applyKicadFootprintMetadata(
       if (metadata.attributes.exclude_from_bom !== undefined) {
         footprint.attr.excludeFromBom = metadata.attributes.exclude_from_bom
       }
+    }
+
+    // Apply footprint name if provided
+    if (metadata.footprintName) {
+      footprint.libraryLink = metadata.footprintName
+    }
+
+    // Apply footprint layer if provided
+    if (metadata.layer) {
+      footprint.layer = metadata.layer
+    }
+
+    // Apply embedded fonts setting
+    if (metadata.embeddedFonts !== undefined) {
+      footprint.embeddedFonts = new EmbeddedFonts(metadata.embeddedFonts)
+    }
+
+    // Apply model if provided. Prepend it so explicit metadata wins over
+    // auto-derived models from the intermediate PCB conversion.
+    if (metadata.model) {
+      const model = new FootprintModel(metadata.model.path)
+      if (metadata.model.offset) {
+        model.offset = {
+          x: Number(metadata.model.offset.x),
+          y: Number(metadata.model.offset.y),
+          z: Number(metadata.model.offset.z),
+        }
+      }
+      if (metadata.model.scale) {
+        model.scale = {
+          x: Number(metadata.model.scale.x),
+          y: Number(metadata.model.scale.y),
+          z: Number(metadata.model.scale.z),
+        }
+      }
+      if (metadata.model.rotate) {
+        model.rotate = {
+          x: Number(metadata.model.rotate.x),
+          y: Number(metadata.model.rotate.y),
+          z: Number(metadata.model.rotate.z),
+        }
+      }
+      const existingModels = footprint.models || []
+      footprint.models = [model, ...existingModels]
     }
 
     return footprint.getString()

--- a/lib/kicad-library/kicad-library-converter-utils/renameKicadFootprint.ts
+++ b/lib/kicad-library/kicad-library-converter-utils/renameKicadFootprint.ts
@@ -57,5 +57,6 @@ export function renameKicadFootprint(params: {
     footprintName: newKicadFootprintName,
     kicadModString: footprint.getString(),
     model3dSourcePaths: kicadFootprint.model3dSourcePaths,
+    isBuiltin: kicadFootprint.isBuiltin,
   }
 }

--- a/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
+++ b/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
@@ -1,19 +1,27 @@
 import type { KicadFootprintMetadata } from "@tscircuit/props"
-import type { PcbComponent } from "circuit-json"
+import type {
+  PcbComponent,
+  CadComponent,
+  SourceComponentBase,
+  CircuitJson,
+} from "circuit-json"
 import type { FootprintEntry } from "../../types"
 import type {
   KicadLibraryConverterContext,
   ExtractedKicadComponent,
+  BuiltTscircuitComponent,
 } from "../KicadLibraryConverterTypes"
 import { renameKicadFootprint } from "../kicad-library-converter-utils/renameKicadFootprint"
 import { applyKicadFootprintMetadata } from "../kicad-library-converter-utils/applyKicadFootprintMetadata"
 import { parseKicadMod } from "kicadts"
+import { getKicadCompatibleComponentName } from "../../utils/getKicadCompatibleComponentName"
 
 const KICAD_3RD_PARTY_PLACEHOLDER = "${KICAD_3RD_PARTY}"
 
 /**
  * Classifies footprints from extracted KiCad components into user and builtin libraries.
- * - Custom footprints (isBuiltin=false) → user library, renamed to component name
+ * - Custom footprints (isBuiltin=false) → user library, renamed to the
+ *   component name unless metadata.footprintName overrides it
  * - Builtin footprints (isBuiltin=true) → builtin library
  */
 export function classifyKicadFootprints(
@@ -25,6 +33,128 @@ export function classifyKicadFootprints(
       extractedKicadComponent,
     })
   }
+}
+
+export function getUserKicadFootprintName(params: {
+  tscircuitComponentName: string
+  metadata?: KicadFootprintMetadata
+}): string {
+  return params.metadata?.footprintName ?? params.tscircuitComponentName
+}
+
+function getFootprintCandidateNamesForPcbComponent(params: {
+  circuitJson: CircuitJson
+  pcbComponent: PcbComponent
+}): Set<string> {
+  const { circuitJson, pcbComponent } = params
+  const candidateNames = new Set<string>()
+
+  if (pcbComponent.metadata?.kicad_footprint?.footprintName) {
+    candidateNames.add(pcbComponent.metadata.kicad_footprint.footprintName)
+  }
+
+  const cadComponent = circuitJson.find(
+    (el): el is CadComponent =>
+      el.type === "cad_component" &&
+      el.pcb_component_id === pcbComponent.pcb_component_id,
+  )
+  const sourceComponentId =
+    pcbComponent.source_component_id ?? cadComponent?.source_component_id
+  const sourceComponent = sourceComponentId
+    ? circuitJson.find(
+        (el): el is SourceComponentBase =>
+          el.type === "source_component" &&
+          el.source_component_id === sourceComponentId,
+      )
+    : undefined
+
+  if (sourceComponent) {
+    candidateNames.add(
+      getKicadCompatibleComponentName(sourceComponent, cadComponent),
+    )
+  }
+
+  return candidateNames
+}
+
+function resolvePrimaryCustomFootprintPcbComponent(params: {
+  builtComponent?: BuiltTscircuitComponent
+  extractedKicadComponent: ExtractedKicadComponent
+}): PcbComponent | undefined {
+  const { builtComponent, extractedKicadComponent } = params
+  if (!builtComponent) return undefined
+
+  const primaryCustomFootprint = extractedKicadComponent.kicadFootprints.find(
+    (fp) => !fp.isBuiltin,
+  )
+  if (!primaryCustomFootprint) return undefined
+
+  const pcbComponents = builtComponent.circuitJson.filter(
+    (el): el is PcbComponent => el.type === "pcb_component",
+  )
+  if (pcbComponents.length === 0) return undefined
+
+  const matchingPcbComponent = pcbComponents.find((pcbComponent) =>
+    getFootprintCandidateNamesForPcbComponent({
+      circuitJson: builtComponent.circuitJson,
+      pcbComponent,
+    }).has(primaryCustomFootprint.footprintName),
+  )
+  if (matchingPcbComponent) {
+    return matchingPcbComponent
+  }
+
+  const pcbComponentsWithMetadata = pcbComponents.filter(
+    (pcbComponent) => pcbComponent.metadata?.kicad_footprint,
+  )
+  if (pcbComponentsWithMetadata.length === 1) {
+    return pcbComponentsWithMetadata[0]
+  }
+
+  if (pcbComponents.length === 1) {
+    return pcbComponents[0]
+  }
+
+  return undefined
+}
+
+export function resolvePrimaryCustomFootprintMatchNames(params: {
+  builtComponent?: BuiltTscircuitComponent
+  extractedKicadComponent: ExtractedKicadComponent
+}): Set<string> {
+  const { builtComponent, extractedKicadComponent } = params
+  const matchNames = new Set(
+    extractedKicadComponent.kicadFootprints
+      .filter((fp) => !fp.isBuiltin)
+      .map((fp) => fp.footprintName),
+  )
+
+  const pcbComponent = resolvePrimaryCustomFootprintPcbComponent({
+    builtComponent,
+    extractedKicadComponent,
+  })
+  if (!pcbComponent || !builtComponent) {
+    return matchNames
+  }
+
+  for (const candidateName of getFootprintCandidateNamesForPcbComponent({
+    circuitJson: builtComponent.circuitJson,
+    pcbComponent,
+  })) {
+    matchNames.add(candidateName)
+  }
+
+  return matchNames
+}
+
+export function resolvePrimaryCustomFootprintMetadata(params: {
+  builtComponent?: BuiltTscircuitComponent
+  extractedKicadComponent: ExtractedKicadComponent
+}): KicadFootprintMetadata | undefined {
+  const pcbComponent = resolvePrimaryCustomFootprintPcbComponent(params)
+  return pcbComponent?.metadata?.kicad_footprint as
+    | KicadFootprintMetadata
+    | undefined
 }
 
 function classifyFootprintsForComponent({
@@ -41,27 +171,23 @@ function classifyFootprintsForComponent({
   const builtComponent = ctx.builtTscircuitComponents.find(
     (c) => c.tscircuitComponentName === tscircuitComponentName,
   )
-  const pcbComponent = builtComponent?.circuitJson.find(
-    (el): el is PcbComponent => el.type === "pcb_component",
-  )
-  const metadata = pcbComponent?.metadata?.kicad_footprint as
-    | KicadFootprintMetadata
-    | undefined
+  const metadata = resolvePrimaryCustomFootprintMetadata({
+    builtComponent,
+    extractedKicadComponent,
+  })
+  const userFootprintName = getUserKicadFootprintName({
+    tscircuitComponentName,
+    metadata,
+  })
 
   for (const kicadFootprint of kicadFootprints) {
     if (kicadFootprint.isBuiltin) {
       addBuiltinFootprint({ ctx, kicadFootprint })
     } else {
-      // First custom footprint gets renamed to component name
+      // First custom footprint becomes the exported user-library footprint.
       if (!hasAddedUserFootprint) {
         hasAddedUserFootprint = true
-        let renamedFootprint = renameKicadFootprint({
-          kicadFootprint,
-          newKicadFootprintName: tscircuitComponentName,
-          kicadLibraryName: ctx.kicadLibraryName,
-          isPcm: ctx.isPcm,
-          kicadPcmPackageId: ctx.kicadPcmPackageId,
-        })
+        let renamedFootprint = kicadFootprint
 
         // Apply kicadFootprintMetadata if available
         if (metadata) {
@@ -70,10 +196,18 @@ function classifyFootprintsForComponent({
             kicadModString: applyKicadFootprintMetadata(
               renamedFootprint.kicadModString,
               metadata,
-              tscircuitComponentName,
+              userFootprintName,
             ),
           }
         }
+
+        renamedFootprint = renameKicadFootprint({
+          kicadFootprint: renamedFootprint,
+          newKicadFootprintName: userFootprintName,
+          kicadLibraryName: ctx.kicadLibraryName,
+          isPcm: ctx.isPcm,
+          kicadPcmPackageId: ctx.kicadPcmPackageId,
+        })
 
         addUserFootprint({ ctx, kicadFootprint: renamedFootprint })
       } else {

--- a/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
+++ b/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
@@ -2,9 +2,9 @@ import type { KicadFootprintMetadata } from "@tscircuit/props"
 import type {
   PcbComponent,
   CadComponent,
-  SourceComponentBase,
   CircuitJson,
 } from "circuit-json"
+import type { SourceComponentBase } from "circuit-json"
 import type { FootprintEntry } from "../../types"
 import type {
   KicadLibraryConverterContext,
@@ -17,6 +17,13 @@ import { parseKicadMod } from "kicadts"
 import { getKicadCompatibleComponentName } from "../../utils/getKicadCompatibleComponentName"
 
 const KICAD_3RD_PARTY_PLACEHOLDER = "${KICAD_3RD_PARTY}"
+// `CircuitJson` is a wide union, so `.find()` needs a narrower element type
+// before we can safely pass a source component into the naming helper.
+type CircuitJsonElement = CircuitJson[number]
+type SourceComponentElement = Extract<
+  CircuitJsonElement,
+  { type: "source_component" }
+>
 
 /**
  * Classifies footprints from extracted KiCad components into user and builtin libraries.
@@ -62,7 +69,7 @@ function getFootprintCandidateNamesForPcbComponent(params: {
     pcbComponent.source_component_id ?? cadComponent?.source_component_id
   const sourceComponent = sourceComponentId
     ? circuitJson.find(
-        (el): el is SourceComponentBase =>
+        (el): el is SourceComponentElement =>
           el.type === "source_component" &&
           el.source_component_id === sourceComponentId,
       )
@@ -70,7 +77,10 @@ function getFootprintCandidateNamesForPcbComponent(params: {
 
   if (sourceComponent) {
     candidateNames.add(
-      getKicadCompatibleComponentName(sourceComponent, cadComponent),
+      getKicadCompatibleComponentName(
+        sourceComponent as SourceComponentBase,
+        cadComponent,
+      ),
     )
   }
 

--- a/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
+++ b/lib/kicad-library/stages/ClassifyKicadFootprintsStage.ts
@@ -1,9 +1,5 @@
 import type { KicadFootprintMetadata } from "@tscircuit/props"
-import type {
-  PcbComponent,
-  CadComponent,
-  CircuitJson,
-} from "circuit-json"
+import type { PcbComponent, CadComponent, CircuitJson } from "circuit-json"
 import type { SourceComponentBase } from "circuit-json"
 import type { FootprintEntry } from "../../types"
 import type {

--- a/lib/kicad-library/stages/ClassifyKicadSymbolsStage.ts
+++ b/lib/kicad-library/stages/ClassifyKicadSymbolsStage.ts
@@ -8,7 +8,12 @@ import type {
 import { renameKicadSymbol } from "../kicad-library-converter-utils/renameKicadSymbol"
 import { updateKicadSymbolFootprint } from "../kicad-library-converter-utils/updateKicadSymbolFootprint"
 import { updateBuiltinKicadSymbolFootprint } from "../kicad-library-converter-utils/updateBuiltinKicadSymbolFootprint"
-import { componentHasCustomFootprint } from "./ClassifyKicadFootprintsStage"
+import {
+  componentHasCustomFootprint,
+  getUserKicadFootprintName,
+  resolvePrimaryCustomFootprintMatchNames,
+  resolvePrimaryCustomFootprintMetadata,
+} from "./ClassifyKicadFootprintsStage"
 import { applyKicadSymbolMetadata } from "../kicad-library-converter-utils/applyKicadSymbolMetadata"
 
 // Track symbol names that have been added for deduplication
@@ -63,16 +68,23 @@ function classifySymbolsForComponent({
   let hasAddedUserSymbol = false
 
   // Build set of custom footprint names to match symbols to custom footprints
-  const customFootprintNames = new Set(
-    extractedKicadComponent.kicadFootprints
-      .filter((fp) => !fp.isBuiltin)
-      .map((fp) => fp.footprintName),
-  )
-
-  // Get metadata from circuit-json schematic_symbol element
   const builtComponent = ctx.builtTscircuitComponents.find(
     (c) => c.tscircuitComponentName === tscircuitComponentName,
   )
+  const customFootprintNames = resolvePrimaryCustomFootprintMatchNames({
+    builtComponent,
+    extractedKicadComponent,
+  })
+
+  // Get metadata from circuit-json schematic_symbol element
+  const footprintMetadata = resolvePrimaryCustomFootprintMetadata({
+    builtComponent,
+    extractedKicadComponent,
+  })
+  const userFootprintName = getUserKicadFootprintName({
+    tscircuitComponentName,
+    metadata: footprintMetadata,
+  })
   const schematicSymbol = builtComponent?.circuitJson.find(
     (el): el is SchematicSymbol => el.type === "schematic_symbol",
   )
@@ -100,7 +112,7 @@ function classifySymbolsForComponent({
         updateKicadSymbolFootprint({
           kicadSymbol,
           kicadLibraryName: ctx.kicadLibraryName,
-          kicadFootprintName: tscircuitComponentName,
+          kicadFootprintName: userFootprintName,
           isPcm: ctx.isPcm,
         })
       }
@@ -125,7 +137,7 @@ function classifySymbolsForComponent({
         updateKicadSymbolFootprint({
           kicadSymbol: renamedSymbol,
           kicadLibraryName: ctx.kicadLibraryName,
-          kicadFootprintName: tscircuitComponentName,
+          kicadFootprintName: userFootprintName,
           isPcm: ctx.isPcm,
         })
         const updatedSymbol = metadata

--- a/tests/fixtures/take-kicad-snapshot.test.ts
+++ b/tests/fixtures/take-kicad-snapshot.test.ts
@@ -71,7 +71,7 @@ test("takeKicadSnapshot - schematic export", async () => {
   const snapshot = await takeKicadSnapshot({
     kicadFilePath: join(
       import.meta.dir,
-      "../../kicad-demos/demos/flat_hierarchy/flat_hierarchy.kicad_sch",
+      "../assets/repro13-schematic-sections-sch.kicad_sch",
     ),
     kicadFileType: "sch",
   })

--- a/tests/kicad-library/apply-kicad-footprint-metadata.test.tsx
+++ b/tests/kicad-library/apply-kicad-footprint-metadata.test.tsx
@@ -81,6 +81,68 @@ async function renderSimpleLedCircuit(): Promise<CircuitJson> {
   return circuit.getCircuitJson() as CircuitJson
 }
 
+const MetadataKeySocket = () => (
+  <chip
+    name="REF**"
+    kicadFootprintMetadata={{
+      footprintName: "MX_HotSwap_Custom",
+      layer: "B.Cu",
+      embeddedFonts: true,
+      attributes: {
+        through_hole: true,
+        exclude_from_bom: true,
+        exclude_from_pos_files: true,
+      },
+      model: {
+        path: "${KIPRJMOD}/3dmodels/MetadataSocket.step",
+        offset: { x: 0, y: 0, z: 0.5 },
+        scale: { x: 1, y: 1, z: 1 },
+        rotate: { x: 0, y: 0, z: 90 },
+      },
+    }}
+    footprint={
+      <footprint>
+        <smtpad
+          shape="rect"
+          width="2.5mm"
+          height="1.2mm"
+          portHints={["pin1"]}
+          pcbX={-3.81}
+          pcbY={2.54}
+        />
+        <smtpad
+          shape="rect"
+          width="2.5mm"
+          height="1.2mm"
+          portHints={["pin2"]}
+          pcbX={2.54}
+          pcbY={5.08}
+        />
+        <hole pcbX={0} pcbY={0} diameter="4mm" />
+        <silkscreentext text="SW" pcbY={8} fontSize="1mm" />
+      </footprint>
+    }
+    cadModel={{
+      stlUrl: "/path/to/CherryMxSwitch.step",
+      rotationOffset: { x: 0, y: 0, z: 0 },
+    }}
+    pinLabels={{ pin1: "1", pin2: "2" }}
+  />
+)
+
+const MetadataKeyHotSocket = () => (
+  <board width="20mm" height="20mm">
+    <MetadataKeySocket />
+  </board>
+)
+
+async function renderMetadataKeyHotSocket(): Promise<CircuitJson> {
+  const circuit = new Circuit()
+  circuit.add(<MetadataKeyHotSocket />)
+  await circuit.renderUntilSettled()
+  return circuit.getCircuitJson() as CircuitJson
+}
+
 test("KicadLibraryConverter with kicadFootprintMetadata callback", async () => {
   const mockExports: Record<string, string[]> = {
     "lib/my-keyboard-library.ts": ["KeyHotSocket", "SimpleLedCircuit"],
@@ -255,4 +317,41 @@ test("KicadLibraryConverter with kicadFootprintMetadata callback", async () => {
   if (symbolsFile) {
     expect(String(symbolsFile)).toContain("KeyHotSocket")
   }
+})
+
+test("KicadLibraryConverter applies metadata parity fields to custom .kicad_mod output", async () => {
+  const circuitJson = await renderMetadataKeyHotSocket()
+
+  const converter = new KicadLibraryConverter({
+    kicadLibraryName: "my-meta-library",
+    entrypoint: "lib/my-meta-library.ts",
+    getExportsFromTsxFile: async () => ["MetadataKeyHotSocket"],
+    buildFileToCircuitJson: async () => circuitJson,
+    includeBuiltins: true,
+  })
+
+  await converter.run()
+  const output = converter.getOutput()
+
+  const footprintPath =
+    "footprints/my-meta-library.pretty/MX_HotSwap_Custom.kicad_mod"
+
+  expect(Object.keys(output.kicadProjectFsMap)).toContain(footprintPath)
+  expect(Object.keys(output.kicadProjectFsMap)).not.toContain(
+    "footprints/my-meta-library.pretty/MetadataKeyHotSocket.kicad_mod",
+  )
+
+  const footprintStr = String(output.kicadProjectFsMap[footprintPath])
+  expect(footprintStr).toContain('"MX_HotSwap_Custom"')
+  expect(footprintStr).toContain("(layer B.Cu)")
+  expect(footprintStr).toContain("(embedded_fonts yes)")
+  expect(footprintStr).toContain("(attr through_hole")
+  expect(footprintStr).toContain("exclude_from_bom")
+  expect(footprintStr).toContain("exclude_from_pos_files")
+  expect(footprintStr).toContain(
+    '"../../3dmodels/my-meta-library.3dshapes/MetadataSocket.step"',
+  )
+  expect(footprintStr).toContain("(xyz 0 0 0.5)")
+  expect(footprintStr).toContain("(xyz 1 1 1)")
+  expect(footprintStr).toContain("(xyz 0 0 90)")
 })

--- a/tests/kicad-library/symbol-footprint-classification01.test.tsx
+++ b/tests/kicad-library/symbol-footprint-classification01.test.tsx
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test"
 import { KicadLibraryConverter } from "lib/kicad-library/KicadLibraryConverter"
 import { Circuit } from "tscircuit"
 import type { CircuitJson } from "circuit-json"
+import type { KicadFootprintMetadata } from "@tscircuit/props"
 import path from "path"
 
 const stepFilePath = path.resolve(
@@ -19,7 +20,9 @@ const stepFilePath = path.resolve(
  * (e.g. resistor) for the user library instead of matching the symbol whose
  * Footprint property references the custom footprint.
  */
-async function renderMixedBoard(): Promise<CircuitJson> {
+async function renderMixedBoard(params?: {
+  footprintMetadata?: KicadFootprintMetadata
+}): Promise<CircuitJson> {
   const circuit = new Circuit()
   circuit.add(
     <board width="30mm" height="20mm">
@@ -27,6 +30,7 @@ async function renderMixedBoard(): Promise<CircuitJson> {
       <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={5} />
       <chip
         name="U1"
+        kicadFootprintMetadata={params?.footprintMetadata}
         footprint={
           <footprint>
             <smtpad
@@ -149,4 +153,38 @@ test("symbol-footprint classification: correct symbol assigned to user library w
   const symLibTable = output.kicadProjectFsMap["sym-lib-table"] as string
   expect(symLibTable).toContain('(name "test-lib")')
   expect(symLibTable).toContain('(name "tscircuit_builtin")')
+})
+
+test("symbol-footprint classification honors metadata footprint rename in user symbol refs", async () => {
+  const circuitJson = await renderMixedBoard({
+    footprintMetadata: {
+      footprintName: "CustomMixedBoardFootprint",
+    },
+  })
+
+  const converter = new KicadLibraryConverter({
+    kicadLibraryName: "test-lib",
+    entrypoint: "lib/index.ts",
+    getExportsFromTsxFile: async () => ["MixedBoard"],
+    buildFileToCircuitJson: async () => circuitJson,
+    includeBuiltins: true,
+  })
+
+  await converter.run()
+  const output = converter.getOutput()
+  const outputKeys = Object.keys(output.kicadProjectFsMap).sort()
+
+  expect(outputKeys).toContain(
+    "footprints/test-lib.pretty/CustomMixedBoardFootprint.kicad_mod",
+  )
+  expect(outputKeys).not.toContain(
+    "footprints/test-lib.pretty/MixedBoard.kicad_mod",
+  )
+
+  const userSymbolContent = output.kicadProjectFsMap[
+    "symbols/test-lib.kicad_sym"
+  ] as string
+  expect(userSymbolContent).toContain(
+    '"Footprint" "test-lib:CustomMixedBoardFootprint"',
+  )
 })


### PR DESCRIPTION
This fixes the metadata mismatch between board footprint export and library `.kicad_mod` export.