### PR TITLE
feat(pcb): export pcb_keepout elements as KiCad rule-area zones

### DIFF
--- a/lib/pcb/CircuitJsonToKicadPcbConverter.ts
+++ b/lib/pcb/CircuitJsonToKicadPcbConverter.ts
@@ -4,6 +4,7 @@ import { KicadPcb } from "kicadts"
 import { cju } from "@tscircuit/circuit-json-util"
 import { compose, translate, scale } from "transformation-matrix"
 import { AddCopperPoursStage } from "./stages/AddCopperPoursStage"
+import { AddKeepoutsStage } from "./stages/AddKeepoutsStage"
 import { InitializePcbStage } from "./stages/InitializePcbStage"
 import { AddNetsStage } from "./stages/AddNetsStage"
 import { AddFootprintsStage } from "./stages/AddFootprintsStage"
@@ -72,6 +73,7 @@ export class CircuitJsonToKicadPcbConverter {
       new AddTracesStage(circuitJson, this.ctx),
       new AddViasStage(circuitJson, this.ctx),
       new AddCopperPoursStage(circuitJson, this.ctx),
+      new AddKeepoutsStage(circuitJson, this.ctx),
       new AddStandalonePcbElements(circuitJson, this.ctx),
       new AddGraphicsStage(circuitJson, this.ctx),
     ]

--- a/lib/pcb/stages/AddKeepoutsStage.ts
+++ b/lib/pcb/stages/AddKeepoutsStage.ts
@@ -1,0 +1,111 @@
+import type { CircuitJson } from "circuit-json"
+import type { KicadPcb } from "kicadts"
+import {
+  Pts,
+  Xy,
+  Zone,
+  ZoneHatch,
+  ZoneKeepout,
+  ZonePolygon,
+} from "kicadts"
+import { applyToPoint, type Matrix } from "transformation-matrix"
+import { ConverterStage } from "../../types"
+import { getKicadLayer } from "../utils/layerMapping"
+import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
+import { circleToPolygon } from "./utils/circleToPolygon"
+
+type PcbKeepout = Extract<CircuitJson[number], { type: "pcb_keepout" }>
+
+const getKeepouts = (circuitJson: CircuitJson): PcbKeepout[] =>
+  circuitJson.filter(
+    (el): el is PcbKeepout => el.type === "pcb_keepout",
+  )
+
+const mapLayers = (layers: string[]): string[] =>
+  layers.map(getKicadLayer)
+
+const getRectPoints = (
+  keepout: PcbKeepout & { shape: "rect" },
+  c2kMatPcb: Matrix,
+): Xy[] => {
+  const { center, width, height } = keepout
+  const halfW = width / 2
+  const halfH = height / 2
+  return [
+    { x: center.x - halfW, y: center.y - halfH },
+    { x: center.x + halfW, y: center.y - halfH },
+    { x: center.x + halfW, y: center.y + halfH },
+    { x: center.x - halfW, y: center.y + halfH },
+  ].map((pt) => {
+    const t = applyToPoint(c2kMatPcb, pt)
+    return new Xy(t.x, t.y)
+  })
+}
+
+const getCirclePoints = (
+  keepout: PcbKeepout & { shape: "circle" },
+  c2kMatPcb: Matrix,
+): Xy[] => {
+  return circleToPolygon(keepout.center, keepout.radius).map(([x, y]) => {
+    const t = applyToPoint(c2kMatPcb, { x, y })
+    return new Xy(t.x, t.y)
+  })
+}
+
+export class AddKeepoutsStage extends ConverterStage<CircuitJson, KicadPcb> {
+  override _step(): void {
+    const { kicadPcb, c2kMatPcb } = this.ctx
+
+    if (!kicadPcb) {
+      throw new Error("KicadPcb instance not initialized in context")
+    }
+
+    if (!c2kMatPcb) {
+      throw new Error("PCB transformation matrix not initialized in context")
+    }
+
+    const keepouts = getKeepouts(this.input)
+
+    for (const keepout of keepouts) {
+      const kicadLayers = mapLayers(keepout.layers)
+
+      let points: Xy[]
+      if (keepout.shape === "rect") {
+        points = getRectPoints(keepout as PcbKeepout & { shape: "rect" }, c2kMatPcb)
+      } else {
+        points = getCirclePoints(keepout as PcbKeepout & { shape: "circle" }, c2kMatPcb)
+      }
+
+      if (points.length < 3) continue
+
+      const zone = new Zone({
+        net: 0,
+        netName: "",
+        layers: kicadLayers.length > 1 ? kicadLayers : undefined,
+        layer: kicadLayers.length === 1 ? kicadLayers[0] : undefined,
+        uuid: generateDeterministicUuid(
+          `keepout:${keepout.pcb_keepout_id}`,
+        ),
+        hatch: new ZoneHatch("edge", 0.5),
+        keepout: new ZoneKeepout({
+          tracks: "not_allowed",
+          vias: "not_allowed",
+          copperpour: "not_allowed",
+          pads: "allowed",
+          footprints: "allowed",
+        }),
+        polygons: [new ZonePolygon(new Pts(points))],
+      })
+
+      const zones = kicadPcb.zones
+      zones.push(zone)
+      kicadPcb.zones = zones
+    }
+
+    this.finished = true
+  }
+
+  override getOutput(): KicadPcb {
+    return this.ctx.kicadPcb!
+  }
+}

--- a/lib/pcb/stages/AddKeepoutsStage.ts
+++ b/lib/pcb/stages/AddKeepoutsStage.ts
@@ -1,13 +1,6 @@
 import type { CircuitJson } from "circuit-json"
 import type { KicadPcb } from "kicadts"
-import {
-  Pts,
-  Xy,
-  Zone,
-  ZoneHatch,
-  ZoneKeepout,
-  ZonePolygon,
-} from "kicadts"
+import { Pts, Xy, Zone, ZoneHatch, ZoneKeepout, ZonePolygon } from "kicadts"
 import { applyToPoint, type Matrix } from "transformation-matrix"
 import { ConverterStage } from "../../types"
 import { getKicadLayer } from "../utils/layerMapping"
@@ -17,12 +10,9 @@ import { circleToPolygon } from "./utils/circleToPolygon"
 type PcbKeepout = Extract<CircuitJson[number], { type: "pcb_keepout" }>
 
 const getKeepouts = (circuitJson: CircuitJson): PcbKeepout[] =>
-  circuitJson.filter(
-    (el): el is PcbKeepout => el.type === "pcb_keepout",
-  )
+  circuitJson.filter((el): el is PcbKeepout => el.type === "pcb_keepout")
 
-const mapLayers = (layers: string[]): string[] =>
-  layers.map(getKicadLayer)
+const mapLayers = (layers: string[]): string[] => layers.map(getKicadLayer)
 
 const getRectPoints = (
   keepout: PcbKeepout & { shape: "rect" },
@@ -71,9 +61,15 @@ export class AddKeepoutsStage extends ConverterStage<CircuitJson, KicadPcb> {
 
       let points: Xy[]
       if (keepout.shape === "rect") {
-        points = getRectPoints(keepout as PcbKeepout & { shape: "rect" }, c2kMatPcb)
+        points = getRectPoints(
+          keepout as PcbKeepout & { shape: "rect" },
+          c2kMatPcb,
+        )
       } else {
-        points = getCirclePoints(keepout as PcbKeepout & { shape: "circle" }, c2kMatPcb)
+        points = getCirclePoints(
+          keepout as PcbKeepout & { shape: "circle" },
+          c2kMatPcb,
+        )
       }
 
       if (points.length < 3) continue
@@ -83,9 +79,7 @@ export class AddKeepoutsStage extends ConverterStage<CircuitJson, KicadPcb> {
         netName: "",
         layers: kicadLayers.length > 1 ? kicadLayers : undefined,
         layer: kicadLayers.length === 1 ? kicadLayers[0] : undefined,
-        uuid: generateDeterministicUuid(
-          `keepout:${keepout.pcb_keepout_id}`,
-        ),
+        uuid: generateDeterministicUuid(`keepout:${keepout.pcb_keepout_id}`),
         hatch: new ZoneHatch("edge", 0.5),
         keepout: new ZoneKeepout({
           tracks: "not_allowed",

--- a/tests/pcb/basics/basics19-keepout.test.ts
+++ b/tests/pcb/basics/basics19-keepout.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+test("pcb basics19 keepout rect exported as KiCad rule-area zone", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "keepout0",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 12,
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+
+  expect(outputString).toContain("(zone")
+  expect(outputString).toContain("(keepout")
+  expect(outputString).toContain("(tracks not_allowed)")
+  expect(outputString).toContain("(vias not_allowed)")
+  expect(outputString).toContain("(copperpour not_allowed)")
+  expect(outputString).toContain("(pads allowed)")
+  expect(outputString).toContain("(footprints allowed)")
+  expect(outputString).toContain("(polygon")
+  // multi-layer keepout uses (layers ...) not (layer ...)
+  expect(outputString).toContain("F.Cu")
+  expect(outputString).toContain("B.Cu")
+})
+
+test("pcb basics19 keepout circle exported as KiCad rule-area zone", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "keepout1",
+      shape: "circle",
+      center: { x: 0, y: 0 },
+      radius: 3,
+      layers: ["top"],
+    },
+  ]
+
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
+  converter.runUntilFinished()
+
+  const outputString = converter.getOutputString()
+
+  expect(outputString).toContain("(zone")
+  expect(outputString).toContain("(keepout")
+  expect(outputString).toContain("(layer F.Cu)")
+  expect(outputString).toContain("(tracks not_allowed)")
+  expect(outputString).toContain("(polygon")
+})


### PR DESCRIPTION
Fixes #371

Adds AddKeepoutsStage to the PCB converter pipeline. Converts pcb_keepout rect and circle shapes into KiCad rule-area zones.

What changed:
- New lib/pcb/stages/AddKeepoutsStage.ts: converts pcb_keepout elements to KiCad zone rule-areas
- Rect shape: 4 corners from center+width+height with coordinate transform applied
- Circle shape: polygon approximation via existing circleToPolygon utility
- Multi-layer keepouts use (layers F.Cu B.Cu), single-layer use (layer F.Cu)
- Keepout rules: tracks not_allowed, vias not_allowed, copperpour not_allowed, pads/footprints allowed
- Modified CircuitJsonToKicadPcbConverter.ts: added AddKeepoutsStage to the pipeline
- New test basics19-keepout.test.ts covering rect and circle keepouts

/claim #371