### PR TITLE
fix(pcb): omit F.Paste aperture on pads with no pcb_solder_paste entry

### DIFF
--- a/lib/pcb/stages/footprints-stage-converters/convertSmdPads.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSmdPads.ts
@@ -24,6 +24,20 @@ export function convertSmdPads(
   const pads: FootprintPad[] = []
   let padNumber = startPadNumber
 
+  // Build a set of smtpad IDs that have an explicit pcb_solder_paste element.
+  // When the circuit JSON contains at least one pcb_solder_paste, we use that
+  // information to decide per-pad whether paste should be emitted (fixes
+  // fiducials and other pads that deliberately have no paste aperture).
+  // If no pcb_solder_paste elements exist we fall back to always emitting
+  // paste so that older circuit JSON without those elements is unaffected.
+  const solderPasteList: Array<{ pcb_smtpad_id?: string }> =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ctx.db as any).pcb_solder_paste?.list() ?? []
+  const solderPasteSmtpadIds = new Set(
+    solderPasteList.map((sp) => sp.pcb_smtpad_id).filter(Boolean),
+  )
+  const hasSolderPasteData = solderPasteSmtpadIds.size > 0
+
   for (const pcbPad of pcbPads) {
     const netInfo = getNetInfo(pcbPad.pcb_port_id)
 
@@ -49,6 +63,10 @@ export function convertSmdPads(
           ? pinHint.replace(/^pin/i, "")
           : (gridHint ?? String(padNumber))
 
+    const includePaste =
+      !hasSolderPasteData ||
+      solderPasteSmtpadIds.has(pcbPad.pcb_smtpad_id ?? "")
+
     const pad = createSmdPadFromCircuitJson({
       pcbPad,
       componentCenter,
@@ -56,6 +74,7 @@ export function convertSmdPads(
       componentRotation,
       netInfo,
       componentId,
+      includePaste,
     })
     pads.push(pad)
     padNumber++

--- a/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
+++ b/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
@@ -28,6 +28,7 @@ export function createSmdPadFromCircuitJson({
   componentRotation = 0,
   netInfo,
   componentId,
+  includePaste = true,
 }: {
   pcbPad: PcbSmtPad
   componentCenter: { x: number; y: number }
@@ -35,6 +36,10 @@ export function createSmdPadFromCircuitJson({
   componentRotation?: number
   netInfo?: PcbNetInfo
   componentId?: string
+  /** Whether to include the solder paste aperture layer. Defaults to true for
+   *  backwards compatibility; set to false for pads like fiducials that have
+   *  no corresponding pcb_solder_paste element in the circuit JSON. */
+  includePaste?: boolean
 }): FootprintPad {
   // For polygon pads, calculate the center from the points
   let padX: number
@@ -157,7 +162,7 @@ export function createSmdPadFromCircuitJson({
     size: padSize,
     layers: [
       `${padLayer}`,
-      `${padLayer === "F.Cu" ? "F" : "B"}.Paste`,
+      ...(includePaste ? [`${padLayer === "F.Cu" ? "F" : "B"}.Paste`] : []),
       `${padLayer === "F.Cu" ? "F" : "B"}.Mask`,
     ],
     solderMaskMargin: pcbPad.soldermask_margin,

--- a/tests/pcb/repros/repro-fiducial-no-paste.test.tsx
+++ b/tests/pcb/repros/repro-fiducial-no-paste.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+/**
+ * Regression test for issue #372: fiducial SMD pads were exported with an
+ * F.Paste aperture even though the circuit JSON emits no pcb_solder_paste for
+ * fiducials. A paste aperture on a fiducial smears solder during reflow and
+ * defeats the optical vision target.
+ *
+ * We verify using the raw KiCad PCB string so we are not tied to kicadts
+ * object internals (PadLayers is not a plain array).
+ */
+test("fiducial pad is exported without F.Paste aperture", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip name="U1">
+        <fiducial name="F1" pcbX={0} pcbY={0} padDiameter="1mm" />
+      </chip>
+      <resistor
+        name="R1"
+        footprint="0402"
+        pcbX={5}
+        pcbY={5}
+        resistance="10k"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+
+  // Split the output into footprint blocks so we can check per-footprint layers.
+  // A footprint block starts with "(footprint" and ends before the next "(footprint"
+  // or the end of the file.
+  const footprintBlocks = outputString
+    .split(/(?=\(footprint\s)/)
+    .filter((block) => block.trimStart().startsWith("(footprint"))
+
+  const fiducialBlock = footprintBlocks.find((block) =>
+    block.includes("fiducial"),
+  )
+  const resistorBlock = footprintBlocks.find((block) =>
+    /resistor|res0402/.test(block),
+  )
+
+  expect(fiducialBlock).toBeDefined()
+  expect(resistorBlock).toBeDefined()
+
+  // Fiducial must NOT export a paste aperture layer
+  expect(fiducialBlock).not.toContain("F.Paste")
+  expect(fiducialBlock).not.toContain("B.Paste")
+
+  // Fiducial must still have copper and mask
+  expect(fiducialBlock).toContain(".Cu")
+  expect(fiducialBlock).toContain(".Mask")
+
+  // Resistor pads SHOULD still have paste (they have pcb_solder_paste elements)
+  expect(resistorBlock).toContain("Paste")
+})


### PR DESCRIPTION
## Summary

Fixes #372

Fiducial pads (and any other pcb_smtpad that has no matching pcb_solder_paste in the circuit JSON) were unconditionally exported with an F.Paste aperture layer.  Stencils then deposit paste onto optical vision targets, which smears during reflow and defeats the purpose of the fiducial.

### Root cause

CreateSmdPadFromCircuitJson.ts builds the layers list unconditionally:

`	s
// before
layers: [padLayer, ${side}.Paste, ${side}.Mask]
`

pcb_solder_paste elements (which the core only emits for real component pads, not fiducials) were never consulted anywhere in lib/.

### Fix

Two-part change:

1. **CreateSmdPadFromCircuitJson.ts** - add optional includePaste: boolean (default 	rue).  When alse, the paste layer is omitted from the exported layers list.

2. **convertSmdPads.ts** - before iterating pads, collect all pcb_smtpad_id values that appear in pcb_solder_paste elements.  For each pad, set includePaste = hasPasteEntry || noSolderPasteDataAtAll.  The fallback to 	rue when no pcb_solder_paste elements exist preserves backwards compatibility with older circuit JSON.

### Behaviour

| Scenario | Before | After |
|---|---|---|
| Fiducial on board with resistors | F.Paste on fiducial ? | No paste on fiducial ? |
| Resistor pads | F.Paste ? | F.Paste ? |
| Old circuit JSON (no pcb_solder_paste) | F.Paste ? | F.Paste ? (unchanged) |

### Test

	ests/pcb/repros/repro-fiducial-no-paste.test.tsx - creates a board with one fiducial + one 0402 resistor and asserts:
- fiducial footprint block does **not** contain Paste
- resistor footprint block **does** contain Paste

/claim #372