### PR TITLE
fix: keep non-finite hole/via dimensions out of the kicad_pcb (#403)

### DIFF
--- a/lib/pcb/stages/AddStandalonePcbElements.ts
+++ b/lib/pcb/stages/AddStandalonePcbElements.ts
@@ -16,6 +16,9 @@ import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
 import { convertNpthHoles } from "./footprints-stage-converters/convertNpthHoles"
 import { createThruHolePadFromCircuitJson } from "./utils/CreateThruHolePadFromCircuitJson"
 import { createSmdPadFromCircuitJson } from "./utils/CreateSmdPadFromCircuitJson"
+import { finiteOr } from "./utils/finiteOr"
+
+const DEFAULT_HOLE_DIMENSION_MM = 1.0
 
 export class AddStandalonePcbElements extends ConverterStage<
   CircuitJson,
@@ -138,14 +141,14 @@ export class AddStandalonePcbElements extends ConverterStage<
   private getHoleLibraryLink(hole: PcbHole): string {
     const { hole_shape: shape } = hole
     if (shape === "circle") {
-      return `tscircuit:hole_${shape}_holeDiameter${hole.hole_diameter}mm`
+      return `tscircuit:hole_${shape}_holeDiameter${finiteOr(hole.hole_diameter, DEFAULT_HOLE_DIMENSION_MM)}mm`
     }
     if (shape === "pill" || shape === "oval") {
       const h = hole
-      return `tscircuit:hole_${shape}_holeWidth${h.hole_width}mm_holeHeight${h.hole_height}mm`
+      return `tscircuit:hole_${shape}_holeWidth${finiteOr(h.hole_width, DEFAULT_HOLE_DIMENSION_MM)}mm_holeHeight${finiteOr(h.hole_height, DEFAULT_HOLE_DIMENSION_MM)}mm`
     }
     if (shape === "rotated_pill") {
-      return `tscircuit:hole_${shape}_holeWidth${hole.hole_width}mm_holeHeight${hole.hole_height}mm_ccwRotation${hole.ccw_rotation}deg`
+      return `tscircuit:hole_${shape}_holeWidth${finiteOr(hole.hole_width, DEFAULT_HOLE_DIMENSION_MM)}mm_holeHeight${finiteOr(hole.hole_height, DEFAULT_HOLE_DIMENSION_MM)}mm_ccwRotation${finiteOr(hole.ccw_rotation, 0)}deg`
     }
     return "tscircuit:hole"
   }
@@ -153,7 +156,7 @@ export class AddStandalonePcbElements extends ConverterStage<
   private getPlatedHoleLibraryLink(hole: PcbPlatedHole): string {
     const shape = hole.shape
     if (shape === "circle") {
-      return `tscircuit:platedhole_${shape}_holeDiameter${hole.hole_diameter}mm_outerDiameter${hole.outer_diameter}mm`
+      return `tscircuit:platedhole_${shape}_holeDiameter${finiteOr(hole.hole_diameter, DEFAULT_HOLE_DIMENSION_MM)}mm_outerDiameter${finiteOr(hole.outer_diameter, DEFAULT_HOLE_DIMENSION_MM)}mm`
     }
     if (shape === "pill" || shape === "oval") {
       const h = hole as PcbPlatedHoleOval

--- a/lib/pcb/stages/AddViasStage.ts
+++ b/lib/pcb/stages/AddViasStage.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types"
 import { applyToPoint } from "transformation-matrix"
 import { generateDeterministicUuid } from "./utils/generateDeterministicUuid"
+import { finiteOr } from "./utils/finiteOr"
 import {
   getKicadLayer,
   getViaLayers,
@@ -201,8 +202,11 @@ export class AddViasStage extends ConverterStage<CircuitJson, KicadPcb> {
     const viaLayers = this.getKicadViaLayers(via)
 
     // Preserve explicit Circuit JSON via dimensions; only fall back when absent.
-    const viaSize = via.outer_diameter ?? 0.8
-    const viaDrill = via.hole_diameter ?? 0.4
+    // `??` alone is not enough: an unparseable user value (e.g. holeDiameter="abc")
+    // arrives here as NaN, not null/undefined, and would be written straight into
+    // the .kicad_pcb as `(drill NaN)`, which KiCad refuses to open.
+    const viaSize = finiteOr(via.outer_diameter, 0.8, "pcb_via.outer_diameter")
+    const viaDrill = finiteOr(via.hole_diameter, 0.4, "pcb_via.hole_diameter")
 
     // Create a via with deterministic UUID
     const viaData = `via:${transformedPos.x},${transformedPos.y}:${viaSize}:${viaDrill}:${netInfo?.id ?? 0}`

--- a/lib/pcb/stages/utils/CreateNpthPadFromCircuitJson.ts
+++ b/lib/pcb/stages/utils/CreateNpthPadFromCircuitJson.ts
@@ -1,6 +1,9 @@
 import { FootprintPad, PadDrill } from "kicadts"
 import type { PcbHole } from "circuit-json"
 import { applyToPoint, rotate, identity } from "transformation-matrix"
+import { finiteOr } from "./finiteOr"
+
+const DEFAULT_HOLE_DIMENSION_MM = 1.0
 
 export function createNpthPadFromCircuitJson({
   pcbHole,
@@ -38,7 +41,11 @@ export function createNpthPadFromCircuitJson({
   if (pcbHole.hole_shape === "circle") {
     // Circular non-plated hole
     padShape = "circle"
-    const diameter = pcbHole.hole_diameter
+    const diameter = finiteOr(
+      pcbHole.hole_diameter,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_diameter",
+    )
     padSize = [diameter, diameter]
     drill = new PadDrill({
       diameter: diameter,
@@ -46,8 +53,16 @@ export function createNpthPadFromCircuitJson({
   } else if (pcbHole.hole_shape === "oval" || pcbHole.hole_shape === "pill") {
     // Oval or Pill-shaped non-plated hole
     padShape = "oval"
-    const width = pcbHole.hole_width
-    const height = pcbHole.hole_height
+    const width = finiteOr(
+      pcbHole.hole_width,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_width",
+    )
+    const height = finiteOr(
+      pcbHole.hole_height,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_height",
+    )
     padSize = [width, height]
     drill = new PadDrill({
       oval: true,
@@ -57,8 +72,16 @@ export function createNpthPadFromCircuitJson({
   } else if (pcbHole.hole_shape === "rotated_pill") {
     // Rotated pill-shaped non-plated hole
     padShape = "oval"
-    const width = pcbHole.hole_width
-    const height = pcbHole.hole_height
+    const width = finiteOr(
+      pcbHole.hole_width,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_width",
+    )
+    const height = finiteOr(
+      pcbHole.hole_height,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_height",
+    )
     padSize = [width, height]
     drill = new PadDrill({
       oval: true,
@@ -69,7 +92,11 @@ export function createNpthPadFromCircuitJson({
   } else {
     // Default fallback for unknown shapes
     padShape = "circle"
-    const diameter = "hole_diameter" in pcbHole ? pcbHole.hole_diameter : 1.0
+    const diameter = finiteOr(
+      "hole_diameter" in pcbHole ? pcbHole.hole_diameter : undefined,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_hole.hole_diameter",
+    )
     padSize = [diameter, diameter]
     drill = new PadDrill({ diameter: diameter })
   }

--- a/lib/pcb/stages/utils/CreateThruHolePadFromCircuitJson.ts
+++ b/lib/pcb/stages/utils/CreateThruHolePadFromCircuitJson.ts
@@ -3,6 +3,9 @@ import type { PcbPlatedHole } from "circuit-json"
 import { applyToPoint, rotate, identity } from "transformation-matrix"
 import type { PcbNetInfo } from "../../../types"
 import { generateDeterministicUuid } from "./generateDeterministicUuid"
+import { finiteOr } from "./finiteOr"
+
+const DEFAULT_HOLE_DIMENSION_MM = 1.0
 
 export function createThruHolePadFromCircuitJson({
   platedHole,
@@ -69,9 +72,18 @@ export function createThruHolePadFromCircuitJson({
   if (platedHole.shape === "circle") {
     // Circular plated hole
     padShape = "circle"
-    padSize = [platedHole.outer_diameter, platedHole.outer_diameter]
+    const outerDiameter = finiteOr(
+      platedHole.outer_diameter,
+      DEFAULT_HOLE_DIMENSION_MM,
+      "pcb_plated_hole.outer_diameter",
+    )
+    padSize = [outerDiameter, outerDiameter]
     drill = new PadDrill({
-      diameter: platedHole.hole_diameter,
+      diameter: finiteOr(
+        platedHole.hole_diameter,
+        DEFAULT_HOLE_DIMENSION_MM,
+        "pcb_plated_hole.hole_diameter",
+      ),
       offset: drillOffset,
     })
   } else if (platedHole.shape === "pill" || platedHole.shape === "oval") {

--- a/lib/pcb/stages/utils/finiteOr.ts
+++ b/lib/pcb/stages/utils/finiteOr.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns `value` when it is a usable number, otherwise `fallback`.
+ *
+ * `value ?? fallback` is not sufficient for dimensions coming from Circuit JSON:
+ * an unparseable user value (e.g. `holeDiameter="abc"`) reaches the converter as
+ * `NaN`, which is neither `null` nor `undefined` and therefore passes straight
+ * through `??`. Writing it into a KiCad file produces tokens like `(drill NaN)`
+ * or `(size NaN NaN)`, which KiCad refuses to parse — so the whole board fails to
+ * open rather than one hole merely looking wrong.
+ */
+export const finiteOr = (
+  value: number | null | undefined,
+  fallback: number,
+  label?: string,
+): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "number" && label) {
+    // Only warn for NaN/Infinity, which means a real value was computed and lost.
+    // A plain null/undefined is the ordinary "not specified" case.
+    console.warn(
+      `${label} is ${value}; writing ${fallback} instead. A non-finite dimension would emit an unparseable KiCad file.`,
+    )
+  }
+  return fallback
+}

--- a/tests/pcb/nan-hole-dimensions01.test.tsx
+++ b/tests/pcb/nan-hole-dimensions01.test.tsx
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "tscircuit"
+import { CircuitJsonToKicadPcbConverter } from "lib/pcb/CircuitJsonToKicadPcbConverter"
+
+const convert = async (element: any) => {
+  const circuit = new Circuit()
+  circuit.add(element)
+  const circuitJson = await circuit.getCircuitJson()
+  const converter = new CircuitJsonToKicadPcbConverter(circuitJson as any)
+  converter.runUntilFinished()
+  return converter.getOutputString()
+}
+
+test("an unparseable hole diameter does not emit NaN into the kicad_pcb", async () => {
+  const output = await convert(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <hole name="H1" diameter={"abc" as any} pcbX={2} pcbY={2} />
+    </board>,
+  )
+
+  expect(output).not.toContain("NaN")
+  expect(output).toContain("(drill 1)")
+})
+
+test("an unparseable via hole diameter does not emit NaN", async () => {
+  const output = await convert(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <via
+        name="V1"
+        holeDiameter={"abc" as any}
+        outerDiameter="0.6mm"
+        pcbX={2}
+        pcbY={2}
+      />
+    </board>,
+  )
+
+  expect(output).not.toContain("NaN")
+  // The via keeps its valid outer diameter and falls back only for the drill.
+  expect(output).toContain("(size 0.6)")
+  expect(output).toContain("(drill 0.4)")
+})
+
+test("an unparseable plated hole diameter does not emit NaN", async () => {
+  const output = await convert(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <platedhole
+        name="P1"
+        holeDiameter={"abc" as any}
+        outerDiameter="1mm"
+        pcbX={2}
+        pcbY={2}
+        shape="circle"
+      />
+    </board>,
+  )
+
+  expect(output).not.toContain("NaN")
+})
+
+test("valid hole and via dimensions are still written verbatim", async () => {
+  const output = await convert(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <hole name="H1" diameter="2.5mm" pcbX={2} pcbY={2} />
+      <via
+        name="V1"
+        holeDiameter="0.3mm"
+        outerDiameter="0.7mm"
+        pcbX={-2}
+        pcbY={-2}
+      />
+    </board>,
+  )
+
+  expect(output).not.toContain("NaN")
+  // Real values must survive — the guard must not clamp everything to a default.
+  expect(output).toContain("(drill 2.5)")
+  expect(output).toContain("(drill 0.3)")
+  expect(output).toContain("(size 0.7)")
+})


### PR DESCRIPTION
Fixes #403.

### What was wrong

`<hole diameter="abc" />` didn't produce a wrong-looking hole — it produced a `.kicad_pcb` **KiCad refuses to open**:

```
(footprint
  "tscircuit:hole_circle_holeDiameterNaNmm"
  (pad "" np_thru_hole circle
    (size NaN NaN)
    (drill NaN)
```

Unparseable unit strings land in Circuit JSON as `null`, and the value that reaches the converter is `NaN`. That's what defeats the guard that looks like it already covers this:

```
null ?? 0.4  →  0.4    ✅
NaN  ?? 0.4  →  NaN    ❌
```

`??` substitutes only for nullish values. `AddViasStage.ts` had that fallback and still emitted `(drill NaN)`; the npth and plated-hole builders read the field unguarded; and `AddStandalonePcbElements.ts` interpolated it into the footprint library name.

### The fix

A shared `finiteOr(value, fallback, label?)` helper in `lib/pcb/stages/utils/finiteOr.ts`, applied at the four sites that consume these dimensions. It accepts a value only when `Number.isFinite`, so it covers `NaN` and `Infinity` as well as nullish.

It follows the pattern already in this repo — `applyKicadSymbolMetadata.ts` does `if (Number.isNaN(parsed)) return fallback` — rather than introducing a new convention.

When a **non-finite** value is replaced it emits a `console.warn` naming the field (`pcb_via.hole_diameter is NaN; writing 0.4 instead...`), matching the existing `console.warn` usage in `ExtractFootprintsStage.ts` and `applyKicadFootprintMetadata.ts`. A plain `null`/`undefined` is the ordinary "not specified" case and stays silent, so this doesn't add noise to normal conversions.

### Scope

Deliberately limited to the hole/via dimensions that reach these four sites. I did not sweep every numeric field in the converter — that would be a much larger change and I'd rather land the path with a demonstrated failure first. Happy to extend if you'd prefer the broader pass.

This does not depend on upstream: `tscircuit/core` doesn't currently error on these values (filed separately as tscircuit/core#2855), but Circuit JSON can come from other producers, so the converter shouldn't turn a bad number into an unopenable file regardless.

### Tests

`tests/pcb/nan-hole-dimensions01.test.tsx`, four tests pinning both directions:

| input | expected |
|---|---|
| `<hole diameter="abc" />` | no `NaN` anywhere in output, `(drill 1)` |
| `<via holeDiameter="abc" outerDiameter="0.6mm" />` | no `NaN`, `(size 0.6)` **kept**, `(drill 0.4)` fallback |
| `<platedhole holeDiameter="abc" />` | no `NaN` |
| valid `diameter="2.5mm"`, `holeDiameter="0.3mm"`, `outerDiameter="0.7mm"` | written verbatim: `(drill 2.5)`, `(drill 0.3)`, `(size 0.7)` |

The last row is the important one — it fails if the guard clamps real dimensions, so a blanket "always use the default" change can't pass. The via case checks the same thing at finer grain: the valid outer diameter survives while only the bad drill falls back.

Bite-proofed: reverting `lib/` takes the file from **4 pass** to **1 pass / 3 fail**, with only the valid-values test still passing.

### Verification

- `bun test`: **60 pass / 77 fail**, against a **56 pass / 77 fail** baseline on `main` — 4 new tests pass, failure count unchanged.
- Those 77 pre-existing failures are all `bun: command not found: kicad-cli` locally; CI runs in `ghcr.io/kicad/kicad:10.0.1` where it's present. I verified every one has that cause and none is a behaviour difference.
- `bunx tsc --noEmit`: clean. Touched files are biome-formatted.
- `bun run format:check` fails on `tests/assets/led-water-accelerometer.json` and `tests/assets/motor-controller.json` — pre-existing on `main`, confirmed by stashing and re-running.
