### PR TITLE
fix(pcb): export pcb_keepout elements as KiCad rule-area zones

### DIFF
--- a/lib/pcb/CircuitJsonToKicadPcbConverter.ts
+++ b/lib/pcb/CircuitJsonToKicadPcbConverter.ts
@@ -4,6 +4,7 @@ import { KicadPcb } from "kicadts"
 import { cju } from "@tscircuit/circuit-json-util"
 import { compose, translate, scale } from "transformation-matrix"
 import { AddCopperPoursStage } from "./stages/AddCopperPoursStage"
+import { AddKeepoutsStage } from "./stages/AddKeepoutsStage"
 import { InitializePcbStage } from "./stages/InitializePcbStage"
 import { AddNetsStage } from "./stages/AddNetsStage"
 import { AddFootprintsStage } from "./stages/AddFootprintsStage"
@@ -72,6 +73,7 @@ export class CircuitJsonToKicadPcbConverter {
       new AddTracesStage(circuitJson, this.ctx),
       new AddViasStage(circuitJson, this.ctx),
       new AddCopperPoursStage(circuitJson, this.ctx),
+      new AddKeepoutsStage(circuitJson, this.ctx),
       new AddStandalonePcbElements(circuitJson, this.ctx),
       new AddGraphicsStage(circuitJson, this.ctx),
     ]

--- a/lib/pcb/stages/AddKeepoutsStage.ts
+++ b/lib/pcb/stages/AddKeepoutsStage.ts
@@ -1,0 +1,77 @@
+import type { CircuitJson, PCBKeepout } from "circuit-json"
+import type { KicadPcb } from "kicadts"
+import { Pts, Xy, Zone, ZoneKeepout, ZonePolygon } from "kicadts"
+import { applyToPoint } from "transformation-matrix"
+import { ConverterStage } from "../../types"
+import { getKicadLayer } from "../utils/layerMapping"
+import { circleToPolygon } from "./utils/circleToPolygon"
+import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
+
+const isPcbKeepout = (element: CircuitJson[number]): element is PCBKeepout =>
+  element.type === "pcb_keepout"
+
+const getKeepouts = (circuitJson: CircuitJson): PCBKeepout[] =>
+  circuitJson.filter(isPcbKeepout)
+
+export class AddKeepoutsStage extends ConverterStage<CircuitJson, KicadPcb> {
+  override _step(): void {
+    const { kicadPcb, c2kMatPcb } = this.ctx
+
+    if (!kicadPcb)
+      throw new Error("KicadPcb instance not initialized in context")
+    if (!c2kMatPcb)
+      throw new Error("PCB transformation matrix not initialized in context")
+
+    const keepouts = getKeepouts(this.input)
+
+    for (const keepout of keepouts) {
+      const kicadLayers = keepout.layers.map(getKicadLayer)
+
+      let rawPoints: { x: number; y: number }[]
+      if (keepout.shape === "rect") {
+        const halfW = keepout.width / 2
+        const halfH = keepout.height / 2
+        rawPoints = [
+          { x: keepout.center.x - halfW, y: keepout.center.y - halfH },
+          { x: keepout.center.x + halfW, y: keepout.center.y - halfH },
+          { x: keepout.center.x + halfW, y: keepout.center.y + halfH },
+          { x: keepout.center.x - halfW, y: keepout.center.y + halfH },
+        ]
+      } else {
+        rawPoints = circleToPolygon(keepout.center, keepout.radius).map(
+          ([x, y]) => ({ x, y }),
+        )
+      }
+
+      const kicadPoints = rawPoints.map((p) => {
+        const t = applyToPoint(c2kMatPcb, p)
+        return new Xy(t.x, t.y)
+      })
+
+      const zone = new Zone({
+        net: 0,
+        netName: "",
+        layers: kicadLayers,
+        uuid: generateDeterministicUuid(`keepout:${keepout.pcb_keepout_id}`),
+        keepout: new ZoneKeepout({
+          tracks: "not_allowed",
+          vias: "not_allowed",
+          pads: "not_allowed",
+          copperpour: "not_allowed",
+          footprints: "not_allowed",
+        }),
+        polygons: [new ZonePolygon(new Pts(kicadPoints))],
+      })
+
+      const zones = kicadPcb.zones
+      zones.push(zone)
+      kicadPcb.zones = zones
+    }
+
+    this.finished = true
+  }
+
+  override getOutput(): KicadPcb {
+    return this.ctx.kicadPcb!
+  }
+}

--- a/tests/pcb/repros/repro29-keepout.test.tsx
+++ b/tests/pcb/repros/repro29-keepout.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
 import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
 import { Circuit } from "tscircuit"
+import { parseKicadPcb } from "kicadts"
 import { stackCircuitJsonKicadPngs } from "../../fixtures/stackCircuitJsonKicadPngs"
 import { takeCircuitJsonSnapshot } from "../../fixtures/take-circuit-json-snapshot"
 import { takeKicadSnapshot } from "../../fixtures/take-kicad-snapshot"
@@ -58,22 +59,31 @@ test(
 )
 
 /**
- * Known bug: pcb_keepout elements are dropped entirely by the PCB converter.
- * The converter has no stage that handles pcb_keepout, so they never appear
- * in the KiCad output as (zone ... (keepout ...)) rule areas.
+ * Regression test: pcb_keepout elements are converted to KiCad rule-area zones.
  *
- * Marked test.failing because it asserts the CORRECT behavior (the output
- * should contain a zone with a keepout sub-block), which the current code
- * does not satisfy. The fix is to add an AddKeepoutsStage; remove .failing
- * once it lands.
+ * kicad-cli's SVG plotter explicitly skips rule-area zones
+ * (GetIsRuleArea() → continue in PlotStandardLayer), so the keepout
+ * produces zero SVG elements regardless of export resolution.  The visual
+ * snapshot therefore cannot differ with or without the fix.
+ *
+ * The parsed-object assertions below provide authoritative structural proof
+ * that the KiCad output contains the keepout zone with all five ZoneKeepout
+ * constraints set to "not_allowed".
  */
-test.failing("pcb repro29 keepout exports as kicad rule-area zone", async () => {
+test("pcb repro29 keepout exports as kicad rule-area zone", async () => {
   const circuitJson = await createRepro29CircuitJson()
   const converter = new CircuitJsonToKicadPcbConverter(circuitJson)
   converter.runUntilFinished()
-  const outputString = converter.getOutputString()
 
-  expect(outputString).toContain("(zone")
-  expect(outputString).toContain("(keepout")
-  expect(outputString).toContain("(tracks not_allowed)")
+  const parsedPcb = parseKicadPcb(converter.getOutputString())
+  expect(parsedPcb.zones.length).toBeGreaterThan(0)
+  const keepoutZone = parsedPcb.zones[0]!
+  expect(keepoutZone.keepout).toBeDefined()
+  expect(keepoutZone.keepout!.tracks).toBe("not_allowed")
+  expect(keepoutZone.keepout!.vias).toBe("not_allowed")
+  expect(keepoutZone.keepout!.pads).toBe("not_allowed")
+  expect(keepoutZone.keepout!.copperpour).toBe("not_allowed")
+  expect(keepoutZone.keepout!.footprints).toBe("not_allowed")
+  expect(keepoutZone.filledPolygons).toHaveLength(0)
+  expect(keepoutZone.net).toBe(0)
 })


### PR DESCRIPTION
Fixes #371.

repro #391.

<img width="696" height="603" alt="keepout-gui" src="https://github.com/user-attachments/assets/9ccfd95c-1705-4ea4-9cc0-34f066a51fa1" />
