### PR TITLE
repro(pcb): document fiducial F.Paste export (#372)

### DIFF
--- a/tests/pcb/repros/repro17-standalone-fiducial.test.tsx
+++ b/tests/pcb/repros/repro17-standalone-fiducial.test.tsx
@@ -51,6 +51,17 @@ test(
     expect(kicadPcb.footprints[0]!.fpPads[0]!.solderMaskMargin).toBe(1)
     expect(outputString).toContain("(solder_mask_margin 1)")
 
+    for (const footprint of kicadPcb.footprints) {
+      const pad = footprint.fpPads[0]!
+      const padLayers = pad.layers!.layers
+      expect(padLayers).toContain("F.Cu")
+      expect(padLayers).toContain("F.Mask")
+
+      // Repro for #372: Documents current behavior to be updated in the fix PR.
+      expect(padLayers).toContain("F.Paste")
+    }
+    expect(outputString).toContain("(layers F.Cu F.Paste F.Mask)")
+
     const kicadSnapshot = await takeKicadSnapshot({
       kicadFileContent: outputString,
       kicadFileType: "pcb",

--- a/tests/pcb/repros/repro17-standalone-fiducial.test.tsx
+++ b/tests/pcb/repros/repro17-standalone-fiducial.test.tsx
@@ -6,7 +6,15 @@ import { takeKicadSnapshot } from "../../fixtures/take-kicad-snapshot"
 import { takeCircuitJsonSnapshot } from "../../fixtures/take-circuit-json-snapshot"
 import { stackCircuitJsonKicadPngs } from "../../fixtures/stackCircuitJsonKicadPngs"
 
-test(
+/**
+ * Known bug: Fiducial pads incorrectly export with F.Paste layer (Issue #372).
+ *
+ * Solder paste is suppressed by default on optical target fiducials.
+ * Marked `test.failing` because it asserts the CORRECT behavior (fiducial
+ * pads should not contain F.Paste, and the generated KiCad output should
+ * use `(layers F.Cu F.Mask)`). Remove `.failing` once the fix lands.
+ */
+test.failing(
   "standalone fiducials export as KiCad SMT pads",
   async () => {
     const circuit = new Circuit()
@@ -56,11 +64,11 @@ test(
       const padLayers = pad.layers!.layers
       expect(padLayers).toContain("F.Cu")
       expect(padLayers).toContain("F.Mask")
-
-      // Repro for #372: Documents current behavior to be updated in the fix PR.
-      expect(padLayers).toContain("F.Paste")
+      expect(padLayers).not.toContain("F.Paste")
     }
-    expect(outputString).toContain("(layers F.Cu F.Paste F.Mask)")
+    expect(outputString).toContain("(layers F.Cu F.Mask)")
+    expect(outputString).not.toContain("(layers F.Cu F.Paste F.Mask)")
+    expect(outputString).not.toContain("(layers F.Cu F.Mask F.Paste)")
 
     const kicadSnapshot = await takeKicadSnapshot({
       kicadFileContent: outputString,


### PR DESCRIPTION
a reproduction test for Issue #372 documenting the current behavior where fiducial SMT pads are exported with an `F.Paste` layer.

- Adds a reproduction test documenting the current behavior.

<img width="1968" height="720" alt="reproduction_comparison" src="https://github.com/user-attachments/assets/3c802bc2-7943-4b39-8847-6af33f162f68" />

