### PR TITLE
Use SMT pad solder paste margin in KiCad output

### DIFF
--- a/lib/pcb/stages/AddStandalonePcbElements.ts
+++ b/lib/pcb/stages/AddStandalonePcbElements.ts
@@ -75,6 +75,11 @@ export class AddStandalonePcbElements extends ConverterStage<
           padNumber: 1,
           componentRotation: 0,
           componentId: pcbPad.pcb_smtpad_id,
+          hasExplicitSolderPaste: this.ctx.circuitJson.some(
+            (element) =>
+              element.type === "pcb_solder_paste" &&
+              element.pcb_smtpad_id === pcbPad.pcb_smtpad_id,
+          ),
         }),
       ]
       const footprints = kicadPcb.footprints

--- a/lib/pcb/stages/footprints-stage-converters/convertSmdPads.ts
+++ b/lib/pcb/stages/footprints-stage-converters/convertSmdPads.ts
@@ -56,6 +56,11 @@ export function convertSmdPads(
       componentRotation,
       netInfo,
       componentId,
+      hasExplicitSolderPaste: ctx.circuitJson.some(
+        (element) =>
+          element.type === "pcb_solder_paste" &&
+          element.pcb_smtpad_id === pcbPad.pcb_smtpad_id,
+      ),
     })
     pads.push(pad)
     padNumber++

--- a/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
+++ b/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
@@ -28,6 +28,7 @@ export function createSmdPadFromCircuitJson({
   componentRotation = 0,
   netInfo,
   componentId,
+  hasExplicitSolderPaste = false,
 }: {
   pcbPad: PcbSmtPad
   componentCenter: { x: number; y: number }
@@ -35,6 +36,7 @@ export function createSmdPadFromCircuitJson({
   componentRotation?: number
   netInfo?: PcbNetInfo
   componentId?: string
+  hasExplicitSolderPaste?: boolean
 }): FootprintPad {
   // For polygon pads, calculate the center from the points
   let padX: number
@@ -71,6 +73,16 @@ export function createSmdPadFromCircuitJson({
     bottom: "B.Cu",
   }
   const padLayer = layerMap[pcbPad.layer] || "F.Cu"
+  const solderPasteMargin =
+    !hasExplicitSolderPaste &&
+    "solderpaste_margin" in pcbPad &&
+    typeof pcbPad.solderpaste_margin === "number"
+      ? pcbPad.solderpaste_margin
+      : undefined
+  const shouldIncludePasteLayer =
+    hasExplicitSolderPaste ||
+    solderPasteMargin !== undefined ||
+    !pcbPad.is_covered_with_solder_mask
 
   // Handle different pad shapes (circle pads have radius, rect pads have width/height, polygon pads use custom shape)
   let padShape: string | undefined
@@ -157,12 +169,13 @@ export function createSmdPadFromCircuitJson({
     size: padSize,
     layers: [
       `${padLayer}`,
-      ...(pcbPad.is_covered_with_solder_mask
-        ? []
-        : [`${padLayer === "F.Cu" ? "F" : "B"}.Paste`]),
+      ...(shouldIncludePasteLayer
+        ? [`${padLayer === "F.Cu" ? "F" : "B"}.Paste`]
+        : []),
       `${padLayer === "F.Cu" ? "F" : "B"}.Mask`,
     ],
     solderMaskMargin: pcbPad.soldermask_margin,
+    solderPasteMargin,
     roundrectRatio: roundrect_rratio,
     uuid: generateDeterministicUuid(padData),
   })

--- a/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
+++ b/lib/pcb/stages/utils/CreateSmdPadFromCircuitJson.ts
@@ -74,9 +74,7 @@ export function createSmdPadFromCircuitJson({
   }
   const padLayer = layerMap[pcbPad.layer] || "F.Cu"
   const solderPasteMargin =
-    !hasExplicitSolderPaste &&
-    "solderpaste_margin" in pcbPad &&
-    typeof pcbPad.solderpaste_margin === "number"
+    !hasExplicitSolderPaste && typeof pcbPad.solderpaste_margin === "number"
       ? pcbPad.solderpaste_margin
       : undefined
   const shouldIncludePasteLayer =

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@tscircuit/common": "^0.0.5",
     "@types/bun": "latest",
     "@types/earcut": "^3.0.0",
-    "circuit-json": "^0.0.450",
+    "circuit-json": "^0.0.463",
     "earcut": "^3.0.2",
     "format-si-unit": "^0.0.7",
     "jszip": "^3.10.1",

--- a/tests/pcb/smtpad-solderpaste-margin.test.ts
+++ b/tests/pcb/smtpad-solderpaste-margin.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { PcbSmtPad } from "circuit-json"
 import { createSmdPadFromCircuitJson } from "lib/pcb/stages/utils/CreateSmdPadFromCircuitJson"
 
-const pcbPad = {
+const pcbPad: PcbSmtPad = {
   type: "pcb_smtpad",
   pcb_smtpad_id: "pcb_smtpad_0",
   shape: "rect",
@@ -13,7 +13,7 @@ const pcbPad = {
   height: 1,
   is_covered_with_solder_mask: true,
   solderpaste_margin: -0.1,
-} as PcbSmtPad & { solderpaste_margin: number }
+}
 
 test("solderpaste margin is used when explicit pad paste is absent", () => {
   const pad = createSmdPadFromCircuitJson({

--- a/tests/pcb/smtpad-solderpaste-margin.test.ts
+++ b/tests/pcb/smtpad-solderpaste-margin.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import type { PcbSmtPad } from "circuit-json"
+import { createSmdPadFromCircuitJson } from "lib/pcb/stages/utils/CreateSmdPadFromCircuitJson"
+
+const pcbPad = {
+  type: "pcb_smtpad",
+  pcb_smtpad_id: "pcb_smtpad_0",
+  shape: "rect",
+  layer: "top",
+  x: 0,
+  y: 0,
+  width: 2,
+  height: 1,
+  is_covered_with_solder_mask: true,
+  solderpaste_margin: -0.1,
+} as PcbSmtPad & { solderpaste_margin: number }
+
+test("solderpaste margin is used when explicit pad paste is absent", () => {
+  const pad = createSmdPadFromCircuitJson({
+    pcbPad,
+    componentCenter: { x: 0, y: 0 },
+    padNumber: 1,
+    hasExplicitSolderPaste: false,
+  })
+
+  expect(pad.layers?.layers).toEqual(["F.Cu", "F.Paste", "F.Mask"])
+  expect(pad.solderPasteMargin).toBe(-0.1)
+  expect(pad.getString()).toContain("(solder_paste_margin -0.1)")
+})
+
+test("explicit pad paste takes precedence over solderpaste margin", () => {
+  const pad = createSmdPadFromCircuitJson({
+    pcbPad,
+    componentCenter: { x: 0, y: 0 },
+    padNumber: 1,
+    hasExplicitSolderPaste: true,
+  })
+
+  expect(pad.layers?.layers).toEqual(["F.Cu", "F.Paste", "F.Mask"])
+  expect(pad.solderPasteMargin).toBeUndefined()
+  expect(pad.getString()).not.toContain("solder_paste_margin")
+})


### PR DESCRIPTION
## Summary

- write `pcb_smtpad.solderpaste_margin` as KiCad `solder_paste_margin` when linked explicit paste is absent
- include the Paste layer when a fallback margin is present
- preserve linked explicit paste precedence for component and standalone pads
- consume the released `PcbSmtPad.solderpaste_margin` type directly

Uses `circuit-json@^0.0.463`; the schema landed in tscircuit/circuit-json#682.

## Testing

- `bun test tests/pcb/smtpad-solderpaste-margin.test.ts`
- `bunx tsc --noEmit`
- `bun run build`

The broader visual suite was also attempted; the local KiCad 10 rendering differs from the repository PNG baselines in unrelated schematic tests.