### PR TITLE
fix: report zero footprints instead of claiming multiple were generated (#401)

### DIFF
--- a/lib/footprint/CircuitJsonToKicadModConverter.ts
+++ b/lib/footprint/CircuitJsonToKicadModConverter.ts
@@ -45,6 +45,12 @@ export class CircuitJsonToKicadModConverter {
   getOutput(): FootprintEntry {
     const footprints = this.libraryConverter.getFootprints()
 
+    if (footprints.length === 0) {
+      throw new Error(
+        'No footprints were generated. CircuitJsonToKicadModConverter needs circuit JSON containing at least one component with a footprint (for example <resistor footprint="0402" />).',
+      )
+    }
+
     if (this.footprintName) {
       const matchingFootprint = footprints.find(
         (footprint) => footprint.footprintName === this.footprintName,

--- a/tests/footprint/kicad-mod-no-footprints01.test.tsx
+++ b/tests/footprint/kicad-mod-no-footprints01.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadModConverter } from "lib/footprint/CircuitJsonToKicadModConverter"
+
+test("zero footprints reports that none were generated, not that there were multiple", () => {
+  const converter = new CircuitJsonToKicadModConverter([] as any)
+  converter.runUntilFinished()
+
+  expect(() => converter.getOutput()).toThrow(/No footprints were generated/)
+  // The old message claimed the opposite of what happened.
+  expect(() => converter.getOutput()).not.toThrow(/Multiple footprints/)
+
+  // Same for the other two public entry points, which both route through getOutput().
+  expect(() => converter.getOutputString()).toThrow(
+    /No footprints were generated/,
+  )
+  expect(() => converter.getModel3dSourcePaths()).toThrow(
+    /No footprints were generated/,
+  )
+})
+
+test("a requested footprintName on an empty circuit also reports zero footprints", () => {
+  const converter = new CircuitJsonToKicadModConverter([] as any, {
+    footprintName: "res0402",
+  })
+  converter.runUntilFinished()
+
+  expect(() => converter.getOutput()).toThrow(/No footprints were generated/)
+  // Previously this said `not found. Available footprints: ` with an empty list.
+  expect(() => converter.getOutput()).not.toThrow(/not found/)
+})
+
+test("two footprints still report the multiple-footprints error", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <capacitor name="C1" capacitance="1uF" footprint="0603" pcbX={5} />
+    </board>,
+  )
+  const circuitJson = await circuit.getCircuitJson()
+
+  const converter = new CircuitJsonToKicadModConverter(circuitJson as any)
+  converter.runUntilFinished()
+
+  expect(() => converter.getOutput()).toThrow(
+    /Multiple footprints were generated/,
+  )
+  expect(() => converter.getOutput()).toThrow(/resistor_res0402/)
+})
+
+test("a single footprint still converts", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+  const circuitJson = await circuit.getCircuitJson()
+
+  const converter = new CircuitJsonToKicadModConverter(circuitJson as any)
+  converter.runUntilFinished()
+
+  expect(converter.getOutputString()).toContain("(footprint")
+})


### PR DESCRIPTION
Fixes #401.

### What was wrong

With zero footprints, `CircuitJsonToKicadModConverter` threw the error written for the *two-or-more* case:

```
Multiple footprints were generated. Pass footprintName to
CircuitJsonToKicadModConverter. Available footprints:
```

It tells you to disambiguate between footprints, and the list to disambiguate from is empty. The real problem is the opposite one — nothing was generated. `getOutput()` returns early for the 1-footprint and single-custom-footprint cases, so zero fell through to the final `throw`, which was only ever meant to catch `>= 2`.

All three public entry points hit it, since `getOutputString()` and `getModel3dSourcePaths()` both call `getOutput()`.

Passing `footprintName` didn't rescue it either — that path threw `Footprint "x" not found. Available footprints: `, which implies alternatives exist when none do.

### The fix

One guard at the top of `getOutput()`, before either branch:

```
No footprints were generated. CircuitJsonToKicadModConverter needs circuit JSON
containing at least one component with a footprint (for example
<resistor footprint="0402" />).
```

Placing it above the `footprintName` branch means both entry paths report the same real cause, and the message points at the input rather than at `footprintName`, which cannot fix a zero-footprint circuit.

### Scope

Six lines, one file, error messages only — no conversion behaviour changes. The `>= 2` error is untouched and still fires with its footprint list.

Worth noting for reviewers: a component that simply has no `footprint` prop is **not** this case. That still produces one footprint entry (named `resistor`, no pads) and converts normally. Reaching zero requires circuit JSON that yields no footprint entries at all, so this guard doesn't intercept the more common no-footprint-prop path.

### Tests

`tests/footprint/kicad-mod-no-footprints01.test.tsx` pins all four states so neither a blanket throw nor a no-op passes:

| input | expected |
|---|---|
| zero footprints | throws `No footprints were generated`, **and explicitly not** `Multiple footprints` |
| zero footprints, via `getOutputString` / `getModel3dSourcePaths` | same error |
| zero footprints + `footprintName` | `No footprints were generated`, **not** `not found` |
| two footprints (`0402` + `0603`) | still `Multiple footprints were generated`, still lists `resistor_res0402` |
| one footprint | still converts, output contains `(footprint` |

Bite-proofed: reverting only `CircuitJsonToKicadModConverter.ts` takes the file from **4 pass** to **2 pass / 2 fail**.

### Verification

- `bun test`: **60 pass / 77 fail**, against a **56 pass / 77 fail** baseline on `main` — the 4 new tests pass and the failure count is unchanged.
- The 77 pre-existing failures are all `bun: command not found: kicad-cli` in my local environment; CI runs inside `ghcr.io/kicad/kicad:10.0.1` where `kicad-cli` is present. I confirmed every one of those 77 failures has that same cause and none is a behaviour difference.
- `bunx tsc --noEmit`: clean.
- `bun run format:check`: fails on `tests/assets/led-water-accelerometer.json` and `tests/assets/motor-controller.json` — **pre-existing on `main`**, verified by stashing my change and re-running. My two touched files are biome-formatted.
